### PR TITLE
feat(file-mapping): add folder sharing controls

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -61,10 +61,6 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     if let Err(e) = crate::shell_context_menu::install_file_transfer_menu() {
         warn!("⚠️  安装文件传输右键菜单失败: {}", e);
     }
-    #[cfg(target_os = "windows")]
-    if let Err(e) = crate::shell_context_menu::install_file_mapping_menu() {
-        warn!("install file mapping context menu failed: {}", e);
-    }
     register_global_shortcuts(app)?;
     setup_menu_event_handler(app);
     start_proxy_server_async();

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -24,6 +24,8 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     let desktop_settings = crate::desktop_settings::load_desktop_settings_from_disk();
     let send_to_client_paths = crate::file_transfer::parse_send_to_client_args(&args);
     let is_send_to_client = !send_to_client_paths.is_empty();
+    let quick_share_folder_paths = crate::file_mapping::parse_quick_share_folder_args(&args);
+    let is_quick_share_folder = !quick_share_folder_paths.is_empty();
     let url_contains_pin = args
         .iter()
         .find(|arg| arg.starts_with("--url="))
@@ -43,7 +45,7 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
         }
         windows::create_main_window_hidden(&app_handle)?;
         false
-    } else if !show_toolbar && !url_contains_pin && !is_send_to_client {
+    } else if !show_toolbar && !url_contains_pin && !is_send_to_client && !is_quick_share_folder {
         if start_minimized {
             windows::create_main_window_hidden(&app_handle)?;
         } else {
@@ -59,6 +61,10 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     if let Err(e) = crate::shell_context_menu::install_file_transfer_menu() {
         warn!("⚠️  安装文件传输右键菜单失败: {}", e);
     }
+    #[cfg(target_os = "windows")]
+    if let Err(e) = crate::shell_context_menu::install_file_mapping_menu() {
+        warn!("install file mapping context menu failed: {}", e);
+    }
     register_global_shortcuts(app)?;
     setup_menu_event_handler(app);
     start_proxy_server_async();
@@ -69,6 +75,9 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
 
     if is_send_to_client {
         crate::file_transfer::dispatch_cli_send(send_to_client_paths);
+    }
+    if is_quick_share_folder {
+        crate::file_mapping::dispatch_cli_quick_share(quick_share_folder_paths);
     }
 
     // 启动 WebView 心跳监控（检测渲染进程崩溃并自动恢复）
@@ -208,6 +217,13 @@ pub fn handle_single_instance(app: &AppHandle, args: Vec<String>) {
     }
 
     // 诊断：列出当前所有窗口
+    let quick_share_folder_paths = crate::file_mapping::parse_quick_share_folder_args(&args);
+    if !quick_share_folder_paths.is_empty() {
+        info!("file mapping quick share request detected");
+        crate::file_mapping::dispatch_cli_quick_share(quick_share_folder_paths);
+        return;
+    }
+
     let windows: Vec<_> = app.webview_windows().keys().cloned().collect();
     info!("📋 当前存在的窗口: {:?}", windows);
 

--- a/src-tauri/src/file_mapping.rs
+++ b/src-tauri/src/file_mapping.rs
@@ -1,0 +1,288 @@
+use crate::sunshine::{create_https_client, get_sunshine_url};
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FileMappingInfo {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub mode: String,
+    pub allow_delete: bool,
+    pub allow_execute: bool,
+    pub follow_reparse_points: bool,
+    pub max_file_size: u64,
+    pub clients: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateMappingResponse {
+    ok: bool,
+    mapping: Option<FileMappingInfo>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListMappingsResponse {
+    ok: bool,
+    mappings: Option<Vec<FileMappingInfo>>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeleteMappingResponse {
+    ok: bool,
+    error: Option<String>,
+}
+
+pub fn parse_quick_share_folder_args(args: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut take_rest = false;
+
+    for arg in args {
+        if take_rest {
+            if !arg.trim().is_empty() {
+                out.push(arg.clone());
+            }
+            continue;
+        }
+
+        if arg == "--quick-share-folder" {
+            take_rest = true;
+            continue;
+        }
+
+        if let Some(path) = arg.strip_prefix("--quick-share-folder=") {
+            if !path.trim().is_empty() {
+                out.push(path.to_string());
+            }
+        }
+    }
+
+    out
+}
+
+pub fn dispatch_cli_quick_share(paths: Vec<String>) {
+    if paths.is_empty() {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        match quick_share_folder_internal(paths).await {
+            Ok(mapping) => info!(
+                "file mapping quick share created: {} ({})",
+                mapping.name, mapping.path
+            ),
+            Err(e) => warn!("file mapping quick share failed: {e}"),
+        }
+    });
+}
+
+#[tauri::command]
+pub async fn quick_share_folder(path: String) -> Result<FileMappingInfo, String> {
+    quick_share_folder_internal(vec![path]).await
+}
+
+#[tauri::command]
+pub async fn list_file_mappings() -> Result<Vec<FileMappingInfo>, String> {
+    list_mappings().await
+}
+
+#[tauri::command]
+pub async fn delete_file_mapping(id: String) -> Result<String, String> {
+    delete_mapping(&id).await?;
+    Ok("success".to_string())
+}
+
+#[tauri::command]
+pub async fn update_file_mapping(
+    id: String,
+    patch: serde_json::Value,
+) -> Result<FileMappingInfo, String> {
+    update_mapping(&id, patch).await
+}
+
+#[tauri::command]
+pub async fn install_file_mapping_menu() -> Result<String, String> {
+    #[cfg(target_os = "windows")]
+    {
+        crate::shell_context_menu::install_file_mapping_menu()?;
+        Ok("success".to_string())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err("file mapping shell menu is only supported on Windows".to_string())
+    }
+}
+
+#[tauri::command]
+pub async fn uninstall_file_mapping_menu() -> Result<String, String> {
+    #[cfg(target_os = "windows")]
+    {
+        crate::shell_context_menu::uninstall_file_mapping_menu()?;
+        Ok("success".to_string())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err("file mapping shell menu is only supported on Windows".to_string())
+    }
+}
+
+async fn quick_share_folder_internal(paths: Vec<String>) -> Result<FileMappingInfo, String> {
+    let first = paths
+        .first()
+        .ok_or_else(|| "no folder was selected".to_string())?;
+
+    if paths.len() > 1 {
+        return Err("only one folder can be shared at a time".to_string());
+    }
+
+    let path = canonicalize_directory(first)?;
+    create_quick_share(&path).await
+}
+
+fn canonicalize_directory(path: &str) -> Result<PathBuf, String> {
+    let raw = PathBuf::from(path);
+    let canonical = std::fs::canonicalize(&raw).map_err(|e| {
+        format!(
+            "folder does not exist or cannot be accessed: {} ({e})",
+            raw.display()
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err("the selected path is not a folder".to_string());
+    }
+    Ok(canonical)
+}
+
+async fn create_quick_share(path: &PathBuf) -> Result<FileMappingInfo, String> {
+    let url = get_sunshine_url().await?;
+    let endpoint = format!("{}/api/v1/file-mapping/mappings", url.trim_end_matches('/'));
+    let client = create_https_client()?;
+    let body = serde_json::json!({
+        "path": path.to_string_lossy(),
+    });
+
+    let resp = client
+        .post(endpoint)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("Sunshine mapping API failed: HTTP {status} {text}"));
+    }
+
+    let parsed: CreateMappingResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse Sunshine mapping API response: {e}; body={text}"))?;
+    if !parsed.ok {
+        return Err(parsed
+            .error
+            .unwrap_or_else(|| "Sunshine mapping API returned an error".to_string()));
+    }
+
+    parsed
+        .mapping
+        .ok_or_else(|| "Sunshine mapping API response did not include a mapping".to_string())
+}
+
+async fn list_mappings() -> Result<Vec<FileMappingInfo>, String> {
+    let url = get_sunshine_url().await?;
+    let endpoint = format!("{}/api/v1/file-mapping/mappings", url.trim_end_matches('/'));
+    let client = create_https_client()?;
+
+    let resp = client
+        .get(endpoint)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("Sunshine mapping API failed: HTTP {status} {text}"));
+    }
+
+    let parsed: ListMappingsResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse Sunshine mapping API response: {e}; body={text}"))?;
+    if !parsed.ok {
+        return Err(parsed
+            .error
+            .unwrap_or_else(|| "Sunshine mapping API returned an error".to_string()));
+    }
+
+    Ok(parsed.mappings.unwrap_or_default())
+}
+
+async fn delete_mapping(id: &str) -> Result<(), String> {
+    let url = get_sunshine_url().await?;
+    let endpoint = format!(
+        "{}/api/v1/file-mapping/mappings/{}",
+        url.trim_end_matches('/'),
+        id
+    );
+    let client = create_https_client()?;
+
+    let resp = client
+        .delete(endpoint)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("Sunshine mapping API failed: HTTP {status} {text}"));
+    }
+
+    let parsed: DeleteMappingResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse Sunshine mapping API response: {e}; body={text}"))?;
+    if !parsed.ok {
+        return Err(parsed
+            .error
+            .unwrap_or_else(|| "Sunshine mapping API returned an error".to_string()));
+    }
+
+    Ok(())
+}
+
+async fn update_mapping(id: &str, patch: serde_json::Value) -> Result<FileMappingInfo, String> {
+    let url = get_sunshine_url().await?;
+    let endpoint = format!(
+        "{}/api/v1/file-mapping/mappings/{}",
+        url.trim_end_matches('/'),
+        id
+    );
+    let client = create_https_client()?;
+
+    let resp = client
+        .patch(endpoint)
+        .json(&patch)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("Sunshine mapping API failed: HTTP {status} {text}"));
+    }
+
+    let parsed: CreateMappingResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse Sunshine mapping API response: {e}; body={text}"))?;
+    if !parsed.ok {
+        return Err(parsed
+            .error
+            .unwrap_or_else(|| "Sunshine mapping API returned an error".to_string()));
+    }
+
+    parsed
+        .mapping
+        .ok_or_else(|| "Sunshine mapping API response did not include a mapping".to_string())
+}

