### PR TITLE
feat(file-transfer): add send-to-client shell entry

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -1,11 +1,11 @@
-use tauri::{Manager, App, AppHandle};
-use log::{info, error, debug};
-use crate::toolbar;
-use crate::windows;
-use crate::tray;
-use crate::sunshine;
 use crate::proxy_server;
+use crate::sunshine;
+use crate::toolbar;
+use crate::tray;
 use crate::update;
+use crate::windows;
+use log::{debug, error, info, warn};
+use tauri::{App, AppHandle, Manager};
 
 /// 应用程序状态
 pub struct AppState {
@@ -18,26 +18,33 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     let args: Vec<String> = std::env::args().collect();
     let show_toolbar = args.iter().any(|arg| arg == "--toolbar" || arg == "-t");
     let show_desktop = args.iter().any(|arg| arg == "--desktop" || arg == "-d");
-    let url_contains_pin = args.iter()
+    let send_to_client_paths = crate::file_transfer::parse_send_to_client_args(&args);
+    let is_send_to_client = !send_to_client_paths.is_empty();
+    let url_contains_pin = args
+        .iter()
         .find(|arg| arg.starts_with("--url="))
         .map_or(false, |arg| arg.contains("/pin"));
-    
+
     let app_handle = app.handle().clone();
-    
+
     // 创建窗口：桌面模式或工具栏模式时不创建主窗口
     let main_window_created = if show_desktop {
         info!("🖥️ 检测到 --desktop 参数，启动桌面 UI 模式");
         windows::create_desktop_window(&app_handle)?;
         windows::create_main_window_hidden(&app_handle)?;
         false
-    } else if !show_toolbar && !url_contains_pin {
+    } else if !show_toolbar && !url_contains_pin && !is_send_to_client {
         windows::create_main_window(&app_handle)?;
         true
     } else {
         false
     };
-    
+
     tray::create_system_tray(&app_handle)?;
+    #[cfg(target_os = "windows")]
+    if let Err(e) = crate::shell_context_menu::install_file_transfer_menu() {
+        warn!("⚠️  安装文件传输右键菜单失败: {}", e);
+    }
     register_global_shortcuts(app)?;
     setup_menu_event_handler(app);
     start_proxy_server_async();
@@ -46,9 +53,13 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     // 不需要额外开关。
     crate::clipboard::auto_start();
 
+    if is_send_to_client {
+        crate::file_transfer::dispatch_cli_send(send_to_client_paths);
+    }
+
     // 启动 WebView 心跳监控（检测渲染进程崩溃并自动恢复）
     windows::start_heartbeat_monitor(app.handle().clone());
-    
+
     // 延迟任务
     tauri::async_runtime::spawn(async move {
         // PIN 配对窗口
@@ -59,7 +70,7 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
                 error!("❌ 创建 PIN 配对窗口失败: {}", e);
             }
         }
-        
+
         // 工具栏窗口（非桌面模式下）
         if show_toolbar && !show_desktop {
             info!("🔧 将在应用启动后打开工具栏");
@@ -68,7 +79,7 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
                 error!("❌ 创建工具栏失败: {}", e);
             }
         }
-        
+
         // 更新检查（仅在主窗口启动时检查）
         if main_window_created {
             tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
@@ -77,7 +88,7 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
             }
         }
     });
-    
+
     Ok(())
 }
 
@@ -87,17 +98,23 @@ fn register_global_shortcuts(app: &mut App) -> Result<(), Box<dyn std::error::Er
 
     let app_handle = app.handle().clone();
 
-    match app.handle().global_shortcut().on_shortcut("CmdOrCtrl+Shift+Alt+T", move |_app, _shortcut, event| {
-        if event.state == ShortcutState::Pressed {
-            debug!("⌨️ 全局快捷键触发: CTRL+SHIFT+ALT+T");
-            toggle_toolbar_window(&app_handle);
-        }
-    }) {
+    match app.handle().global_shortcut().on_shortcut(
+        "CmdOrCtrl+Shift+Alt+T",
+        move |_app, _shortcut, event| {
+            if event.state == ShortcutState::Pressed {
+                debug!("⌨️ 全局快捷键触发: CTRL+SHIFT+ALT+T");
+                toggle_toolbar_window(&app_handle);
+            }
+        },
+    ) {
         Ok(_) => {
             info!("⌨️ 全局快捷键已注册: CTRL+SHIFT+ALT+T");
         }
         Err(e) => {
-            log::warn!("⚠️  全局快捷键 CTRL+SHIFT+ALT+T 注册失败（可能已被其他程序占用）: {}", e);
+            log::warn!(
+                "⚠️  全局快捷键 CTRL+SHIFT+ALT+T 注册失败（可能已被其他程序占用）: {}",
+                e
+            );
             log::warn!("⚠️  工具栏快捷键不可用，但应用程序将继续正常运行");
         }
     }
@@ -154,7 +171,7 @@ fn start_proxy_server_async() {
                 }
             }
         }
