### PR TITLE
fix(proxy): refresh GUI after Sunshine port changes

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -108,6 +108,7 @@ fn main() {
             sunshine::restart_sunshine_in_user_mode,
             sunshine::restart_sunshine_service,
             proxy_server::get_proxy_url_command,
+            proxy_server::refresh_sunshine_target,
             utils::open_external_url,
             utils::restart_graphics_driver,
             utils::restart_as_admin,

--- a/src-tauri/src/proxy_server.rs
+++ b/src-tauri/src/proxy_server.rs
@@ -15,6 +15,10 @@ use log::{info, warn, error, debug};
 static SUNSHINE_TARGET: Lazy<Arc<RwLock<String>>> = 
     Lazy::new(|| Arc::new(RwLock::new(String::from("https://localhost:47990"))));
 
+#[cfg(test)]
+static TEST_REFRESH_TARGET: Lazy<std::sync::Mutex<Option<String>>> =
+    Lazy::new(|| std::sync::Mutex::new(None));
+
 /// 快速失败机制：记录 Sunshine 是否可用
 static SUNSHINE_AVAILABLE: AtomicBool = AtomicBool::new(true);
 static LAST_CHECK_TIME: AtomicU64 = AtomicU64::new(0);
@@ -51,6 +55,34 @@ pub fn set_sunshine_target(url: String) {
         info!("🎯 代理目标已更新: {}", url);
         *target = url;
     }
+}
+
+/// Dynamic Sunshine target helpers.
+fn get_sunshine_target() -> String {
+    SUNSHINE_TARGET.read()
+        .map(|url| url.clone())
+        .unwrap_or_else(|_| "https://localhost:47990".to_string())
+}
+
+async fn refresh_sunshine_target_internal() -> Result<String, String> {
+    #[cfg(test)]
+    if let Some(base_url) = TEST_REFRESH_TARGET.lock().unwrap().clone() {
+        set_sunshine_target(base_url.clone());
+        mark_available();
+        return Ok(base_url);
+    }
+
+    let url = crate::sunshine::get_sunshine_url().await?;
+    let base_url = url.trim_end_matches('/').to_string();
+    set_sunshine_target(base_url.clone());
+    mark_available();
+    Ok(base_url)
+}
+
+/// Refresh the proxy target from the current Sunshine config.
+#[tauri::command]
+pub async fn refresh_sunshine_target() -> Result<String, String> {
+    refresh_sunshine_target_internal().await
 }
 
 /// 注入到 Sunshine 页面的 CSS 样式（编译时从文件读取）
@@ -313,9 +345,7 @@ async fn proxy_handler(req: Request) -> Response {
     };
     
     // 构建目标 URL