--- a/src-tauri/src/file_mapping.rs
+++ b/src-tauri/src/file_mapping.rs
@@ -38,26 +38,25 @@ struct DeleteMappingResponse {
 
 pub fn parse_quick_share_folder_args(args: &[String]) -> Vec<String> {
     let mut out = Vec::new();
-    let mut take_rest = false;
+    let mut index = 0;
 
-    for arg in args {
-        if take_rest {
-            if !arg.trim().is_empty() {
-                out.push(arg.clone());
-            }
-            continue;
-        }
+    while index < args.len() {
+        let arg = &args[index];
 
         if arg == "--quick-share-folder" {
-            take_rest = true;
-            continue;
-        }
-
-        if let Some(path) = arg.strip_prefix("--quick-share-folder=") {
+            if let Some(path) = args.get(index + 1) {
+                if !path.trim().is_empty() && !path.starts_with("--") {
+                    out.push(path.clone());
+                    index += 1;
+                }
+            }
+        } else if let Some(path) = arg.strip_prefix("--quick-share-folder=") {
             if !path.trim().is_empty() {
                 out.push(path.to_string());
             }
         }
+
+        index += 1;
     }
 
     out

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod clipboard;
 mod commands;
 mod controllermeta;
 mod desktop_settings;
+mod file_mapping;
 mod file_transfer;
 mod fs_utils;
 mod hwinfo;
@@ -171,6 +172,12 @@ fn main() {
             controllermeta::controllermeta_get_install_path,
             controllermeta::controllermeta_uninstall,
             clipboard::clipboard_sync_status,
+            file_mapping::quick_share_folder,
+            file_mapping::list_file_mappings,
+            file_mapping::delete_file_mapping,
+            file_mapping::update_file_mapping,
+            file_mapping::install_file_mapping_menu,
+            file_mapping::uninstall_file_mapping_menu,
             file_transfer::send_file_to_client,
             windows::webview_heartbeat,
             rtss::get_rtss_status,

--- a/src-tauri/src/shell_context_menu.rs
+++ b/src-tauri/src/shell_context_menu.rs
@@ -30,3 +30,72 @@ pub fn install_file_transfer_menu() -> Result<(), String> {
 
     Ok(())
 }
+
+#[cfg(target_os = "windows")]
+pub fn install_file_mapping_menu() -> Result<(), String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe failed: {e}"))?;
+    let exe = exe.to_string_lossy().to_string();
+
+    install_file_mapping_menu_key(
+        r"Software\Classes\Directory\shell\Sunshine.ShareFolder",
+        &exe,
+        "%1",
+    )?;
+    install_file_mapping_menu_key(
+        r"Software\Classes\Directory\Background\shell\Sunshine.ShareFolder",
+        &exe,
+        "%V",
+    )?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn uninstall_file_mapping_menu() -> Result<(), String> {
+    use winreg::enums::*;
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    for key in [
+        r"Software\Classes\Directory\shell\Sunshine.ShareFolder",
+        r"Software\Classes\Directory\Background\shell\Sunshine.ShareFolder",
+    ] {
+        match hkcu.delete_subkey_all(key) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("delete context menu key failed: {e}")),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn install_file_mapping_menu_key(key_path: &str, exe: &str, path_token: &str) -> Result<(), String> {
+    use winreg::enums::*;
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let (verb, _) = hkcu
+        .create_subkey(key_path)
+        .map_err(|e| format!("create file mapping context menu key failed: {e}"))?;
+
+    verb.set_value("", &"通过 Sunshine 共享")
+        .map_err(|e| format!("set file mapping context menu title failed: {e}"))?;
+    verb.set_value("MUIVerb", &"通过 Sunshine 共享")
+        .map_err(|e| format!("set file mapping context menu verb failed: {e}"))?;
+    verb.set_value("Icon", &exe)
+        .map_err(|e| format!("set file mapping context menu icon failed: {e}"))?;
+    verb.set_value("MultiSelectModel", &"Single")
+        .map_err(|e| format!("set file mapping context menu multiselect failed: {e}"))?;
+
+    let (command, _) = verb
+        .create_subkey("command")
+        .map_err(|e| format!("create file mapping context menu command key failed: {e}"))?;
+    let command_line = format!("\"{}\" --quick-share-folder \"{}\"", exe, path_token);
+    command
+        .set_value("", &command_line)
+        .map_err(|e| format!("set file mapping context menu command failed: {e}"))?;
+
+    Ok(())
+}

--- a/src/renderer/desktop/components/settings/SettingsFileSharingCard.vue
+++ b/src/renderer/desktop/components/settings/SettingsFileSharingCard.vue
@@ -1,0 +1,301 @@
+<template>
+  <SettingsCard title="文件夹共享" :icon="FolderOpened">
+    <template #actions>
+      <button class="desktop-btn icon-btn" :disabled="loading" title="刷新" @click="loadMappings">
+        <Refresh />
+      </button>
+      <button class="desktop-btn primary" :disabled="busy" @click="addFolder">
+        <Plus />
+        添加文件夹
+      </button>
+    </template>
+
+    <div class="sharing-toolbar">
+      <div class="sharing-status">
+        <span class="status-indicator" :class="mappings.length > 0 ? 'online' : 'connecting'"></span>
+        <span>{{ statusText }}</span>
+      </div>
+      <div class="sharing-actions">
+        <button class="desktop-btn compact" :disabled="busy" @click="installMenu">
+          <Link />
+          添加右键菜单
+        </button>
+        <button class="desktop-btn compact" :disabled="busy" @click="uninstallMenu">
+          移除右键菜单
+        </button>
+      </div>
+    </div>
+
+    <div v-if="error" class="sharing-error">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="sharing-empty">
+      正在读取共享列表
+    </div>
+
+    <div v-else-if="mappings.length === 0" class="sharing-empty">
+      还没有共享文件夹
+    </div>
+
+    <div v-else class="sharing-list">
+      <div v-for="mapping in mappings" :key="mapping.id" class="sharing-row">
+        <div class="share-main">
+          <div class="share-name">{{ mapping.name || mapping.id }}</div>
+          <div class="share-path" :title="mapping.path">{{ mapping.path }}</div>
+        </div>
+        <div class="share-meta">
+          <span class="share-chip">{{ mapping.mode === 'readwrite' ? '读写' : '只读' }}</span>
+          <span class="share-chip">{{ mapping.clients?.length ? `${mapping.clients.length} 台设备` : '已配对设备' }}</span>
+          <span v-if="!mapping.follow_reparse_points" class="share-chip safe">阻止链接穿透</span>
+        </div>
+        <button
+          class="desktop-btn danger icon-btn"
+          :disabled="busy"
+          title="撤销共享"
+          @click="removeMapping(mapping)"
+        >
+          <Delete />
+        </button>
+      </div>
+    </div>
+  </SettingsCard>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { Delete, FolderOpened, Link, Plus, Refresh } from '@element-plus/icons-vue'
+import { open } from '@tauri-apps/plugin-dialog'
+import { fileMapping } from '../../../tauri-adapter.js'
+import SettingsCard from './SettingsCard.vue'
+
+const mappings = ref([])
+const loading = ref(false)
+const busy = ref(false)
+const error = ref('')
+
+const statusText = computed(() => {
+  if (loading.value) return '同步中'
+  if (mappings.value.length === 0) return '未共享'
+  return `${mappings.value.length} 个共享`
+})
+
+async function loadMappings() {
+  loading.value = true
+  error.value = ''
+  try {
+    mappings.value = await fileMapping.list()
+  } catch (err) {
+    mappings.value = []
+    error.value = friendlyError(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function addFolder() {
+  if (busy.value) return
+  busy.value = true
+  error.value = ''
+  try {
+    const path = await open({
+      directory: true,
+      multiple: false,
+    })
+    if (!path) return
+    await fileMapping.quickShareFolder(path)
+    await loadMappings()
+  } catch (err) {
+    error.value = friendlyError(err)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function removeMapping(mapping) {
+  if (!mapping?.id || busy.value) return
+  if (!confirm(`撤销共享“${mapping.name || mapping.id}”？`)) return
+
+  busy.value = true
+  error.value = ''
+  try {
+    await fileMapping.remove(mapping.id)
+    mappings.value = mappings.value.filter(item => item.id !== mapping.id)
+  } catch (err) {
+    error.value = friendlyError(err)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function installMenu() {
+  busy.value = true
+  error.value = ''
+  try {
+    await fileMapping.installMenu()
+  } catch (err) {
+    error.value = friendlyError(err)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function uninstallMenu() {
+  busy.value = true
+  error.value = ''
+  try {
+    await fileMapping.uninstallMenu()
+  } catch (err) {
+    error.value = friendlyError(err)
+  } finally {
+    busy.value = false
+  }
+}
+
+function friendlyError(err) {
+  const text = String(err || '').trim()
+  if (!text) return '操作失败'
+  if (text.includes('Connection') || text.includes('connection') || text.includes('refused')) {
+    return '无法连接 Sunshine，请确认 Sunshine 正在运行'
+  }
+  return text
+}
+
+onMounted(loadMappings)
+</script>
+
+<style lang="less" scoped>
+.sharing-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.sharing-status,
+.sharing-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.desktop-btn {
+  &:disabled {
+    opacity: 0.55;
+    cursor: default;
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+.compact {
+  padding: 8px 12px;
+}
+
+.icon-btn {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  justify-content: center;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.sharing-error {
+  color: var(--fd-status-danger, #ff6b35);
+  background: rgba(var(--fd-status-danger-rgb, 255, 107, 53), 0.1);
+  border: 1px solid rgba(var(--fd-status-danger-rgb, 255, 107, 53), 0.24);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 14px;
+  line-height: 1.45;
+}
+
+.sharing-empty {
+  color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.5);
+  border: 1px dashed rgba(var(--fd-accent-rgb, 0, 255, 245), 0.2);
+  border-radius: 8px;
+  padding: 18px;
+  text-align: center;
+}
+
+.sharing-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sharing-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 40px;
+  align-items: center;
+  gap: 14px;
+  padding: 12px;
+  border: 1px solid rgba(var(--fd-accent-rgb, 0, 255, 245), 0.1);
+  border-radius: 8px;
+  background: rgba(var(--fd-bg-primary-rgb, 15, 15, 35), 0.2);
+}
+
+.share-main {
+  min-width: 0;
+}
+
+.share-name {
+  color: var(--fd-text-primary, #fff);
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.share-path {
+  color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.52);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.share-chip {
+  color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.75);
+  background: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.08);
+  border-radius: 999px;
+  padding: 4px 9px;
+  font-size: 12px;
+  white-space: nowrap;
+
+  &.safe {
+    color: var(--fd-status-success, #00ff88);
+    background: rgba(var(--fd-status-success-rgb, 0, 255, 136), 0.1);
+  }
+}
+
+@media (max-width: 760px) {
+  .sharing-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sharing-actions {
+    flex-wrap: wrap;
+  }
+
+  .sharing-row {
+    grid-template-columns: minmax(0, 1fr) 40px;
+  }
+
+  .share-meta {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/src/renderer/desktop/components/settings/SettingsFileSharingCard.vue
+++ b/src/renderer/desktop/components/settings/SettingsFileSharingCard.vue
@@ -12,19 +12,32 @@
 
     <div class="sharing-toolbar">
       <div class="sharing-status">
-        <span class="status-indicator" :class="mappings.length > 0 ? 'online' : 'connecting'"></span>
+        <span class="status-indicator" :class="statusClass"></span>
         <span>{{ statusText }}</span>
       </div>
       <div class="sharing-actions">
         <button class="desktop-btn compact" :disabled="busy" @click="installMenu">
           <Link />
-          添加右键菜单
+          启用右键共享
         </button>
         <button class="desktop-btn compact" :disabled="busy" @click="uninstallMenu">
-          移除右键菜单
+          关闭右键共享
         </button>
       </div>
     </div>
+
+    <div class="sharing-policy">
+      <span class="share-chip safe">只读</span>
+      <span class="share-chip safe">仅已配对设备</span>
+      <span class="share-chip safe">阻止链接穿透</span>
+    </div>
+
+    <Transition name="notice">
+      <div v-if="notice.text" class="sharing-notice" :class="notice.type">
+        <span>{{ notice.text }}</span>
+        <button class="notice-close" title="关闭" @click="clearNotice">×</button>
+      </div>
+    </Transition>
 
     <div v-if="error" class="sharing-error">
       {{ error }}
@@ -35,7 +48,17 @@
     </div>
 
     <div v-else-if="mappings.length === 0" class="sharing-empty">
-      还没有共享文件夹
+      <div class="empty-title">还没有共享文件夹</div>
+      <div class="empty-actions">
+        <button class="desktop-btn primary" :disabled="busy" @click="addFolder">
+          <Plus />
+          选择文件夹
+        </button>
+        <button class="desktop-btn" :disabled="busy" @click="installMenu">
+          <Link />
+          启用右键共享
+        </button>
+      </div>
     </div>
 
     <div v-else class="sharing-list">
@@ -46,7 +69,7 @@
         </div>
         <div class="share-meta">
           <span class="share-chip">{{ mapping.mode === 'readwrite' ? '读写' : '只读' }}</span>
-          <span class="share-chip">{{ mapping.clients?.length ? `${mapping.clients.length} 台设备` : '已配对设备' }}</span>
+          <span class="share-chip">{{ clientLabel(mapping) }}</span>
           <span v-if="!mapping.follow_reparse_points" class="share-chip safe">阻止链接穿透</span>
         </div>
         <button
@@ -73,6 +96,12 @@ const mappings = ref([])
 const loading = ref(false)
 const busy = ref(false)
 const error = ref('')
+const notice = ref({ type: 'success', text: '' })
+
+const statusClass = computed(() => {
+  if (loading.value) return 'connecting'
+  return mappings.value.length > 0 ? 'online' : 'offline'
+})
 
 const statusText = computed(() => {
   if (loading.value) return '同步中'
@@ -103,8 +132,9 @@ async function addFolder() {
       multiple: false,
     })
     if (!path) return
-    await fileMapping.quickShareFolder(path)
+    const mapping = await fileMapping.quickShareFolder(path)
     await loadMappings()
+    showNotice('success', `已共享“${mapping?.name || folderName(path)}”，Moonlight 可只读访问`)
   } catch (err) {
     error.value = friendlyError(err)
   } finally {
@@ -121,6 +151,7 @@ async function removeMapping(mapping) {
   try {
     await fileMapping.remove(mapping.id)
     mappings.value = mappings.value.filter(item => item.id !== mapping.id)
+    showNotice('success', `已撤销“${mapping.name || mapping.id}”`)
   } catch (err) {
     error.value = friendlyError(err)
   } finally {
@@ -133,6 +164,7 @@ async function installMenu() {
   error.value = ''
   try {
     await fileMapping.installMenu()
+    showNotice('success', '已添加资源管理器右键共享入口')
   } catch (err) {
     error.value = friendlyError(err)
   } finally {
@@ -145,11 +177,31 @@ async function uninstallMenu() {
   error.value = ''
   try {
     await fileMapping.uninstallMenu()
+    showNotice('success', '已移除资源管理器右键共享入口')
   } catch (err) {
     error.value = friendlyError(err)
   } finally {
     busy.value = false
   }
+}
+
+function clientLabel(mapping) {
+  return mapping.clients?.length ? `${mapping.clients.length} 台设备` : '所有已配对设备'
+}
+
+function folderName(path) {
+  return String(path || '')
+    .split(/[\\/]/)
+    .filter(Boolean)
+    .pop() || '文件夹'
+}
+
+function showNotice(type, text) {
+  notice.value = { type, text }
+}
+
+function clearNotice() {
+  notice.value = { type: 'success', text: '' }
 }
 
 function friendlyError(err) {
@@ -158,6 +210,11 @@ function friendlyError(err) {
   if (text.includes('Connection') || text.includes('connection') || text.includes('refused')) {
     return '无法连接 Sunshine，请确认 Sunshine 正在运行'
   }
+  if (text.includes('not a folder')) return '请选择一个文件夹'
+  if (text.includes('does not exist') || text.includes('cannot be accessed')) return '文件夹不存在或无法访问'
+  if (text.includes('readwrite mode is not supported')) return '当前阶段仅支持只读共享'
+  if (text.includes('allow_delete')) return '当前阶段不允许远端删除文件'
+  if (text.includes('follow_reparse_points')) return '当前阶段不允许穿透符号链接或 junction'
   return text
 }
 
@@ -179,6 +236,13 @@ onMounted(loadMappings)
   align-items: center;
   gap: 10px;
   min-width: 0;
+}
+
+.sharing-policy {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: -4px 0 14px;
 }
 
 .desktop-btn {
@@ -206,6 +270,34 @@ onMounted(loadMappings)
   }
 }
 
+.sharing-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 14px;
+  line-height: 1.45;
+
+  &.success {
+    color: var(--fd-status-success, #00ff88);
+    background: rgba(var(--fd-status-success-rgb, 0, 255, 136), 0.1);
+    border: 1px solid rgba(var(--fd-status-success-rgb, 0, 255, 136), 0.24);
+  }
+}
+
+.notice-close {
+  border: 0;
+  background: transparent;
+  color: currentColor;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  opacity: 0.8;
+  padding: 0 2px;
+}
+
 .sharing-error {
   color: var(--fd-status-danger, #ff6b35);
   background: rgba(var(--fd-status-danger-rgb, 255, 107, 53), 0.1);
@@ -222,6 +314,17 @@ onMounted(loadMappings)
   border-radius: 8px;
   padding: 18px;
   text-align: center;
+}
+
+.empty-title {
+  margin-bottom: 12px;
+}
+
+.empty-actions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .sharing-list {
@@ -277,6 +380,17 @@ onMounted(loadMappings)
     color: var(--fd-status-success, #00ff88);
     background: rgba(var(--fd-status-success-rgb, 0, 255, 136), 0.1);
   }
+}
+
+.notice-enter-active,
+.notice-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.notice-enter-from,
+.notice-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
 }
 
 @media (max-width: 760px) {

--- a/src/renderer/desktop/components/settings/SettingsFileSharingCard.vue
+++ b/src/renderer/desktop/components/settings/SettingsFileSharingCard.vue
@@ -1,10 +1,10 @@
 <template>
   <SettingsCard title="文件夹共享" :icon="FolderOpened">
     <template #actions>
-      <button class="desktop-btn icon-btn" :disabled="loading" title="刷新" @click="loadMappings">
+      <button class="desktop-btn icon-btn" :disabled="refreshDisabled" title="刷新" @click="loadMappings">
         <Refresh />
       </button>
-      <button class="desktop-btn primary" :disabled="busy" @click="addFolder">
+      <button class="desktop-btn primary" :disabled="actionDisabled" @click="addFolder">
         <Plus />
         添加文件夹
       </button>
@@ -16,11 +16,11 @@
         <span>{{ statusText }}</span>
       </div>
       <div class="sharing-actions">
-        <button class="desktop-btn compact" :disabled="busy" @click="installMenu">
+        <button class="desktop-btn compact" :disabled="actionDisabled" @click="installMenu">
           <Link />
           启用右键共享
         </button>
-        <button class="desktop-btn compact" :disabled="busy" @click="uninstallMenu">
+        <button class="desktop-btn compact" :disabled="actionDisabled" @click="uninstallMenu">
           关闭右键共享
         </button>
       </div>
@@ -43,18 +43,22 @@
       {{ error }}
     </div>
 
-    <div v-if="loading" class="sharing-empty">
-      正在读取共享列表
+    <div v-if="!runtimeChecked || loading" class="sharing-empty">
+      {{ runtimeChecked ? '正在读取共享列表' : '正在检测运行环境' }}
+    </div>
+
+    <div v-else-if="!hasTauri" class="sharing-empty">
+      <div class="empty-title">文件夹共享需要在桌面端使用</div>
     </div>
 
     <div v-else-if="mappings.length === 0" class="sharing-empty">
       <div class="empty-title">还没有共享文件夹</div>
       <div class="empty-actions">
-        <button class="desktop-btn primary" :disabled="busy" @click="addFolder">
+        <button class="desktop-btn primary" :disabled="actionDisabled" @click="addFolder">
           <Plus />
           选择文件夹
         </button>
-        <button class="desktop-btn" :disabled="busy" @click="installMenu">
+        <button class="desktop-btn" :disabled="actionDisabled" @click="installMenu">
           <Link />
           启用右键共享
         </button>
@@ -74,7 +78,7 @@
         </div>
         <button
           class="desktop-btn danger icon-btn"
-          :disabled="busy"
+          :disabled="actionDisabled"
           title="撤销共享"
           @click="removeMapping(mapping)"
         >
@@ -89,27 +93,44 @@
 import { computed, onMounted, ref } from 'vue'
 import { Delete, FolderOpened, Link, Plus, Refresh } from '@element-plus/icons-vue'
 import { open } from '@tauri-apps/plugin-dialog'
+import { isTauriRuntime } from '../../composables/useTauri.js'
 import { fileMapping } from '../../../tauri-adapter.js'
 import SettingsCard from './SettingsCard.vue'
 
 const mappings = ref([])
 const loading = ref(false)
 const busy = ref(false)
+const runtimeChecked = ref(false)
+const hasTauri = ref(false)
 const error = ref('')
 const notice = ref({ type: 'success', text: '' })
 
+const canUseSharing = computed(() => runtimeChecked.value && hasTauri.value)
+const actionDisabled = computed(() => busy.value || !canUseSharing.value)
+const refreshDisabled = computed(() => loading.value || !canUseSharing.value)
+
 const statusClass = computed(() => {
-  if (loading.value) return 'connecting'
+  if (!runtimeChecked.value || loading.value) return 'connecting'
+  if (!hasTauri.value) return 'offline'
   return mappings.value.length > 0 ? 'online' : 'offline'
 })
 
 const statusText = computed(() => {
+  if (!runtimeChecked.value) return '检测中'
+  if (!hasTauri.value) return '仅桌面端可用'
   if (loading.value) return '同步中'
   if (mappings.value.length === 0) return '未共享'
   return `${mappings.value.length} 个共享`
 })
 
 async function loadMappings() {
+  if (!canUseSharing.value) {
+    mappings.value = []
+    loading.value = false
+    error.value = ''
+    return
+  }
+
   loading.value = true
   error.value = ''
   try {
@@ -123,7 +144,7 @@ async function loadMappings() {
 }
 
 async function addFolder() {
-  if (busy.value) return
+  if (actionDisabled.value) return
   busy.value = true
   error.value = ''
   try {
@@ -143,7 +164,7 @@ async function addFolder() {
 }
 
 async function removeMapping(mapping) {
-  if (!mapping?.id || busy.value) return
+  if (!mapping?.id || actionDisabled.value) return
   if (!confirm(`撤销共享“${mapping.name || mapping.id}”？`)) return
 
   busy.value = true
@@ -160,6 +181,7 @@ async function removeMapping(mapping) {
 }
 
 async function installMenu() {
+  if (actionDisabled.value) return
   busy.value = true
   error.value = ''
   try {
@@ -173,6 +195,7 @@ async function installMenu() {
 }
 
 async function uninstallMenu() {
+  if (actionDisabled.value) return
   busy.value = true
   error.value = ''
   try {
@@ -218,7 +241,13 @@ function friendlyError(err) {
   return text
 }
 
-onMounted(loadMappings)
+onMounted(async () => {
+  hasTauri.value = await isTauriRuntime()
+  runtimeChecked.value = true
+  if (hasTauri.value) {
+    await loadMappings()
+  }
+})
 </script>
 
 <style lang="less" scoped>

--- a/src/renderer/desktop/views/SettingsView.vue
+++ b/src/renderer/desktop/views/SettingsView.vue
@@ -17,6 +17,8 @@
 
     <SettingsLaunchAssistantCard :has-tauri="hasTauri" />
 
+    <SettingsFileSharingCard />
+
     <SettingsToggleSection
       :title="t.settings.notifications"
       :icon="Bell"
@@ -54,6 +56,7 @@ import SettingsActions from '../components/settings/SettingsActions.vue'
 import SettingsAboutCard from '../components/settings/SettingsAboutCard.vue'
 import SettingsAdvancedCard from '../components/settings/SettingsAdvancedCard.vue'
 import SettingsAppearanceCard from '../components/settings/SettingsAppearanceCard.vue'
+import SettingsFileSharingCard from '../components/settings/SettingsFileSharingCard.vue'
 import SettingsLaunchAssistantCard from '../components/settings/SettingsLaunchAssistantCard.vue'
 import SettingsNotice from '../components/settings/SettingsNotice.vue'
 import SettingsPetCard from '../components/settings/SettingsPetCard.vue'

--- a/src/renderer/tauri-adapter.js
+++ b/src/renderer/tauri-adapter.js
@@ -117,6 +117,17 @@ export const tools = {
   uninstallVddDriver: () => invoke('uninstall_vdd_driver'),
 }
 
+// Folder Sharing
+
+export const fileMapping = {
+  list: () => invoke('list_file_mappings'),
+  quickShareFolder: (path) => invoke('quick_share_folder', { path }),
+  remove: (id) => invoke('delete_file_mapping', { id }),
+  update: (id, patch) => invoke('update_file_mapping', { id, patch }),
+  installMenu: () => invoke('install_file_mapping_menu'),
+  uninstallMenu: () => invoke('uninstall_file_mapping_menu'),
+}
+
 // ─── Moonlight Web ───────────────────────────────────────
 
 export const moonlightWeb = {
@@ -161,6 +172,7 @@ export default {
   vigem,
   sunshine,
   tools,
+  fileMapping,
   moonlightWeb,
   controllerMeta,
   readDirectory,


### PR DESCRIPTION
﻿## 改了啥呢

- 新增文件夹共享 Tauri command，Control Panel 可以调用 Sunshine 本机 API 创建、列出、更新和删除 file mapping。
- 在设置页加入「文件夹共享」卡片，普通用户可以添加文件夹、查看共享列表、撤销共享。
- 注册 Explorer 文件夹右键菜单：`通过 Sunshine 共享`，默认走安全的快速共享路径。
- 支持 `--quick-share-folder` 单实例入口，右键菜单触发时不会强行打开主窗口。

## 为啥要改

普通用户建立主机目录共享时，不应该先面对一堆高级权限。这个 PR 让入口贴近 Windows 使用习惯：右键目录即可共享，默认只读和安全权限由 Sunshine core 兜底，杂鱼复杂度被按在 Control Panel 之外。

## 验证

- `npm run build:renderer`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2024 --check src-tauri/src/file_mapping.rs`
- `git diff --check`

已知：renderer build 仍有既有 Rolldown pure annotation 和 chunk-size warning。