-        
+
         // 启动代理服务器
         if let Err(e) = proxy_server::start_proxy_server().await {
             error!("❌ 代理服务器启动失败: {}", e);
@@ -166,11 +183,18 @@ fn start_proxy_server_async() {
 pub fn handle_single_instance(app: &AppHandle, args: Vec<String>) {
     info!("🔔 检测到第二个实例启动，激活现有窗口");
     info!("   启动参数: {:?}", args);
-    
+
+    let send_to_client_paths = crate::file_transfer::parse_send_to_client_args(&args);
+    if !send_to_client_paths.is_empty() {
+        info!("📤 检测到文件传输右键菜单请求");
+        crate::file_transfer::dispatch_cli_send(send_to_client_paths);
+        return;
+    }
+
     // 诊断：列出当前所有窗口
     let windows: Vec<_> = app.webview_windows().keys().cloned().collect();
     info!("📋 当前存在的窗口: {:?}", windows);
-    
+
     // 检查是否要打开桌面 UI
     if args.iter().any(|arg| arg == "--desktop" || arg == "-d") {
         info!("🖥️ 检测到 --desktop 参数，打开桌面 UI");
@@ -179,22 +203,23 @@ pub fn handle_single_instance(app: &AppHandle, args: Vec<String>) {
         }
         return;
     }
-    
+
     // 检查是否要打开工具栏
     if args.iter().any(|arg| arg == "--toolbar" || arg == "-t") {
         info!("🔧 检测到 --toolbar 参数，打开工具栏");
         toggle_toolbar_window(app);
         return;
     }
-    
+
     // 提取 URL 参数并激活主窗口
-    let target_url = args.iter()
+    let target_url = args
+        .iter()
         .find(|arg| arg.starts_with("--url="))
         .map(|arg| arg.trim_start_matches("--url=").to_string());
-    
+
     if let Some(url) = &target_url {
         info!("📍 检测到 URL 参数: {}", url);
-        
+
         // 检测 URL 中是否包含 /pin 路径
         if url.contains("/pin") {
             info!("🔐 检测到 /pin 路径，打开 PIN 配对窗口");
@@ -204,6 +229,6 @@ pub fn handle_single_instance(app: &AppHandle, args: Vec<String>) {
             return;
         }
     }
-    
+
     windows::activate_main_window(app, target_url);
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -9,7 +9,8 @@
 //!
 //! ```text
 //!   u8 version=1
-//!   u8 kind        (1 = utf8 text, 2 = png image, 3 = blob ref JSON)
+//!   u8 kind        (1 = utf8 text, 2 = png image, 3 = blob ref JSON,
+//!                   4 = file-transfer offer JSON)
 //!   u32 token      (echo-suppression nonce)
 //!   u32 length
 //!   bytes payload  (length bytes)
@@ -27,15 +28,15 @@
 
 use std::collections::VecDeque;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
 };
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use clipboard_rs::{
-    common::RustImage as _, Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher,
-    ClipboardWatcherContext, RustImageData, WatcherShutdown,
+    Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher, ClipboardWatcherContext,
+    RustImageData, WatcherShutdown, common::RustImage as _,
 };
 use log::{debug, info, warn};
 use serde::Serialize;
@@ -48,6 +49,7 @@ const WIRE_VERSION: u8 = 1;
 const KIND_TEXT: u8 = 1;
 const KIND_PNG: u8 = 2;
 const KIND_REF: u8 = 3;
+const KIND_FILE_OFFER: u8 = 4;
 
 const MAX_TEXT_BYTES: usize = 1 * 1024 * 1024;
 const MAX_IMAGE_BYTES: usize = 50 * 1024 * 1024; // matches service blob cap
@@ -78,6 +80,7 @@ enum Kind {
     Text,
     Png,
     Ref,
+    FileOffer,
 }
 
 impl Kind {
@@ -86,6 +89,7 @@ impl Kind {
             KIND_TEXT => Some(Kind::Text),
             KIND_PNG => Some(Kind::Png),
             KIND_REF => Some(Kind::Ref),
+            KIND_FILE_OFFER => Some(Kind::FileOffer),
             _ => None,
         }
     }
@@ -94,6 +98,7 @@ impl Kind {
             Kind::Text => KIND_TEXT,
             Kind::Png => KIND_PNG,
             Kind::Ref => KIND_REF,
+            Kind::FileOffer => KIND_FILE_OFFER,
         }
     }
 }
@@ -242,7 +247,11 @@ fn snapshot_and_post(echo: &Arc<Mutex<EchoState>>) {
         }
         let bytes = text.into_bytes();
         if bytes.len() > MAX_TEXT_BYTES {
-            warn!("local clipboard text {}B exceeds {}B cap; dropped", bytes.len(), MAX_TEXT_BYTES);
+            warn!(
+                "local clipboard text {}B exceeds {}B cap; dropped",
+                bytes.len(),
+                MAX_TEXT_BYTES
+            );
             return;
         }
         if echo.lock().unwrap().is_echo(Kind::Text, &bytes) {
@@ -262,7 +271,11 @@ fn snapshot_and_post(echo: &Arc<Mutex<EchoState>>) {
         };
         let bytes = png.get_bytes().to_vec();
         if bytes.len() > MAX_IMAGE_BYTES {
-            warn!("local clipboard png {}B exceeds {}B cap; dropped", bytes.len(), MAX_IMAGE_BYTES);
+            warn!(
+                "local clipboard png {}B exceeds {}B cap; dropped",
+                bytes.len(),
+                MAX_IMAGE_BYTES
+            );
             return;
         }
         if echo.lock().unwrap().is_echo(Kind::Png, &bytes) {
@@ -283,7 +296,11 @@ fn post_outbound(kind: Kind, payload: Vec<u8>, mime: &'static str) {
 
 fn post_inline(kind: Kind, payload: Vec<u8>) {
     let token = next_token();
-    let body = encode_frame(&Frame { kind, token, payload });
+    let body = encode_frame(&Frame {
+        kind,
+        token,
+        payload,
+    });
     tauri::async_runtime::spawn(async move {
         if let Err(e) = post_item(body).await {
             warn!("clipboard /item POST failed: {e}");
@@ -297,11 +314,18 @@ fn post_via_blob(kind: Kind, payload: Vec<u8>, mime: &'static str) {
         let id = match upload_blob(payload, mime).await {
             Ok(id) => id,
             Err(e) => {
-                warn!("clipboard blob upload failed (kind={:?}, size={}): {e}", kind, size);
+                warn!(
+                    "clipboard blob upload failed (kind={:?}, size={}): {e}",
+                    kind, size
+                );
                 return;
             }
         };
-        let meta = RefMeta { id, mime: mime.to_string(), size };
+        let meta = RefMeta {
+            id,
+            mime: mime.to_string(),
+            size,
+        };
         let json = match serde_json::to_vec(&meta) {
             Ok(v) => v,
             Err(e) => {
@@ -310,7 +334,11 @@ fn post_via_blob(kind: Kind, payload: Vec<u8>, mime: &'static str) {
             }
         };
         let token = next_token();
-        let body = encode_frame(&Frame { kind: Kind::Ref, token, payload: json });
+        let body = encode_frame(&Frame {
+            kind: Kind::Ref,
+            token,
+            payload: json,
+        });
         if let Err(e) = post_item(body).await {
             warn!("clipboard /item POST (ref) failed: {e}");
         }
@@ -327,7 +355,10 @@ async fn post_item(body: Vec<u8>) -> Result<(), String> {
     let url = get_sunshine_url().await?;
     let client = create_https_client()?;
     let resp = client
-        .post(format!("{}/api/v1/clipboard/item", url.trim_end_matches('/')))
+        .post(format!(
+            "{}/api/v1/clipboard/item",
+            url.trim_end_matches('/')
+        ))
         .header("Content-Type", "application/octet-stream")
         .body(body)
         .send()
@@ -339,11 +370,24 @@ async fn post_item(body: Vec<u8>) -> Result<(), String> {
     Ok(())
 }
 
+pub async fn post_file_offer_payload(payload: Vec<u8>) -> Result<(), String> {
+    let token = next_token();
+    let body = encode_frame(&Frame {
+        kind: Kind::FileOffer,
+        token,
+        payload,
+    });
+    post_item(body).await
+}
+
 async fn post_capability_once() -> Result<(), String> {
     let url = get_sunshine_url().await?;
     let client = create_https_client()?;
     let resp = client
-        .post(format!("{}/api/v1/clipboard/capability", url.trim_end_matches('/')))
+        .post(format!(
+            "{}/api/v1/clipboard/capability",
+            url.trim_end_matches('/')
+        ))
         .send()
         .await
         .map_err(|e| e.to_string())?;
@@ -359,7 +403,10 @@ async fn upload_blob(bytes: Vec<u8>, mime: &str) -> Result<String, String> {
     let url = get_sunshine_url().await?;
     let client = create_https_client()?;
     let resp = client
-        .post(format!("{}/api/v1/clipboard/blob", url.trim_end_matches('/')))
+        .post(format!(
+            "{}/api/v1/clipboard/blob",
+            url.trim_end_matches('/')
+        ))
         .header("Content-Type", "application/octet-stream")
         .header("X-Clipboard-Mime", mime)
         .body(bytes)
@@ -382,7 +429,11 @@ async fn fetch_blob(id: &str) -> Result<(Vec<u8>, String), String> {
     let url = get_sunshine_url().await?;
     let client = create_https_client()?;
     let resp = client
-        .get(format!("{}/api/v1/clipboard/blob/{}", url.trim_end_matches('/'), id))
+        .get(format!(
+            "{}/api/v1/clipboard/blob/{}",
+            url.trim_end_matches('/'),
+            id
+        ))
         .send()
         .await
         .map_err(|e| e.to_string())?;
@@ -430,12 +481,17 @@ async fn apply_inbound_ref(frame: Frame, echo: Arc<Mutex<EchoState>>) {
     let kind = match meta.mime.as_str() {
         m if m.starts_with("text/") => Kind::Text,
         "image/png" => Kind::Png,
+        "application/vnd.sunshine.file-offer+json" => Kind::FileOffer,
         other => {
             warn!("inbound REF: unsupported mime '{}'", other);
             return;
         }
     };
-    let frame = Frame { kind, token: frame.token, payload: bytes };
+    let frame = Frame {
+        kind,
+        token: frame.token,
+        payload: bytes,
+    };
     let echo = echo.clone();
     let _ = tauri::async_runtime::spawn_blocking(move || apply_inbound_inline(frame, &echo)).await;
 }
@@ -493,6 +549,12 @@ fn apply_inbound_inline(frame: Frame, echo: &Arc<Mutex<EchoState>>) {
         Kind::Ref => {
             // Already unwrapped above; should never reach here.
             warn!("apply_inbound_inline got Kind::Ref; dropped");
+        }
+        Kind::FileOffer => {
+            // Host GUI currently only sends this to clients. If a client sends
+            // one back, ignore it rather than writing arbitrary file metadata
+            // to the host clipboard.
+            warn!("inbound file offer on host GUI agent; dropped");
         }
     }
 }
@@ -654,12 +716,14 @@ pub fn start() -> Result<(), String> {
     // Spawn watcher thread (blocking; the crate's start_watch() is sync).
     let watcher_echo = echo.clone();
     let (shutdown_tx, watcher_handle) = {
-        let mut watcher = ClipboardWatcherContext::new()
-            .map_err(|e| format!("ClipboardWatcherContext: {e}"))?;
-        let shutdown = watcher.add_handler(WatcherCallbacks {
-            echo: watcher_echo,
-            busy,
-        }).get_shutdown_channel();
+        let mut watcher =
+            ClipboardWatcherContext::new().map_err(|e| format!("ClipboardWatcherContext: {e}"))?;
+        let shutdown = watcher
+            .add_handler(WatcherCallbacks {
+                echo: watcher_echo,
+                busy,
+            })
+            .get_shutdown_channel();
         let handle = std::thread::Builder::new()
             .name("clipboard-watcher".into())
             .spawn(move || {
@@ -736,10 +800,7 @@ async fn query_service_allowed() -> bool {
         Ok(c) => c,
         Err(_) => return true,
     };
-    let endpoint = format!(
-        "{}/api/v1/clipboard/capability",
-        url.trim_end_matches('/')
-    );
+    let endpoint = format!("{}/api/v1/clipboard/capability", url.trim_end_matches('/'));
     let resp = match client.post(&endpoint).send().await {
         Ok(r) => r,
         Err(_) => return true,

--- a/src-tauri/src/file_transfer.rs
+++ b/src-tauri/src/file_transfer.rs
@@ -1,0 +1,136 @@
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::clipboard;
+use crate::sunshine::{create_https_client, get_active_sessions, get_sunshine_url};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct FileOffer {
+    id: String,
+    name: String,
+    size: u64,
+    mime: String,
+    download_url: String,
+    expires_in: u64,
+    #[serde(rename = "type")]
+    offer_type: String,
+}
+
+pub fn parse_send_to_client_args(args: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut take_rest = false;
+
+    for arg in args {
+        if take_rest {
+            if !arg.trim().is_empty() {
+                out.push(arg.clone());
+            }
+            continue;
+        }
+
+        if arg == "--send-to-client" {
+            take_rest = true;
+            continue;
+        }
+
+        if let Some(path) = arg.strip_prefix("--send-to-client=") {
+            if !path.trim().is_empty() {
+                out.push(path.to_string());
+            }
+        }
+    }
+
+    out
+}
+
+pub fn dispatch_cli_send(paths: Vec<String>) {
+    if paths.is_empty() {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        match send_paths_to_client(paths).await {
+            Ok(msg) => info!("file transfer: {msg}"),
+            Err(e) => warn!("file transfer failed: {e}"),
+        }
+    });
+}
+
+#[tauri::command]
+pub async fn send_file_to_client(path: String) -> Result<String, String> {
+    send_paths_to_client(vec![path]).await
+}
+
+async fn send_paths_to_client(paths: Vec<String>) -> Result<String, String> {
+    let first = paths.first().ok_or_else(|| "没有选择文件".to_string())?;
+
+    if paths.len() > 1 {
+        return Err("当前版本仅支持一次发送一个文件".to_string());
+    }
+
+    let active_sessions = get_active_sessions()
+        .await
+        .map_err(|e| format!("无法查询客户端连接状态: {e}"))?;
+
+    let running_sessions = active_sessions
+        .iter()
+        .filter(|s| s.state.eq_ignore_ascii_case("RUNNING"))
+        .count();
+
+    if running_sessions == 0 {
+        return Err("没有正在串流的客户端连接".to_string());
+    }
+
+    let path = canonicalize_file(first)?;
+    let offer = register_offer(&path).await?;
+    let payload = build_client_offer_payload(&offer)?;
+    clipboard::post_file_offer_payload(payload)
+        .await
+        .map_err(|e| format!("发送文件 offer 失败: {e}"))?;
+
+    Ok(format!(
+        "已发送文件 offer: {} ({} bytes, {} 个客户端)",
+        offer.name, offer.size, running_sessions
+    ))
+}
+
+fn canonicalize_file(path: &str) -> Result<PathBuf, String> {
+    let raw = PathBuf::from(path);
+    let canonical = std::fs::canonicalize(&raw)
+        .map_err(|e| format!("文件不存在或无法访问: {} ({e})", raw.display()))?;
+    if !canonical.is_file() {
+        return Err("当前版本仅支持发送单个文件".to_string());
+    }
+    Ok(canonical)
+}
+
+async fn register_offer(path: &PathBuf) -> Result<FileOffer, String> {
+    let url = get_sunshine_url().await?;
+    let client = create_https_client()?;
+    let endpoint = format!("{}/api/v1/file-transfer/offers", url.trim_end_matches('/'));
+
+    let body = serde_json::json!({
+        "path": path.to_string_lossy(),
+    });
+
+    let resp = client
+        .post(endpoint)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("注册文件 offer 失败: HTTP {status} {text}"));
+    }
+
+    serde_json::from_str::<FileOffer>(&text)
+        .map_err(|e| format!("解析文件 offer 响应失败: {e}; body={text}"))
+}
+
+fn build_client_offer_payload(offer: &FileOffer) -> Result<Vec<u8>, String> {
+    serde_json::to_vec(offer).map_err(|e| format!("编码文件 offer 失败: {e}"))
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,29 +1,32 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod app;
+mod bat_runner;
+mod clipboard;
+mod commands;
+mod controllermeta;
+mod file_transfer;
+mod fs_utils;
+mod hwinfo;
+mod logger;
+mod moonlight_web;
+mod proxy_server;
+mod rtss;
+#[cfg(target_os = "windows")]
+mod shell_context_menu;
+mod sunshine;
+mod system;
+mod toolbar;
+mod tray;
+mod update;
+mod utils;
 mod vdd;
 #[cfg(target_os = "windows")]
 mod vdd_ioctl;
-mod bat_runner;
 mod vigem;
 mod vmouse;
-mod rtss;
-mod hwinfo;
-mod system;
-mod sunshine;
-mod utils;
-mod proxy_server;
-mod fs_utils;
-mod toolbar;
-mod update;
-mod logger;
-mod tray;
 mod windows;
-mod app;
-mod commands;
-mod moonlight_web;
-mod controllermeta;
-mod clipboard;
 
 use log::info;
 
@@ -46,7 +49,7 @@ fn main() {
             "--renderer-process-limit=1",
         ].join(" "));
     }
-    
+
     tauri::Builder::default()
         .manage(app::AppState {
             main_window: std::sync::Mutex::new(None),
@@ -62,7 +65,7 @@ fn main() {
             // 初始化日志系统（需要在 setup 中获取 app handle）
             logger::init_logger(app.handle().clone());
             info!("🚀 Sunshine Control Panel 启动中...");
-            
+
             app::setup_application(app)
         })
         .on_window_event(|window, event| {
@@ -160,6 +163,7 @@ fn main() {
             controllermeta::controllermeta_get_install_path,
             controllermeta::controllermeta_uninstall,
             clipboard::clipboard_sync_status,
+            file_transfer::send_file_to_client,
             windows::webview_heartbeat,
             rtss::get_rtss_status,
             rtss::rtss_set_osd,

--- a/src-tauri/src/shell_context_menu.rs
+++ b/src-tauri/src/shell_context_menu.rs
@@ -1,0 +1,32 @@
+#[cfg(target_os = "windows")]
+pub fn install_file_transfer_menu() -> Result<(), String> {
+    use winreg::RegKey;
+    use winreg::enums::*;
+
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe failed: {e}"))?;
+    let exe = exe.to_string_lossy().to_string();
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let (verb, _) = hkcu
+        .create_subkey(r"Software\Classes\*\shell\Sunshine.SendToClient")
+        .map_err(|e| format!("create context menu key failed: {e}"))?;
+
+    verb.set_value("", &"发送到 Sunshine 客户端")
+        .map_err(|e| format!("set context menu title failed: {e}"))?;
+    verb.set_value("MUIVerb", &"发送到 Sunshine 客户端")
+        .map_err(|e| format!("set context menu verb failed: {e}"))?;
+    verb.set_value("Icon", &exe)
+        .map_err(|e| format!("set context menu icon failed: {e}"))?;
+    verb.set_value("MultiSelectModel", &"Single")
+        .map_err(|e| format!("set context menu multiselect failed: {e}"))?;
+
+    let (command, _) = verb
+        .create_subkey("command")
+        .map_err(|e| format!("create context menu command key failed: {e}"))?;
+    let command_line = format!("\"{}\" --send-to-client \"%1\"", exe);
+    command
+        .set_value("", &command_line)
+        .map_err(|e| format!("set context menu command failed: {e}"))?;
+
+    Ok(())
+}

--- a/src/renderer/desktop/components/ThemeEditor.vue
+++ b/src/renderer/desktop/components/ThemeEditor.vue
@@ -9,14 +9,14 @@
     <Transition name="slide">
       <div v-if="open" class="theme-editor" @click.stop>
         <div class="editor-header">
-          <h2><Brush /> 主题编辑</h2>
+          <h2><Brush /> {{ t.themeEditor.title }}</h2>
           <button class="close-btn" @click="$emit('close')">✕</button>
         </div>
 
         <div class="editor-body">
           <!-- 壁纸 -->
           <section class="editor-section">
-            <label class="section-title">壁纸</label>
+            <label class="section-title">{{ t.themeEditor.wallpaper }}</label>
             <div
               class="wallpaper-drop"
               :class="{ dragging: isDragging, 'has-wallpaper': wallpaper }"
@@ -28,13 +28,13 @@
               <template v-if="wallpaper">
                 <img :src="wallpaper" class="wallpaper-preview" />
                 <div class="wallpaper-actions">
-                  <button class="wp-btn" @click.stop="triggerFileInput"><Refresh /> 更换</button>
-                  <button class="wp-btn danger" @click.stop="$emit('removeWallpaper')">✕ 移除</button>
+                  <button class="wp-btn" @click.stop="triggerFileInput"><Refresh /> {{ t.themeEditor.replace }}</button>
+                  <button class="wp-btn danger" @click.stop="$emit('removeWallpaper')">✕ {{ t.themeEditor.remove }}</button>
                 </div>
               </template>
               <template v-else>
                 <div class="drop-icon"><Picture /></div>
-                <div class="drop-text">拖拽图片到此处<br/><small>或点击选择文件</small></div>
+                <div class="drop-text">{{ t.themeEditor.dropImage }}<br/><small>{{ t.themeEditor.chooseFile }}</small></div>
               </template>
             </div>
             <input
@@ -58,7 +58,7 @@
 
           <!-- 预设主题 -->
           <section class="editor-section">
-            <label class="section-title">预设主题</label>
+            <label class="section-title">{{ t.themeEditor.presets }}</label>
             <div class="preset-grid">
               <button
                 v-for="(preset, key) in presets"
@@ -68,42 +68,42 @@
                 @click="$emit('applyPreset', key)"
               >
                 <span class="preset-dot" :style="{ background: preset.vars['--fd-accent'] }"></span>
-                {{ preset.label }}
+                {{ t.themeEditor.presetNames[key] || preset.label }}
               </button>
             </div>
           </section>
 
           <!-- 颜色 -->
           <section class="editor-section">
-            <label class="section-title">颜色</label>
+            <label class="section-title">{{ t.themeEditor.colors }}</label>
             <div class="control-row">
-              <span class="control-label">主题色</span>
+              <span class="control-label">{{ t.themeEditor.accentColor }}</span>
               <input type="color" :value="vars['--fd-accent']" @input="throttledSetVar('--fd-accent', $event.target.value)" @change="$emit('setVar', '--fd-accent', $event.target.value)" />
             </div>
             <div class="control-row">
-              <span class="control-label">辅助色</span>
+              <span class="control-label">{{ t.themeEditor.secondaryColor }}</span>
               <input type="color" :value="vars['--fd-accent-secondary']" @input="throttledSetVar('--fd-accent-secondary', $event.target.value)" @change="$emit('setVar', '--fd-accent-secondary', $event.target.value)" />
             </div>
             <div class="control-row">
-              <span class="control-label">背景主色</span>
+              <span class="control-label">{{ t.themeEditor.backgroundPrimary }}</span>
               <input type="color" :value="vars['--fd-bg-primary']" @input="throttledSetVar('--fd-bg-primary', $event.target.value)" @change="$emit('setVar', '--fd-bg-primary', $event.target.value)" />
             </div>
             <div class="control-row">
-              <span class="control-label">背景副色</span>
+              <span class="control-label">{{ t.themeEditor.backgroundSecondary }}</span>
               <input type="color" :value="vars['--fd-bg-secondary']" @input="throttledSetVar('--fd-bg-secondary', $event.target.value)" @change="$emit('setVar', '--fd-bg-secondary', $event.target.value)" />
             </div>
           </section>
 
           <!-- 外观 -->
           <section class="editor-section">
-            <label class="section-title">外观</label>
+            <label class="section-title">{{ t.themeEditor.appearance }}</label>
             <div class="control-row">
-              <span class="control-label">卡片圆角</span>
+              <span class="control-label">{{ t.themeEditor.cardRadius }}</span>
               <input type="range" min="0" max="32" :value="parseInt(vars['--fd-card-radius'])" @input="$emit('setVar', '--fd-card-radius', $event.target.value + 'px')" />
               <span class="control-value">{{ vars['--fd-card-radius'] }}</span>
             </div>
             <div class="control-row">
-              <span class="control-label">字体大小</span>
+              <span class="control-label">{{ t.themeEditor.fontSize }}</span>
               <input type="range" min="12" max="18" :value="parseInt(vars['--fd-font-size'])" @input="$emit('setVar', '--fd-font-size', $event.target.value + 'px')" />
               <span class="control-value">{{ vars['--fd-font-size'] }}</span>
             </div>
@@ -111,16 +111,16 @@
 
           <!-- 效果 -->
           <section class="editor-section">
-            <label class="section-title">效果</label>
+            <label class="section-title">{{ t.themeEditor.effects }}</label>
             <div class="control-row">
-              <span class="control-label">背景网格</span>
+              <span class="control-label">{{ t.themeEditor.backgroundGrid }}</span>
               <label class="switch">
                 <input type="checkbox" :checked="vars['--fd-grid-visible'] === '1'" @change="$emit('setVar', '--fd-grid-visible', $event.target.checked ? '1' : '0')" />
                 <span class="slider"></span>
               </label>
             </div>
             <div class="control-row">
-              <span class="control-label">扫描线</span>
+              <span class="control-label">{{ t.themeEditor.scanlines }}</span>
               <label class="switch">
                 <input type="checkbox" :checked="vars['--fd-scanline-visible'] === '1'" @change="$emit('setVar', '--fd-scanline-visible', $event.target.checked ? '1' : '0')" />
                 <span class="slider"></span>
@@ -130,10 +130,10 @@
 
           <!-- 导入导出 -->
           <section class="editor-section">
-            <label class="section-title">数据</label>
+            <label class="section-title">{{ t.themeEditor.data }}</label>
             <div class="action-row">
-              <button class="action-btn" @click="handleExport"><Upload /> 导出主 题</button>
-              <button class="action-btn" @click="handleImport"><Download /> 导入主 题</button>
+              <button class="action-btn" @click="handleExport"><Upload /> {{ t.themeEditor.exportTheme }}</button>
+              <button class="action-btn" @click="handleImport"><Download /> {{ t.themeEditor.importTheme }}</button>
             </div>
           </section>
         </div>
@@ -145,6 +145,7 @@
 <script setup>
 import { ref } from 'vue'
 import { Brush, Refresh, Picture, Upload, Download } from '@element-plus/icons-vue'
+import { useI18n } from '../i18n/index.js'
 
 const props = defineProps({
   open: { type: Boolean, required: true },
@@ -157,6 +158,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'setVar', 'applyPreset', 'export', 'import', 'setWallpaper', 'removeWallpaper'])
 
+const { t } = useI18n()
 const isDragging = ref(false)
 const fileInputRef = ref(null)
 

--- a/src/renderer/desktop/i18n/en.js
+++ b/src/renderer/desktop/i18n/en.js
@@ -207,6 +207,38 @@ export const en = {
     resetSuccess: 'Settings reset to defaults',
   },
 
+  // === Theme Editor ===
+  themeEditor: {
+    title: 'Theme Editor',
+    wallpaper: 'Wallpaper',
+    replace: 'Replace',
+    remove: 'Remove',
+    dropImage: 'Drop image here',
+    chooseFile: 'or click to choose a file',
+    presets: 'Presets',
+    presetNames: {
+      cyberpunk: 'Cyberpunk',
+      midnight: 'Midnight Blue',
+      emerald: 'Emerald',
+      rose: 'Rose Gold',
+      steam: 'Steam Classic',
+    },
+    colors: 'Colors',
+    accentColor: 'Accent Color',
+    secondaryColor: 'Secondary Color',
+    backgroundPrimary: 'Primary Background',
+    backgroundSecondary: 'Secondary Background',
+    appearance: 'Appearance',
+    cardRadius: 'Card Radius',
+    fontSize: 'Font Size',
+    effects: 'Effects',
+    backgroundGrid: 'Background Grid',
+    scanlines: 'Scanlines',
+    data: 'Data',
+    exportTheme: 'Export Theme',
+    importTheme: 'Import Theme',
+  },
+
   // === Tools ===
   tools: {
     pageTitle: 'Utility Tools',

--- a/src/renderer/desktop/i18n/zh.js
+++ b/src/renderer/desktop/i18n/zh.js
@@ -207,6 +207,38 @@ export const zh = {
     resetSuccess: '设置已恢复默认',
   },
 
+  // === 主题编辑 ===
+  themeEditor: {
+    title: '主题编辑',
+    wallpaper: '壁纸',
+    replace: '更换',
+    remove: '移除',
+    dropImage: '拖拽图片到此处',
+    chooseFile: '或点击选择文件',
+    presets: '预设主题',
+    presetNames: {
+      cyberpunk: '赛博朋克',
+      midnight: '午夜蓝',
+      emerald: '翡翠绿',
+      rose: '玫瑰金',
+      steam: 'Steam 经典',
+    },
+    colors: '颜色',
+    accentColor: '主题色',
+    secondaryColor: '辅助色',
+    backgroundPrimary: '背景主色',
+    backgroundSecondary: '背景副色',
+    appearance: '外观',
+    cardRadius: '卡片圆角',
+    fontSize: '字体大小',
+    effects: '效果',
+    backgroundGrid: '背景网格',
+    scanlines: '扫描线',
+    data: '数据',
+    exportTheme: '导出主题',
+    importTheme: '导入主题',
+  },
+
   // === 工具 ===
   tools: {
     pageTitle: '实用工具',

--- a/src/renderer/desktop/views/ToolsView.vue
+++ b/src/renderer/desktop/views/ToolsView.vue
@@ -6,9 +6,9 @@
     </div>
 
     <!-- 工具网格 - 平铺所有工具 -->
-    <DesktopGrid :cols="2" gap="lg" :responsive="true">
+    <DesktopGrid class="tools-grid" :cols="2" gap="lg" :responsive="true">
       <!-- 码率调节器 -->
-      <DesktopCard :title="t.tools.bitrateAdjust" variant="success" hoverable class="tool-panel-card">
+      <DesktopCard variant="success" hoverable class="tool-panel-card bitrate-card">
         <template #title>
           <span class="title-icon"><DataAnalysis /></span>
           {{ t.tools.bitrateAdjust }}
@@ -20,7 +20,7 @@
       </DesktopCard>
 
       <!-- DPI 调节器 -->
-      <DesktopCard :title="t.tools.dpiScaling" variant="secondary" hoverable class="tool-panel-card">
+      <DesktopCard variant="secondary" hoverable class="tool-panel-card dpi-card">
         <template #title>
           <span class="title-icon"><Search /></span>
           {{ t.tools.dpiScaling }}
@@ -32,7 +32,7 @@
       </DesktopCard>
 
       <!-- 快捷键管理 -->
-      <DesktopCard :title="t.tools.shortcutGuide" variant="warning" hoverable class="tool-panel-card">
+      <DesktopCard variant="warning" hoverable class="tool-panel-card shortcuts-card">
         <template #title>
           <span class="title-icon"><Key /></span>
           {{ t.tools.shortcutGuide }}
@@ -240,10 +240,11 @@ onMounted(async () => {
 .tools-view {
   max-width: 1600px;
   margin: 0 auto;
+  padding-bottom: 32px;
 }
 
 .page-header {
-  margin-bottom: 40px;
+  margin-bottom: 34px;
 
   .page-title {
     font-size: 40px;
@@ -260,11 +261,29 @@ onMounted(async () => {
 }
 
 .tool-panel-card {
-  min-height: 400px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  :deep(.card-header) {
+    margin-bottom: 18px;
+  }
+
+  :deep(.card-title) {
+    min-width: 0;
+    flex-wrap: wrap;
+    line-height: 1.25;
+  }
+
+  :deep(.card-content) {
+    flex: 1;
+    min-height: 0;
+  }
 
   .tool-panel-content {
-    max-height: 600px;
-    overflow-y: auto;
+    min-height: 0;
+    overflow: visible;
 
     &::-webkit-scrollbar {
       width: 6px;
@@ -291,11 +310,24 @@ onMounted(async () => {
   }
 }
 
+.bitrate-card,
+.dpi-card {
+  min-height: 320px;
+}
+
+.shortcuts-card {
+  grid-column: ~"1 / -1";
+
+  .tool-panel-content {
+    overflow: visible;
+  }
+}
+
 .section-title {
   font-size: 20px;
   font-weight: 600;
   color: var(--fd-text-primary, #fff);
-  margin: 48px 0 16px 0;
+  margin: 36px 0 16px 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -323,16 +355,21 @@ onMounted(async () => {
 
   .diagnostic-item {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    text-align: center;
+    text-align: left;
     gap: 12px;
+    min-width: 0;
+    padding: 16px;
+    border: 1px solid rgba(var(--fd-accent-rgb, 0, 255, 245), 0.1);
+    border-radius: 12px;
+    background: rgba(var(--fd-bg-primary-rgb, 15, 15, 35), 0.22);
   }
 
   .diagnostic-icon {
-    width: 64px;
-    height: 64px;
-    border-radius: 16px;
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    flex: 0 0 48px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -353,12 +390,15 @@ onMounted(async () => {
     }
 
     svg {
-      width: 32px;
-      height: 32px;
+      width: 26px;
+      height: 26px;
     }
   }
 
   .diagnostic-info {
+    min-width: 0;
+    flex: 1;
+
     .diagnostic-name {
       font-size: 14px;
       color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.5);
@@ -369,6 +409,9 @@ onMounted(async () => {
       font-size: 14px;
       font-weight: 500;
       color: var(--fd-text-primary, #fff);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 
@@ -376,6 +419,7 @@ onMounted(async () => {
     font-size: 12px;
     padding: 4px 12px;
     border-radius: 12px;
+    flex-shrink: 0;
 
     &.good {
       background: rgba(var(--fd-status-success-rgb, 0, 255, 136), 0.1);
@@ -390,6 +434,46 @@ onMounted(async () => {
     &.error {
       background: rgba(var(--fd-status-danger-rgb, 255, 107, 53), 0.1);
       color: var(--fd-status-danger, #ff6b35);
+    }
+  }
+
+  :deep(.card-footer) {
+    flex-wrap: wrap;
+
+    .desktop-btn {
+      min-width: 132px;
+      justify-content: center;
+      white-space: nowrap;
+    }
+
+    .desktop-btn svg {
+      width: 18px;
+      height: 18px;
+      flex-shrink: 0;
+    }
+  }
+}
+
+@media (max-width: 800px) {
+  .tools-view {
+    padding-bottom: 20px;
+  }
+
+  .page-header {
+    margin-bottom: 24px;
+
+    .page-title {
+      font-size: 32px;
+    }
+  }
+
+  .shortcuts-card {
+    grid-column: auto;
+  }
+
+  .diagnostics-card {
+    .diagnostic-item {
+      align-items: flex-start;
     }
   }
 }

--- a/src/renderer/tool-window/tools/BitrateTool.vue
+++ b/src/renderer/tool-window/tools/BitrateTool.vue
@@ -27,9 +27,7 @@
           :disabled="isLoading || applying"
           :title="t.bitrateTool.refresh"
         >
-          <el-icon :size="18" :class="{ spinning: refreshing }">
-            <RefreshRight />
-          </el-icon>
+          <RefreshRight class="refresh-icon" :class="{ spinning: refreshing }" />
         </button>
       </div>
 
@@ -300,6 +298,7 @@ onMounted(loadSessions)
     
     .tool-content {
       padding: 0;
+      min-height: 236px;
     }
   }
 }
@@ -419,6 +418,12 @@ onMounted(loadSessions)
   .spinning {
     animation: spin 1s linear infinite;
   }
+
+  .refresh-icon {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+  }
 }
 
 @keyframes spin {
@@ -433,24 +438,46 @@ onMounted(loadSessions)
 .loading-state,
 .empty-state {
   text-align: center;
-  padding: 40px 20px;
+  padding: 28px 20px;
 }
 
 .empty-state {
+  min-height: 190px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
   .icon {
-    font-size: 48px;
+    width: 64px;
+    height: 64px;
     margin-bottom: 16px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.88);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+
+    :deep(svg) {
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
+    }
   }
 
   p {
     font-size: 16px;
-    opacity: 0.9;
+    color: rgba(255, 255, 255, 0.9);
+    opacity: 1;
     margin-bottom: 8px;
   }
 
   .subtitle {
     font-size: 14px;
-    opacity: 0.7;
+    color: rgba(255, 255, 255, 0.62);
+    opacity: 1;
   }
 
   .warning-text {

--- a/src/renderer/tool-window/tools/DpiAdjusterTool.vue
+++ b/src/renderer/tool-window/tools/DpiAdjusterTool.vue
@@ -135,6 +135,8 @@ onMounted(() => {
     
     .tool-content {
       padding: 0;
+      min-height: 236px;
+      justify-content: center;
     }
   }
 }
@@ -181,7 +183,7 @@ onMounted(() => {
   padding: 20px 30px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
 }
 
 .dpi-display {
@@ -189,7 +191,7 @@ onMounted(() => {
 }
 
 .dpi-value {
-  font-size: 48px;
+  font-size: 46px;
   font-weight: 700;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   display: inline-block;
@@ -259,6 +261,8 @@ onMounted(() => {
   flex-wrap: wrap;
   gap: 6px;
   justify-content: center;
+  max-width: 560px;
+  margin: 0 auto;
 }
 
 .preset-btn {

--- a/src/renderer/tool-window/tools/ShortcutsTool.vue
+++ b/src/renderer/tool-window/tools/ShortcutsTool.vue
@@ -66,7 +66,7 @@ onMounted(() => {
   
   &.embedded {
     width: 100%;
-    max-height: 600px;
+    max-height: none;
     
     .tool-header {
       display: none;
@@ -74,7 +74,7 @@ onMounted(() => {
     
     .tool-content {
       padding: 0;
-      max-height: 600px;
+      max-height: min(52vh, 520px);
     }
   }
 }
@@ -121,6 +121,7 @@ onMounted(() => {
   padding: 20px 28px;
   max-height: 70vh;
   overflow-y: auto;
+  padding-right: 10px;
 }
 
 /* Markdown 渲染样式 - 白色主题 */
@@ -132,12 +133,16 @@ onMounted(() => {
 }
 
 .tool-content :deep(h2) {
-  font-size: 18px;
+  font-size: 17px;
   color: white;
-  margin: 24px 0 12px 0;
+  margin: 22px 0 12px 0;
   padding-bottom: 6px;
   border-bottom: 2px solid rgba(255, 255, 255, 0.3);
   font-weight: 600;
+}
+
+.tool-content :deep(h2:first-of-type) {
+  margin-top: 0;
 }
 
 .tool-content :deep(h3) {
@@ -151,6 +156,9 @@ onMounted(() => {
   list-style: none;
   padding: 0;
   margin: 0 0 14px 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 8px;
 }
 
 .tool-content :deep(li) {
@@ -158,12 +166,14 @@ onMounted(() => {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(5px);
   border-radius: 6px;
-  margin-bottom: 5px;
+  margin-bottom: 0;
   transition: all 0.2s;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   font-size: 13px;
+  min-width: 0;
+  min-height: 38px;
 }
 
 .tool-content :deep(li:hover) {
@@ -183,6 +193,7 @@ onMounted(() => {
   color: white;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tool-content :deep(li code:not(kbd)) {
@@ -205,6 +216,7 @@ onMounted(() => {
 
 .tool-content :deep(.note p) {
   margin: 0;
+  color: inherit;
 }
 
 .tool-content :deep(hr) {
@@ -226,6 +238,13 @@ onMounted(() => {
   margin: 6px 0;
   line-height: 1.5;
   font-size: 13px;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+@media (max-width: 900px) {
+  .tool-content :deep(ul) {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* 滚动条样式 */


### PR DESCRIPTION
﻿**改了啥呀**
- 新增 Windows Explorer 文件右键菜单，入口会用当前 GUI exe 启动 `--send-to-client`。
- 菜单点击走 Tauri 单实例路径，不弹主窗口，先检查是否存在 `RUNNING` 串流会话。
- 新增 file-transfer offer 发送逻辑，通过现有 clipboard `/item` 通道发 `kind=4` JSON offer，文件字节不塞剪贴板。

**为啥要改**
- 让主机文件可以从资源管理器一键发送到客户端，剪贴板通道只做控制消息，避免大文件把剪贴板/控制帧打爆，杂鱼状态退散。

**验证**
- `cargo check`
- `git diff --check`