-    let sunshine_base = SUNSHINE_TARGET.read()
-        .map(|url| url.clone())
-        .unwrap_or_else(|_| "https://localhost:47990".to_string());
+    let sunshine_base = get_sunshine_target();
     
     let target_url = if query.is_empty() {
         format!("{}{}", sunshine_base, path)
@@ -334,9 +364,17 @@ async fn proxy_handler(req: Request) -> Response {
     }
     
     // 请求 Sunshine
-    match fetch_and_proxy(&target_url, &method, &headers, body).await {
+    match fetch_and_proxy(&target_url, &method, &headers, body.clone()).await {
         Ok(response) => {
             mark_available();
+            if method == axum::http::Method::POST && path == "/api/restart" && response.status().is_success() {
+                tauri::async_runtime::spawn(async {
+                    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+                    if let Err(e) = refresh_sunshine_target_internal().await {
+                        warn!("Failed to refresh Sunshine target after restart request: {}", e);
+                    }
+                });
+            }
             let status = response.status();
             if status.is_client_error() || status.is_server_error() {
                 warn!("⚠️ 代理响应异常 [{}]: HTTP {}", path, status.as_u16());
@@ -360,8 +398,36 @@ async fn proxy_handler(req: Request) -> Response {
             error!("❌ 代理错误 [{}] ({}): {}", path, error_kind, error_str);
             
             if is_connection_error(&error_str) {
-                mark_unavailable();
-                service_unavailable_response(is_api)
+                match refresh_sunshine_target_internal().await {
+                    Ok(refreshed_base) if refreshed_base != sunshine_base => {
+                        let refreshed_url = if query.is_empty() {
+                            format!("{}{}", refreshed_base, path)
+                        } else {
+                            format!("{}{}?{}", refreshed_base, path, query)
+                        };
+
+                        match fetch_and_proxy(&refreshed_url, &method, &headers, body).await {
+                            Ok(response) => {
+                                mark_available();
+                                response
+                            }
+                            Err(retry_err) => {
+                                error!("Proxy retry failed [{}]: {}", path, retry_err);
+                                mark_unavailable();
+                                service_unavailable_response(is_api)
+                            }
+                        }
+                    }
+                    Ok(_) => {
+                        mark_unavailable();
+                        service_unavailable_response(is_api)
+                    }
+                    Err(refresh_err) => {
+                        warn!("Failed to refresh Sunshine target after proxy error: {}", refresh_err);
+                        mark_unavailable();
+                        service_unavailable_response(is_api)
+                    }
+                }
             } else {
                 if is_api {
                     (
@@ -737,4 +803,70 @@ fn inject_theme_script(html: String) -> String {
     result.push_str(&html[pos..]);
     
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn unused_local_port() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        listener.local_addr().unwrap().port()
+    }
+
+    async fn spawn_one_shot_http_server(body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request_buf = [0_u8; 1024];
+            let _ = stream.read(&mut request_buf).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        format!("http://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn proxy_retries_with_refreshed_target_when_port_changes() {
+        let marker = "proxy-refresh-target-ok";
+        let old_port = unused_local_port().await;
+        let new_target = spawn_one_shot_http_server(marker).await;
+
+        set_sunshine_target(format!("http://127.0.0.1:{}", old_port));
+        *TEST_REFRESH_TARGET.lock().unwrap() = Some(new_target);
+
+        let request = axum::http::Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = proxy_handler(request).await;
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+
+        *TEST_REFRESH_TARGET.lock().unwrap() = None;
+
+        assert!(status.is_success(), "unexpected status: {status}");
+        assert!(
+            text.contains(marker),
+            "proxy did not retry against refreshed target: {text}"
+        );
+    }
 }

--- a/src-tauri/src/proxy_server.rs
+++ b/src-tauri/src/proxy_server.rs
@@ -4,6 +4,7 @@ use axum::{
     Router,
     middleware::Next,
 };
+use bytes::Bytes;
 use tower_http::cors::CorsLayer;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
@@ -68,21 +69,21 @@ async fn refresh_sunshine_target_internal() -> Result<String, String> {
     #[cfg(test)]
     if let Some(base_url) = TEST_REFRESH_TARGET.lock().unwrap().clone() {
         set_sunshine_target(base_url.clone());
-        mark_available();
         return Ok(base_url);
     }
 
     let url = crate::sunshine::get_sunshine_url().await?;
     let base_url = url.trim_end_matches('/').to_string();
     set_sunshine_target(base_url.clone());
-    mark_available();
     Ok(base_url)
 }
 
 /// Refresh the proxy target from the current Sunshine config.
 #[tauri::command]
 pub async fn refresh_sunshine_target() -> Result<String, String> {
-    refresh_sunshine_target_internal().await
+    let base_url = refresh_sunshine_target_internal().await?;
+    reset_fast_fail();
+    Ok(base_url)
 }
 
 /// 注入到 Sunshine 页面的 CSS 样式（编译时从文件读取）
@@ -337,7 +338,7 @@ async fn proxy_handler(req: Request) -> Response {
     
     // 获取请求体
     let body = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
-        Ok(bytes) => bytes.to_vec(),
+        Ok(bytes) => bytes,
         Err(e) => {
             error!("❌ 读取请求体失败: {}", e);
             return (axum::http::StatusCode::BAD_REQUEST, "读取请求体失败").into_response();
@@ -364,7 +365,7 @@ async fn proxy_handler(req: Request) -> Response {
     }
     
     // 请求 Sunshine
-    match fetch_and_proxy(&target_url, &method, &headers, body.clone()).await {
+    match fetch_and_proxy(&target_url, &method, &headers, &body).await {
         Ok(response) => {
             mark_available();
             if method == axum::http::Method::POST && path == "/api/restart" && response.status().is_success() {
@@ -406,7 +407,7 @@ async fn proxy_handler(req: Request) -> Response {
                             format!("{}{}?{}", refreshed_base, path, query)
                         };
 
-                        match fetch_and_proxy(&refreshed_url, &method, &headers, body).await {
+                        match fetch_and_proxy(&refreshed_url, &method, &headers, &body).await {
                             Ok(response) => {
                                 mark_available();
                                 response
@@ -453,7 +454,7 @@ async fn handle_steam_api(
 ) -> Response {
     // 获取请求体
     let body = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
-        Ok(bytes) => bytes.to_vec(),
+        Ok(bytes) => bytes,
         Err(e) => {
             error!("❌ 读取请求体失败: {}", e);
             return (axum::http::StatusCode::BAD_REQUEST, "读取请求体失败").into_response();
@@ -578,7 +579,7 @@ async fn handle_external_proxy(
     
     // 获取请求体
     let body = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
-        Ok(bytes) => bytes.to_vec(),
+        Ok(bytes) => bytes,
         Err(e) => {
             error!("❌ 读取请求体失败: {}", e);
             return (axum::http::StatusCode::BAD_REQUEST, "读取请求体失败").into_response();
@@ -660,7 +661,7 @@ async fn send_request(
     url: &str,
     method: &axum::http::Method,
     headers: &axum::http::HeaderMap,
-    body: &[u8]
+    body: &Bytes,
 ) -> Result<reqwest::Response, reqwest::Error> {
     let mut req_builder = match method.as_str() {
         "GET" => client.get(url),
@@ -683,7 +684,7 @@ async fn send_request(
     }
     
     if !body.is_empty() {
-        req_builder = req_builder.body(body.to_vec());
+        req_builder = req_builder.body(body.clone());
     }
     
     req_builder.send().await
@@ -694,17 +695,17 @@ async fn fetch_and_proxy(
     url: &str, 
     method: &axum::http::Method,
     headers: &axum::http::HeaderMap,
-    body: Vec<u8>
+    body: &Bytes,
 ) -> Result<Response, Box<dyn std::error::Error + Send + Sync>> {
     let client = get_http_client();
     
     // 尝试请求，HTTPS 失败时降级到 HTTP（仅限非连接错误）
-    let response = match send_request(client, url, method, headers, &body).await {
+    let response = match send_request(client, url, method, headers, body).await {
         Ok(resp) => resp,
         Err(e) if url.starts_with("https://") && !is_connection_error(&e.to_string()) => {
             let http_url = url.replace("https://", "http://");
             warn!("⚠️  HTTPS 连接失败，尝试 HTTP: {}", http_url);
-            send_request(client, &http_url, method, headers, &body).await?
+            send_request(client, &http_url, method, headers, body).await?
         }
         Err(e) => return Err(e.into()),
     };

--- a/src/renderer/components/SunshineFrame.vue
+++ b/src/renderer/components/SunshineFrame.vue
@@ -83,10 +83,9 @@ const isWelcomePath = (url) => {
 const openWelcome = () => sidebarMenuRef.value?.openWelcome?.()
 
 const refreshProxyTarget = async () => {
-  try {
-    await sunshine.refreshTarget()
-  } catch (error) {
-    console.warn('[SunshineFrame] refresh proxy target failed:', error)
+  const refreshedTarget = await sunshine.refreshTarget()
+  if (!refreshedTarget) {
+    console.warn('[SunshineFrame] refresh proxy target failed')
   }
 }
 

--- a/src/renderer/components/SunshineFrame.vue
+++ b/src/renderer/components/SunshineFrame.vue
@@ -82,6 +82,14 @@ const isWelcomePath = (url) => {
 
 const openWelcome = () => sidebarMenuRef.value?.openWelcome?.()
 
+const refreshProxyTarget = async () => {
+  try {
+    await sunshine.refreshTarget()
+  } catch (error) {
+    console.warn('[SunshineFrame] refresh proxy target failed:', error)
+  }
+}
+
 // Navigation handler
 const handleNavigateFrame = (event) => {
   const url = event.detail?.url
@@ -223,7 +231,7 @@ const setupWindowStateMonitor = async (currentWindow) => {
   pollTimer = setInterval(checkWindowStateFn, POLL_INTERVAL)
   await checkWindowStateFn()
 
-  const visibilityHandler = () => {
+  const visibilityHandler = async () => {
     const hidden = document.hidden
     setAnimationsPaused(hidden)
 
@@ -241,6 +249,7 @@ const setupWindowStateMonitor = async (currentWindow) => {
       }
     } else {
       // 窗口恢复 → 唤醒 iframe（仅当是窗口隐藏导致的休眠时恢复）
+      await refreshProxyTarget()
       if (windowSuspendedUrl) {
         sunshineUrl.value = windowSuspendedUrl
         windowSuspendedUrl = ''
@@ -284,6 +293,7 @@ onMounted(async () => {
   window.addEventListener('locale-changed', handleLocaleChanged)
 
   try {
+    await refreshProxyTarget()
     const proxyBaseUrl = await sunshine.getProxyUrl()
     proxyBase = proxyBaseUrl
     const cmdLineUrl = await sunshine.getCommandLineUrl()

--- a/src/renderer/desktop/components/ThemeEditor.vue
+++ b/src/renderer/desktop/components/ThemeEditor.vue
@@ -218,6 +218,13 @@ function handleDrop(e) {
   display: flex;
   flex-direction: column;
   box-shadow: -8px 0 40px rgba(0, 0, 0, 0.5);
+
+  :deep(svg) {
+    width: 16px;
+    height: 16px;
+    display: block;
+    flex: 0 0 auto;
+  }
 }
 
 .editor-header {
@@ -232,6 +239,16 @@ function handleDrop(e) {
     font-size: 18px;
     font-weight: 600;
     color: var(--fd-text-primary, #fff);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    line-height: 1;
+
+    :deep(svg) {
+      width: 20px;
+      height: 20px;
+      color: var(--fd-accent, #00fff5);
+    }
   }
 
   .close-btn {
@@ -425,6 +442,10 @@ function handleDrop(e) {
   cursor: pointer;
   font-size: 12px;
   transition: all 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
 
   &:hover {
     background: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.06);
@@ -460,8 +481,16 @@ function handleDrop(e) {
   }
 
   .drop-icon {
-    font-size: 28px;
     margin-bottom: 6px;
+    color: var(--fd-accent, #00fff5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    :deep(svg) {
+      width: 32px;
+      height: 32px;
+    }
   }
 
   .drop-text {
@@ -511,6 +540,15 @@ function handleDrop(e) {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
   transition: background 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+
+  :deep(svg) {
+    width: 12px;
+    height: 12px;
+  }
 
   &:hover {
     background: rgba(255, 255, 255, 0.25);

--- a/src/renderer/tauri-adapter.js
+++ b/src/renderer/tauri-adapter.js
@@ -97,6 +97,7 @@ export const sunshine = {
   getUrl: () => wrapDefault('get_sunshine_url', 'https://localhost:47990/'),
   getCommandLineUrl: () => wrapDefault('get_command_line_url', null),
   getProxyUrl: () => wrapDefault('get_proxy_url_command', 'http://localhost:48081'),
+  refreshTarget: () => wrapDefault('refresh_sunshine_target', null),
   getActiveSessions: () => wrapDefault('get_active_sessions', []),
   getLocale: () => wrapDefault('get_sunshine_locale', 'en'),
   setLocale: (locale) => invoke('set_sunshine_locale', { locale }),


### PR DESCRIPTION
## 改了啥呀
- 保留已有的主题编辑器图标尺寸修复提交。
- GUI 内嵌 Sunshine 页面的代理目标会按当前 Sunshine 配置刷新。
- Sunshine 重启或端口变更后，代理遇到连接失败会刷新目标并重试一次，尽量避免必须退出 GUI 才能恢复显示。
- 前端在窗口恢复/挂载时主动通知 Tauri 刷新 Sunshine 代理目标。

## 验证
- `npm run build:renderer`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy_retries_with_refreshed_target_when_port_changes -- --nocapture`

目标分支按实际远端分支使用 `tauri`，因为远端没有 `tarui` 分支。杂鱼式放心，这次没有把旁边那些未提交改动偷塞进去。