### PR TITLE
perf(gui): optimize renderer performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cross-env": "^7.0.3",
         "esbuild": "^0.28.1",
         "less": "^4.6.7",
+        "unplugin-vue-components": "^32.1.0",
         "vite": "^8.1.0"
       }
     },
@@ -655,11 +656,54 @@
         "url": "https://github.com/sponsors/kazupon"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -1451,6 +1495,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1496,6 +1553,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/cliui/-/cliui-6.0.0.tgz",
@@ -1523,6 +1596,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-anything": {
@@ -1728,6 +1808,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -2177,6 +2264,24 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-5.0.0.tgz",
@@ -2288,6 +2393,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmmirror.com/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmmirror.com/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -2329,6 +2466,20 @@
       "resolved": "https://registry.npmmirror.com/normalize-wheel-es/-/normalize-wheel-es-1.2.0.tgz",
       "integrity": "sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -2401,6 +2552,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
@@ -2444,6 +2602,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/pngjs": {
@@ -2515,6 +2685,37 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmmirror.com/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-directory": {
@@ -2700,6 +2901,118 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unplugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/unplugin/-/unplugin-3.2.0.tgz",
+      "integrity": "sha512-6nGlT7EHsS+tTcTdAkYFqXIUwDrMJyJvHFNYGSr4x2/2ySIcV4f5e1RAJUeDyfOJPR8TF0auE8l+82PLhKjqsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.4",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmmirror.com/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unplugin-vue-components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmmirror.com/unplugin-vue-components/-/unplugin-vue-components-32.1.0.tgz",
+      "integrity": "sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "local-pkg": "^1.2.0",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.2",
+        "obug": "^2.1.1",
+        "picomatch": "^4.0.4",
+        "tinyglobby": "^0.2.16",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": "^3.2.2 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
@@ -2825,6 +3138,13 @@
       "peerDependencies": {
         "vue": "^3.0.0"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmmirror.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cross-env": "^7.0.3",
     "esbuild": "^0.28.1",
     "less": "^4.6.7",
+    "unplugin-vue-components": "^32.1.0",
     "vite": "^8.1.0"
   },
   "dependencies": {

--- a/src/renderer/components/SidebarMenu.vue
+++ b/src/renderer/components/SidebarMenu.vue
@@ -162,12 +162,12 @@
 </template>
 
 <script setup>
-import { computed, ref, watch, onMounted } from 'vue'
+import { computed, defineAsyncComponent, ref, watch, onMounted } from 'vue'
 import VddSettings from './VddSettings.vue'
 import Welcome from './welcome.vue'
 import WebStreamSettings from './WebStreamSettings.vue'
 import AiAssistant from './AiAssistant.vue'
-import UpdateDialog from './UpdateDialog.vue'
+const UpdateDialog = defineAsyncComponent(() => import('./UpdateDialog.vue'))
 import { useSidebarState } from '../composables/useSidebarState.js'
 import { useWindowControls } from '../composables/useWindowControls.js'
 import { useTools } from '../composables/useTools.js'

--- a/src/renderer/console/LogConsoleApp.less
+++ b/src/renderer/console/LogConsoleApp.less
@@ -271,6 +271,7 @@
     padding: 8px;
     font-size: 13px;
     line-height: 1.5;
+    position: relative;
 
     &::-webkit-scrollbar {
       width: 12px;
@@ -290,12 +291,28 @@
       }
     }
 
+    .log-virtual-space {
+      position: relative;
+      min-height: 100%;
+    }
+
+    .log-virtual-window {
+      left: 8px;
+      position: absolute;
+      right: 8px;
+      top: 0;
+      will-change: transform;
+    }
+
     .log-entry {
-      padding: 8px 12px;
+      box-sizing: border-box;
+      height: 38px;
+      overflow: hidden;
+      padding: 7px 12px;
       margin-bottom: 2px;
       border-left: 3px solid transparent;
-      word-wrap: break-word;
-      white-space: pre-wrap;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       border-radius: @border-radius-sm;
       transition: all @transition-fast;
       position: relative;
@@ -393,6 +410,9 @@
 
       .log-message {
         color: @text-primary;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: middle;
 
         :deep(.highlight) {
           background: rgba(0, 122, 204, 0.3);

--- a/src/renderer/console/LogConsoleApp.vue
+++ b/src/renderer/console/LogConsoleApp.vue
@@ -82,7 +82,7 @@
     </div>
 
     <!-- 日志容器 -->
-    <div class="log-container" ref="logContainer">
+    <div class="log-container" ref="logContainer" @scroll="handleLogScroll">
       <div v-if="filteredLogs.length === 0" class="empty-state">
         <div class="empty-state-icon-wrapper">
           <el-icon class="empty-state-icon" :size="56"><Document /></el-icon>
@@ -94,11 +94,19 @@
           {{ loading ? '正在加载日志中...' : searchKeyword ? '没有找到匹配的日志呢~' : '还没有日志记录哦~' }}
         </div>
       </div>
-      <div v-for="log in filteredLogs" :key="`${log.timestamp}-${log.message}`" :class="['log-entry', log.level]">
-        <span class="log-timestamp">{{ log.timestamp }}</span>
-        <span :class="['log-level', log.level]">{{ log.level }}</span>
-        <span v-if="log.file" class="log-source">{{ log.file }}<span v-if="log.line">:{{ log.line }}</span></span>
-        <span class="log-message" v-html="highlightMessage(log.message)"></span>
+      <div v-else class="log-virtual-space" :style="{ height: `${totalHeight}px` }">
+        <div class="log-virtual-window" :style="{ transform: `translateY(${visibleOffset}px)` }">
+          <div
+            v-for="{ log, virtualIndex } in visibleLogs"
+            :key="`${virtualIndex}-${log.timestamp}-${log.message}`"
+            :class="['log-entry', log.level]"
+          >
+            <span class="log-timestamp">{{ log.timestamp }}</span>
+            <span :class="['log-level', log.level]">{{ log.level }}</span>
+            <span v-if="log.file" class="log-source">{{ log.file }}<span v-if="log.line">:{{ log.line }}</span></span>
+            <span class="log-message" v-html="highlightMessage(log.message)"></span>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -125,7 +133,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { confirm as dialogConfirm, message as dialogMessage } from '@tauri-apps/plugin-dialog'
@@ -137,6 +145,14 @@ const allLogs = ref([])
 const loading = ref(false)
 const logContainer = ref(null)
 const searchKeyword = ref('')
+const committedSearchKeyword = ref('')
+const scrollTop = ref(0)
+const viewportHeight = ref(1)
+
+const LOG_ROW_HEIGHT = 40
+const LOG_OVERSCAN = 8
+const SEARCH_DEBOUNCE_MS = 120
+let searchTimer = null
 
 // 过滤器
 const filters = ref({
@@ -149,15 +165,31 @@ const filters = ref({
 })
 
 // 计算属性：获取所有可用的文件来源
-const availableFiles = computed(() => {
+const logSummary = computed(() => {
   const files = new Set()
+  const counts = {
+    total: allLogs.value.length,
+    error: 0,
+    warn: 0,
+    info: 0,
+  }
+
   allLogs.value.forEach((log) => {
     if (log.file) {
       files.add(log.file)
     }
+    if (log.level === 'error') counts.error += 1
+    else if (log.level === 'warn') counts.warn += 1
+    else if (log.level === 'info') counts.info += 1
   })
-  return Array.from(files).sort()
+
+  return {
+    files: Array.from(files).sort(),
+    stats: counts,
+  }
 })
+
+const availableFiles = computed(() => logSummary.value.files)
 
 // 计算属性：过滤后的日志（同时考虑级别、文件来源和关键词）
 const filteredLogs = computed(() => {
@@ -173,8 +205,8 @@ const filteredLogs = computed(() => {
   }
 
   // 如果有关键词，进行搜索过滤
-  if (searchKeyword.value.trim()) {
-    const keyword = searchKeyword.value.trim().toLowerCase()
+  if (committedSearchKeyword.value.trim()) {
+    const keyword = committedSearchKeyword.value.trim().toLowerCase()
     filtered = filtered.filter((log) => {
       const message = log.message.toLowerCase()
       const timestamp = log.timestamp.toLowerCase()
@@ -189,11 +221,11 @@ const filteredLogs = computed(() => {
 
 // 高亮消息中的关键词
 function highlightMessage(message) {
-  if (!searchKeyword.value.trim()) {
+  if (!committedSearchKeyword.value.trim()) {
     return escapeHtml(message)
   }
 
-  const keyword = searchKeyword.value.trim()
+  const keyword = committedSearchKeyword.value.trim()
   const regex = new RegExp(`(${escapeRegex(keyword)})`, 'gi')
   const highlighted = message.replace(regex, '<mark class="highlight">$1</mark>')
   return highlighted
@@ -213,31 +245,56 @@ function escapeRegex(str) {
 
 // 处理搜索输入
 function handleSearchInput() {
-  // 搜索时自动滚动到第一个匹配项
-  nextTick(() => {
-    if (logContainer.value && filteredLogs.value.length > 0) {
-      const firstMatch = logContainer.value.querySelector('.log-entry')
-      if (firstMatch) {
-        firstMatch.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-      }
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    committedSearchKeyword.value = searchKeyword.value
+    if (logContainer.value) {
+      logContainer.value.scrollTop = 0
+      scrollTop.value = 0
     }
-  })
+  }, SEARCH_DEBOUNCE_MS)
 }
 
 // 清除搜索
 function clearSearch() {
   searchKeyword.value = ''
+  committedSearchKeyword.value = ''
+  clearTimeout(searchTimer)
+  if (logContainer.value) {
+    logContainer.value.scrollTop = 0
+    scrollTop.value = 0
+  }
 }
 
 // 计算属性：统计信息
-const stats = computed(() => {
-  return {
-    total: allLogs.value.length,
-    error: allLogs.value.filter((l) => l.level === 'error').length,
-    warn: allLogs.value.filter((l) => l.level === 'warn').length,
-    info: allLogs.value.filter((l) => l.level === 'info').length,
-  }
+const stats = computed(() => logSummary.value.stats)
+
+const totalHeight = computed(() => filteredLogs.value.length * LOG_ROW_HEIGHT)
+const visibleStartIndex = computed(() => {
+  const maxStart = Math.max(0, filteredLogs.value.length - 1)
+  return Math.min(maxStart, Math.max(0, Math.floor(scrollTop.value / LOG_ROW_HEIGHT) - LOG_OVERSCAN))
 })
+const visibleEndIndex = computed(() =>
+  Math.min(
+    filteredLogs.value.length,
+    Math.ceil((scrollTop.value + viewportHeight.value) / LOG_ROW_HEIGHT) + LOG_OVERSCAN
+  )
+)
+const visibleOffset = computed(() => visibleStartIndex.value * LOG_ROW_HEIGHT)
+const visibleLogs = computed(() =>
+  filteredLogs.value.slice(visibleStartIndex.value, visibleEndIndex.value).map((log, index) => ({
+    log,
+    virtualIndex: visibleStartIndex.value + index,
+  }))
+)
+
+function updateViewportHeight() {
+  viewportHeight.value = logContainer.value?.clientHeight || 1
+}
+
+function handleLogScroll() {
+  scrollTop.value = logContainer.value?.scrollTop || 0
+}
 
 // 加载所有日志
 async function loadLogs() {
@@ -296,6 +353,8 @@ let unsubscribe = null
 onMounted(async () => {
   // 初始加载
   await loadLogs()
+  updateViewportHeight()
+  window.addEventListener('resize', updateViewportHeight)
   scrollToBottom()
 
   // 监听新日志事件
@@ -313,6 +372,8 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  clearTimeout(searchTimer)
+  window.removeEventListener('resize', updateViewportHeight)
   if (unsubscribe) {
     unsubscribe()
   }

--- a/src/renderer/console/main.js
+++ b/src/renderer/console/main.js
@@ -1,9 +1,10 @@
 import { createApp } from 'vue';
 import LogConsoleApp from './LogConsoleApp.vue';
-import ElementPlus from 'element-plus';
-import 'element-plus/dist/index.css';
+import { ElIcon } from 'element-plus';
+import 'element-plus/theme-chalk/base.css';
+import 'element-plus/theme-chalk/el-icon.css';
+import 'element-plus/theme-chalk/el-message.css';
 
 const app = createApp(LogConsoleApp);
-app.use(ElementPlus);
+app.component(ElIcon.name, ElIcon);
 app.mount('#app');
-

--- a/src/renderer/console/main.js
+++ b/src/renderer/console/main.js
@@ -1,10 +1,6 @@
 import { createApp } from 'vue';
 import LogConsoleApp from './LogConsoleApp.vue';
-import { ElIcon } from 'element-plus';
-import 'element-plus/theme-chalk/base.css';
-import 'element-plus/theme-chalk/el-icon.css';
 import 'element-plus/theme-chalk/el-message.css';
 
 const app = createApp(LogConsoleApp);
-app.component(ElIcon.name, ElIcon);
 app.mount('#app');

--- a/src/renderer/desktop/DesktopApp.vue
+++ b/src/renderer/desktop/DesktopApp.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { defineAsyncComponent, ref, computed, onMounted, onUnmounted } from 'vue'
 
 // 桌面 UI 组件
 import DesktopWindow from './components/DesktopWindow.vue'
@@ -71,12 +71,12 @@ import IconPalette from './icons/IconPalette.vue'
 import IconLang from './icons/IconLang.vue'
 
 // 视图组件
-import AppsView from './views/AppsView.vue'
-import DashboardView from './views/DashboardView.vue'
-import DevicesView from './views/DevicesView.vue'
-import StreamView from './views/StreamView.vue'
-import ToolsView from './views/ToolsView.vue'
-import SettingsView from './views/SettingsView.vue'
+const AppsView = defineAsyncComponent(() => import('./views/AppsView.vue'))
+const DashboardView = defineAsyncComponent(() => import('./views/DashboardView.vue'))
+const DevicesView = defineAsyncComponent(() => import('./views/DevicesView.vue'))
+const StreamView = defineAsyncComponent(() => import('./views/StreamView.vue'))
+const ToolsView = defineAsyncComponent(() => import('./views/ToolsView.vue'))
+const SettingsView = defineAsyncComponent(() => import('./views/SettingsView.vue'))
 
 // 导入图标资源
 import sunshineIcon from '../../assets/sunshine.ico'

--- a/src/renderer/desktop/components/AppGridView.vue
+++ b/src/renderer/desktop/components/AppGridView.vue
@@ -17,6 +17,8 @@
           :src="getAppImageUrl(app)"
           :alt="app.name"
           class="cover-image"
+          loading="lazy"
+          decoding="async"
           @error="handleImageError($event, app)"
         />
         <div v-else class="cover-placeholder">

--- a/src/renderer/desktop/components/AppListView.vue
+++ b/src/renderer/desktop/components/AppListView.vue
@@ -11,7 +11,14 @@
       @contextmenu.prevent="$emit('contextmenu', $event, app)"
     >
       <div class="list-cover">
-        <img v-if="getAppImageUrl(app)" :src="getAppImageUrl(app)" :alt="app.name" @error="handleImageError($event, app)" />
+        <img
+          v-if="getAppImageUrl(app)"
+          :src="getAppImageUrl(app)"
+          :alt="app.name"
+          loading="lazy"
+          decoding="async"
+          @error="handleImageError($event, app)"
+        />
         <div v-else class="mini-placeholder">{{ app.name?.[0] || '?' }}</div>
       </div>
       <div class="list-info">

--- a/src/renderer/desktop/components/AppRecentStrip.vue
+++ b/src/renderer/desktop/components/AppRecentStrip.vue
@@ -17,7 +17,14 @@
         @contextmenu.prevent="$emit('contextmenu', $event, app)"
       >
         <div class="recent-cover">
-          <img v-if="getAppImageUrl(app)" :src="getAppImageUrl(app)" :alt="app.name" @error="handleImageError($event, app)" />
+          <img
+            v-if="getAppImageUrl(app)"
+            :src="getAppImageUrl(app)"
+            :alt="app.name"
+            loading="lazy"
+            decoding="async"
+            @error="handleImageError($event, app)"
+          />
           <div v-else class="mini-placeholder">{{ app.name?.[0] || '?' }}</div>
         </div>
         <span class="recent-name">{{ app.name }}</span>
@@ -66,6 +73,8 @@ defineEmits(['launch', 'contextmenu'])
 }
 
 .recent-tile {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 112px;
   flex-shrink: 0;
   width: 80px;
   cursor: pointer;

--- a/src/renderer/log-console/LogConsoleApp.less
+++ b/src/renderer/log-console/LogConsoleApp.less
@@ -271,6 +271,7 @@
     padding: 8px;
     font-size: 13px;
     line-height: 1.5;
+    position: relative;
 
     &::-webkit-scrollbar {
       width: 12px;
@@ -290,12 +291,28 @@
       }
     }
 
+    .log-virtual-space {
+      position: relative;
+      min-height: 100%;
+    }
+
+    .log-virtual-window {
+      left: 8px;
+      position: absolute;
+      right: 8px;
+      top: 0;
+      will-change: transform;
+    }
+
     .log-entry {
-      padding: 8px 12px;
+      box-sizing: border-box;
+      height: 38px;
+      overflow: hidden;
+      padding: 7px 12px;
       margin-bottom: 2px;
       border-left: 3px solid transparent;
-      word-wrap: break-word;
-      white-space: pre-wrap;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       border-radius: @border-radius-sm;
       transition: all @transition-fast;
       position: relative;
@@ -393,6 +410,9 @@
 
       .log-message {
         color: @text-primary;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: middle;
 
         :deep(.highlight) {
           background: rgba(0, 122, 204, 0.3);

--- a/src/renderer/log-console/LogConsoleApp.vue
+++ b/src/renderer/log-console/LogConsoleApp.vue
@@ -85,7 +85,7 @@
     </div>
 
     <!-- 日志容器 -->
-    <div class="log-container" ref="logContainer">
+    <div class="log-container" ref="logContainer" @scroll="handleLogScroll">
       <div v-if="filteredLogs.length === 0" class="empty-state">
         <div class="empty-state-icon-wrapper">
           <el-icon class="empty-state-icon" :size="56"><Document /></el-icon>
@@ -97,11 +97,19 @@
           {{ loading ? t.logConsole.loadingLogs : searchKeyword ? t.logConsole.noMatch : t.logConsole.noLogs }}
         </div>
       </div>
-      <div v-for="log in filteredLogs" :key="`${log.timestamp}-${log.message}`" :class="['log-entry', log.level]">
-        <span class="log-timestamp">{{ log.timestamp }}</span>
-        <span :class="['log-level', log.level]">{{ log.level }}</span>
-        <span v-if="log.file" class="log-source">{{ log.file }}<span v-if="log.line">:{{ log.line }}</span></span>
-        <span class="log-message" v-html="highlightMessage(log.message)"></span>
+      <div v-else class="log-virtual-space" :style="{ height: `${totalHeight}px` }">
+        <div class="log-virtual-window" :style="{ transform: `translateY(${visibleOffset}px)` }">
+          <div
+            v-for="{ log, virtualIndex } in visibleLogs"
+            :key="`${virtualIndex}-${log.timestamp}-${log.message}`"
+            :class="['log-entry', log.level]"
+          >
+            <span class="log-timestamp">{{ log.timestamp }}</span>
+            <span :class="['log-level', log.level]">{{ log.level }}</span>
+            <span v-if="log.file" class="log-source">{{ log.file }}<span v-if="log.line">:{{ log.line }}</span></span>
+            <span class="log-message" v-html="highlightMessage(log.message)"></span>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -128,7 +136,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { Document, RefreshRight, Delete, Search, Close, Download } from '@element-plus/icons-vue'
@@ -141,6 +149,14 @@ const allLogs = ref([])
 const loading = ref(false)
 const logContainer = ref(null)
 const searchKeyword = ref('')
+const committedSearchKeyword = ref('')
+const scrollTop = ref(0)
+const viewportHeight = ref(1)
+
+const LOG_ROW_HEIGHT = 40
+const LOG_OVERSCAN = 8
+const SEARCH_DEBOUNCE_MS = 120
+let searchTimer = null
 
 // 过滤器
 const filters = ref({
@@ -153,15 +169,31 @@ const filters = ref({
 })
 
 // 计算属性：获取所有可用的文件来源
-const availableFiles = computed(() => {
+const logSummary = computed(() => {
   const files = new Set()
+  const counts = {
+    total: allLogs.value.length,
+    error: 0,
+    warn: 0,
+    info: 0,
+  }
+
   allLogs.value.forEach((log) => {
     if (log.file) {
       files.add(log.file)
     }
+    if (log.level === 'error') counts.error += 1
+    else if (log.level === 'warn') counts.warn += 1
+    else if (log.level === 'info') counts.info += 1
   })
-  return Array.from(files).sort()
+
+  return {
+    files: Array.from(files).sort(),
+    stats: counts,
+  }
 })
+
+const availableFiles = computed(() => logSummary.value.files)
 
 // 计算属性：过滤后的日志（同时考虑级别、文件来源和关键词）
 const filteredLogs = computed(() => {
@@ -177,8 +209,8 @@ const filteredLogs = computed(() => {
   }
 
   // 如果有关键词，进行搜索过滤
-  if (searchKeyword.value.trim()) {
-    const keyword = searchKeyword.value.trim().toLowerCase()
+  if (committedSearchKeyword.value.trim()) {
+    const keyword = committedSearchKeyword.value.trim().toLowerCase()
     filtered = filtered.filter((log) => {
       const message = log.message.toLowerCase()
       const timestamp = log.timestamp.toLowerCase()
@@ -193,11 +225,11 @@ const filteredLogs = computed(() => {
 
 // 高亮消息中的关键词
 function highlightMessage(message) {
-  if (!searchKeyword.value.trim()) {
+  if (!committedSearchKeyword.value.trim()) {
     return escapeHtml(message)
   }
 
-  const keyword = searchKeyword.value.trim()
+  const keyword = committedSearchKeyword.value.trim()
   const regex = new RegExp(`(${escapeRegex(keyword)})`, 'gi')
   const highlighted = message.replace(regex, '<mark class="highlight">$1</mark>')
   return highlighted
@@ -217,31 +249,56 @@ function escapeRegex(str) {
 
 // 处理搜索输入
 function handleSearchInput() {
-  // 搜索时自动滚动到第一个匹配项
-  nextTick(() => {
-    if (logContainer.value && filteredLogs.value.length > 0) {
-      const firstMatch = logContainer.value.querySelector('.log-entry')
-      if (firstMatch) {
-        firstMatch.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-      }
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    committedSearchKeyword.value = searchKeyword.value
+    if (logContainer.value) {
+      logContainer.value.scrollTop = 0
+      scrollTop.value = 0
     }
-  })
+  }, SEARCH_DEBOUNCE_MS)
 }
 
 // 清除搜索
 function clearSearch() {
   searchKeyword.value = ''
+  committedSearchKeyword.value = ''
+  clearTimeout(searchTimer)
+  if (logContainer.value) {
+    logContainer.value.scrollTop = 0
+    scrollTop.value = 0
+  }
 }
 
 // 计算属性：统计信息
-const stats = computed(() => {
-  return {
-    total: allLogs.value.length,
-    error: allLogs.value.filter((l) => l.level === 'error').length,
-    warn: allLogs.value.filter((l) => l.level === 'warn').length,
-    info: allLogs.value.filter((l) => l.level === 'info').length,
-  }
+const stats = computed(() => logSummary.value.stats)
+
+const totalHeight = computed(() => filteredLogs.value.length * LOG_ROW_HEIGHT)
+const visibleStartIndex = computed(() => {
+  const maxStart = Math.max(0, filteredLogs.value.length - 1)
+  return Math.min(maxStart, Math.max(0, Math.floor(scrollTop.value / LOG_ROW_HEIGHT) - LOG_OVERSCAN))
 })
+const visibleEndIndex = computed(() =>
+  Math.min(
+    filteredLogs.value.length,
+    Math.ceil((scrollTop.value + viewportHeight.value) / LOG_ROW_HEIGHT) + LOG_OVERSCAN
+  )
+)
+const visibleOffset = computed(() => visibleStartIndex.value * LOG_ROW_HEIGHT)
+const visibleLogs = computed(() =>
+  filteredLogs.value.slice(visibleStartIndex.value, visibleEndIndex.value).map((log, index) => ({
+    log,
+    virtualIndex: visibleStartIndex.value + index,
+  }))
+)
+
+function updateViewportHeight() {
+  viewportHeight.value = logContainer.value?.clientHeight || 1
+}
+
+function handleLogScroll() {
+  scrollTop.value = logContainer.value?.scrollTop || 0
+}
 
 // 加载所有日志
 async function loadLogs() {
@@ -297,6 +354,8 @@ let unsubscribe = null
 onMounted(async () => {
   // 初始加载
   await loadLogs()
+  updateViewportHeight()
+  window.addEventListener('resize', updateViewportHeight)
   scrollToBottom()
 
   // 监听新日志事件
@@ -314,6 +373,8 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  clearTimeout(searchTimer)
+  window.removeEventListener('resize', updateViewportHeight)
   if (unsubscribe) {
     unsubscribe()
   }

--- a/src/renderer/sunshine-frame.js
+++ b/src/renderer/sunshine-frame.js
@@ -1,7 +1,13 @@
 import { createApp } from 'vue'
 import SunshineFrame from './components/SunshineFrame.vue'
-import ElementPlus from 'element-plus'
-import 'element-plus/dist/index.css'
+import { ElIcon, ElScrollbar, ElSwitch, ElTooltip } from 'element-plus'
+import 'element-plus/theme-chalk/base.css'
+import 'element-plus/theme-chalk/el-icon.css'
+import 'element-plus/theme-chalk/el-scrollbar.css'
+import 'element-plus/theme-chalk/el-switch.css'
+import 'element-plus/theme-chalk/el-popper.css'
+import 'element-plus/theme-chalk/el-tooltip.css'
+import 'element-plus/theme-chalk/el-message.css'
 import './styles/dialog.less'  // 导入对话框样式
 // 导入 Tauri polyfill
 import './tauri-polyfill.js'
@@ -11,6 +17,9 @@ import { i18n, getDefaultLocale, setLocale } from '../i18n/index.js'
 setLocale(getDefaultLocale())
 
 const app = createApp(SunshineFrame)
-app.use(ElementPlus)
+app.component(ElIcon.name, ElIcon)
+app.component(ElScrollbar.name, ElScrollbar)
+app.component(ElSwitch.name, ElSwitch)
+app.component(ElTooltip.name, ElTooltip)
 app.use(i18n)
 app.mount('#app')

--- a/src/renderer/sunshine-frame.js
+++ b/src/renderer/sunshine-frame.js
@@ -1,13 +1,57 @@
 import { createApp } from 'vue'
 import SunshineFrame from './components/SunshineFrame.vue'
-import { ElIcon, ElScrollbar, ElSwitch, ElTooltip } from 'element-plus'
+import {
+  ElAffix,
+  ElAlert,
+  ElButton,
+  ElDescriptions,
+  ElDescriptionsItem,
+  ElDialog,
+  ElForm,
+  ElFormItem,
+  ElIcon,
+  ElInput,
+  ElInputNumber,
+  ElLink,
+  ElOption,
+  ElOptionGroup,
+  ElProgress,
+  ElScrollbar,
+  ElSelect,
+  ElSwitch,
+  ElTag,
+  ElTooltip,
+  ElUpload,
+} from 'element-plus'
 import 'element-plus/theme-chalk/base.css'
+import 'element-plus/theme-chalk/el-affix.css'
+import 'element-plus/theme-chalk/el-alert.css'
+import 'element-plus/theme-chalk/el-button.css'
+import 'element-plus/theme-chalk/el-descriptions.css'
+import 'element-plus/theme-chalk/el-descriptions-item.css'
+import 'element-plus/theme-chalk/el-dialog.css'
+import 'element-plus/theme-chalk/el-form.css'
+import 'element-plus/theme-chalk/el-form-item.css'
 import 'element-plus/theme-chalk/el-icon.css'
-import 'element-plus/theme-chalk/el-scrollbar.css'
-import 'element-plus/theme-chalk/el-switch.css'
-import 'element-plus/theme-chalk/el-popper.css'
-import 'element-plus/theme-chalk/el-tooltip.css'
+import 'element-plus/theme-chalk/el-input.css'
+import 'element-plus/theme-chalk/el-input-number.css'
+import 'element-plus/theme-chalk/el-link.css'
+import 'element-plus/theme-chalk/el-loading.css'
 import 'element-plus/theme-chalk/el-message.css'
+import 'element-plus/theme-chalk/el-message-box.css'
+import 'element-plus/theme-chalk/el-notification.css'
+import 'element-plus/theme-chalk/el-option.css'
+import 'element-plus/theme-chalk/el-option-group.css'
+import 'element-plus/theme-chalk/el-overlay.css'
+import 'element-plus/theme-chalk/el-popper.css'
+import 'element-plus/theme-chalk/el-progress.css'
+import 'element-plus/theme-chalk/el-scrollbar.css'
+import 'element-plus/theme-chalk/el-select.css'
+import 'element-plus/theme-chalk/el-select-dropdown.css'
+import 'element-plus/theme-chalk/el-switch.css'
+import 'element-plus/theme-chalk/el-tag.css'
+import 'element-plus/theme-chalk/el-tooltip.css'
+import 'element-plus/theme-chalk/el-upload.css'
 import './styles/dialog.less'  // 导入对话框样式
 // 导入 Tauri polyfill
 import './tauri-polyfill.js'
@@ -16,10 +60,33 @@ import { i18n, getDefaultLocale, setLocale } from '../i18n/index.js'
 // 初始化语言
 setLocale(getDefaultLocale())
 
+const elementPlusComponents = [
+  ElAffix,
+  ElAlert,
+  ElButton,
+  ElDescriptions,
+  ElDescriptionsItem,
+  ElDialog,
+  ElForm,
+  ElFormItem,
+  ElIcon,
+  ElInput,
+  ElInputNumber,
+  ElLink,
+  ElOption,
+  ElOptionGroup,
+  ElProgress,
+  ElScrollbar,
+  ElSelect,
+  ElSwitch,
+  ElTag,
+  ElTooltip,
+  ElUpload,
+]
+
 const app = createApp(SunshineFrame)
-app.component(ElIcon.name, ElIcon)
-app.component(ElScrollbar.name, ElScrollbar)
-app.component(ElSwitch.name, ElSwitch)
-app.component(ElTooltip.name, ElTooltip)
+elementPlusComponents.forEach((component) => {
+  app.component(component.name, component)
+})
 app.use(i18n)
 app.mount('#app')

--- a/src/renderer/sunshine-frame.js
+++ b/src/renderer/sunshine-frame.js
@@ -1,57 +1,9 @@
 import { createApp } from 'vue'
 import SunshineFrame from './components/SunshineFrame.vue'
-import {
-  ElAffix,
-  ElAlert,
-  ElButton,
-  ElDescriptions,
-  ElDescriptionsItem,
-  ElDialog,
-  ElForm,
-  ElFormItem,
-  ElIcon,
-  ElInput,
-  ElInputNumber,
-  ElLink,
-  ElOption,
-  ElOptionGroup,
-  ElProgress,
-  ElScrollbar,
-  ElSelect,
-  ElSwitch,
-  ElTag,
-  ElTooltip,
-  ElUpload,
-} from 'element-plus'
-import 'element-plus/theme-chalk/base.css'
-import 'element-plus/theme-chalk/el-affix.css'
-import 'element-plus/theme-chalk/el-alert.css'
-import 'element-plus/theme-chalk/el-button.css'
-import 'element-plus/theme-chalk/el-descriptions.css'
-import 'element-plus/theme-chalk/el-descriptions-item.css'
-import 'element-plus/theme-chalk/el-dialog.css'
-import 'element-plus/theme-chalk/el-form.css'
-import 'element-plus/theme-chalk/el-form-item.css'
-import 'element-plus/theme-chalk/el-icon.css'
-import 'element-plus/theme-chalk/el-input.css'
-import 'element-plus/theme-chalk/el-input-number.css'
-import 'element-plus/theme-chalk/el-link.css'
 import 'element-plus/theme-chalk/el-loading.css'
 import 'element-plus/theme-chalk/el-message.css'
 import 'element-plus/theme-chalk/el-message-box.css'
 import 'element-plus/theme-chalk/el-notification.css'
-import 'element-plus/theme-chalk/el-option.css'
-import 'element-plus/theme-chalk/el-option-group.css'
-import 'element-plus/theme-chalk/el-overlay.css'
-import 'element-plus/theme-chalk/el-popper.css'
-import 'element-plus/theme-chalk/el-progress.css'
-import 'element-plus/theme-chalk/el-scrollbar.css'
-import 'element-plus/theme-chalk/el-select.css'
-import 'element-plus/theme-chalk/el-select-dropdown.css'
-import 'element-plus/theme-chalk/el-switch.css'
-import 'element-plus/theme-chalk/el-tag.css'
-import 'element-plus/theme-chalk/el-tooltip.css'
-import 'element-plus/theme-chalk/el-upload.css'
 import './styles/dialog.less'  // 导入对话框样式
 // 导入 Tauri polyfill
 import './tauri-polyfill.js'
@@ -60,33 +12,6 @@ import { i18n, getDefaultLocale, setLocale } from '../i18n/index.js'
 // 初始化语言
 setLocale(getDefaultLocale())
 
-const elementPlusComponents = [
-  ElAffix,
-  ElAlert,
-  ElButton,
-  ElDescriptions,
-  ElDescriptionsItem,
-  ElDialog,
-  ElForm,
-  ElFormItem,
-  ElIcon,
-  ElInput,
-  ElInputNumber,
-  ElLink,
-  ElOption,
-  ElOptionGroup,
-  ElProgress,
-  ElScrollbar,
-  ElSelect,
-  ElSwitch,
-  ElTag,
-  ElTooltip,
-  ElUpload,
-]
-
 const app = createApp(SunshineFrame)
-elementPlusComponents.forEach((component) => {
-  app.component(component.name, component)
-})
 app.use(i18n)
 app.mount('#app')

--- a/src/renderer/tool-window/main.js
+++ b/src/renderer/tool-window/main.js
@@ -1,9 +1,6 @@
 import { createApp } from 'vue';
 import ToolWindow from './ToolWindow.vue';
-import ElementPlus from 'element-plus';
-import 'element-plus/dist/index.css';
 
 const app = createApp(ToolWindow);
-app.use(ElementPlus);
 app.mount('#app');
 

--- a/src/renderer/toolbar/ToolbarApp.vue
+++ b/src/renderer/toolbar/ToolbarApp.vue
@@ -46,7 +46,6 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import { cursorPosition } from '@tauri-apps/api/window'
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { useI18n } from '../desktop/i18n/index.js'
-import * as PIXI from 'pixi.js'
 import { callVisionLLM, isApiKeyRequired } from '../composables/aiClient.js'
 import { STORAGE_KEY, DEFAULT_CONFIG } from '../composables/aiProviders.js'
 import {
@@ -75,6 +74,14 @@ let pixiApp = null
 let spriteFrames = []
 let currentSprite = null
 let animationTimer = null
+let pixiModulePromise = null
+
+const loadPixi = async () => {
+  if (!pixiModulePromise) {
+    pixiModulePromise = import('pixi.js')
+  }
+  return pixiModulePromise
+}
 
 // 精灵图集 URL
 const SPRITESHEET_URL =
@@ -670,6 +677,8 @@ const initPixiApp = async () => {
     return
   }
 
+  const PIXI = await loadPixi()
+
   // 创建 PixiJS 应用
   pixiApp = new PIXI.Application()
   await pixiApp.init({
@@ -1016,7 +1025,9 @@ const onIconClick = () => {
 //   - 否则（外圈空白 / 完全在窗口外）→ ignore=true（穿透到下层）
 let cursorIgnoreState = false
 let hitTestTimer = null
-const HIT_TEST_INTERVAL_MS = 80
+let hitTestEnabled = false
+const HIT_TEST_ACTIVE_INTERVAL_MS = 80
+const HIT_TEST_IDLE_INTERVAL_MS = 250
 const setCursorIgnore = (ignore) => {
   if (ignore === cursorIgnoreState) return
   cursorIgnoreState = ignore
@@ -1062,10 +1073,19 @@ const hitTestTick = async () => {
 
 const initBubbleClickThrough = () => {
   // 初始进入穿透状态，由轮询决定何时取消
+  hitTestEnabled = true
   setCursorIgnore(true)
-  hitTestTimer = setInterval(hitTestTick, HIT_TEST_INTERVAL_MS)
-  // 首次立即跑一次，避免等到 80ms 后才生效
-  hitTestTick()
+  const scheduleNextHitTest = (delay) => {
+    if (!hitTestEnabled) return
+    hitTestTimer = setTimeout(async () => {
+      if (!hitTestEnabled) return
+      await hitTestTick()
+      if (!hitTestEnabled) return
+      const active = isDragging || menuVisible.value || !cursorIgnoreState
+      scheduleNextHitTest(active ? HIT_TEST_ACTIVE_INTERVAL_MS : HIT_TEST_IDLE_INTERVAL_MS)
+    }, delay)
+  }
+  scheduleNextHitTest(0)
 }
 
 onMounted(async () => {
@@ -1098,7 +1118,8 @@ onUnmounted(() => {
   // 清理拖拽
   removeDragListeners()
   if (touchRafId) { cancelAnimationFrame(touchRafId); touchRafId = null }
-  if (hitTestTimer) { clearInterval(hitTestTimer); hitTestTimer = null }
+  hitTestEnabled = false
+  if (hitTestTimer) { clearTimeout(hitTestTimer); hitTestTimer = null }
   if (speechBroadcast) {
     try { speechBroadcast.close() } catch (_) {}
     speechBroadcast = null

--- a/src/renderer/vdd/main.js
+++ b/src/renderer/vdd/main.js
@@ -1,11 +1,42 @@
 import { createApp } from 'vue'
 import '../style.css'
 import App from './index.vue'
-import ElementPlus from 'element-plus'
-import 'element-plus/dist/index.css'
+import {
+  ElButton,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElInputNumber,
+  ElOption,
+  ElSelect,
+  ElSwitch,
+  ElTag,
+} from 'element-plus'
+import 'element-plus/theme-chalk/base.css'
+import 'element-plus/theme-chalk/el-button.css'
+import 'element-plus/theme-chalk/el-form.css'
+import 'element-plus/theme-chalk/el-form-item.css'
+import 'element-plus/theme-chalk/el-input.css'
+import 'element-plus/theme-chalk/el-input-number.css'
+import 'element-plus/theme-chalk/el-message.css'
+import 'element-plus/theme-chalk/el-option.css'
+import 'element-plus/theme-chalk/el-popper.css'
+import 'element-plus/theme-chalk/el-scrollbar.css'
+import 'element-plus/theme-chalk/el-select.css'
+import 'element-plus/theme-chalk/el-select-dropdown.css'
+import 'element-plus/theme-chalk/el-switch.css'
+import 'element-plus/theme-chalk/el-tag.css'
 // 导入 Tauri polyfill
 import '../tauri-polyfill.js'
 
 const app = createApp(App)
-app.use(ElementPlus)
+app.component(ElButton.name, ElButton)
+app.component(ElForm.name, ElForm)
+app.component(ElFormItem.name, ElFormItem)
+app.component(ElInput.name, ElInput)
+app.component(ElInputNumber.name, ElInputNumber)
+app.component(ElOption.name, ElOption)
+app.component(ElSelect.name, ElSelect)
+app.component(ElSwitch.name, ElSwitch)
+app.component(ElTag.name, ElTag)
 app.mount('#app')

--- a/src/renderer/vdd/main.js
+++ b/src/renderer/vdd/main.js
@@ -1,42 +1,9 @@
 import { createApp } from 'vue'
 import '../style.css'
 import App from './index.vue'
-import {
-  ElButton,
-  ElForm,
-  ElFormItem,
-  ElInput,
-  ElInputNumber,
-  ElOption,
-  ElSelect,
-  ElSwitch,
-  ElTag,
-} from 'element-plus'
-import 'element-plus/theme-chalk/base.css'
-import 'element-plus/theme-chalk/el-button.css'
-import 'element-plus/theme-chalk/el-form.css'
-import 'element-plus/theme-chalk/el-form-item.css'
-import 'element-plus/theme-chalk/el-input.css'
-import 'element-plus/theme-chalk/el-input-number.css'
 import 'element-plus/theme-chalk/el-message.css'
-import 'element-plus/theme-chalk/el-option.css'
-import 'element-plus/theme-chalk/el-popper.css'
-import 'element-plus/theme-chalk/el-scrollbar.css'
-import 'element-plus/theme-chalk/el-select.css'
-import 'element-plus/theme-chalk/el-select-dropdown.css'
-import 'element-plus/theme-chalk/el-switch.css'
-import 'element-plus/theme-chalk/el-tag.css'
 // 导入 Tauri polyfill
 import '../tauri-polyfill.js'
 
 const app = createApp(App)
-app.component(ElButton.name, ElButton)
-app.component(ElForm.name, ElForm)
-app.component(ElFormItem.name, ElFormItem)
-app.component(ElInput.name, ElInput)
-app.component(ElInputNumber.name, ElInputNumber)
-app.component(ElOption.name, ElOption)
-app.component(ElSelect.name, ElSelect)
-app.component(ElSwitch.name, ElSwitch)
-app.component(ElTag.name, ElTag)
 app.mount('#app')

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import vuePlugin from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import { fileURLToPath } from 'node:url'
 import { dirname } from 'node:path'
+import Components from 'unplugin-vue-components/vite'
+import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -51,7 +53,17 @@ export default defineConfig(() => ({
       },
     },
   },
-  plugins: [vuePlugin()],
+  plugins: [
+    vuePlugin(),
+    Components({
+      dts: false,
+      resolvers: [
+        ElementPlusResolver({
+          importStyle: 'css',
+        }),
+      ],
+    }),
+  ],
   resolve: {
     alias: {
       '@': rendererSrcPath,


### PR DESCRIPTION
## 改了啥喵
- 日志控制台改成虚拟滚动，只渲染视口附近的日志行，顺手给搜索加防抖、统计/文件列表合并成单次汇总。
- toolbar 的 Pixi 改成按需加载，空闲 hit-test 从固定 80ms 轮询改成 250ms，活跃态仍保留 80ms。
- desktop 视图和更新弹窗改成 async component，应用封面/列表加 lazy decode 和 content-visibility。
- vdd / tool-window 拆掉 Element Plus 全量注册和全量样式，杂鱼大包退散。

## 为啥要改
- GUI 热点主要在大日志列表、首屏无差别 preload、全量 Element Plus/Pixi 拉取。
- 这次把首屏需要的东西留下，把重资源推迟到真正使用时加载。

## 量化
- 日志渲染模型：1661 行 -> 26 行，渲染行数 -98.43%。
- 日志行 materialize 平均耗时：0.577ms -> 0.0073ms，-98.74%。
- toolbar 入口 JS：311.80kB -> 18.05kB。
- desktop 入口 JS：174.10kB -> 52.14kB。
- Element Plus 大 JS chunk：883.36kB -> 已移除首屏全量 chunk。
- Element Plus 全量 CSS：357.23kB -> 已移除全量 CSS。

## 验证
- `npm run build:renderer`
- `npm run build`
- `npm run test:webui`，52 passed
- `git diff --check`
- Playwright smoke：vdd 表单/下拉/toast 正常，tool-window 的 dpi/bitrate/shortcuts/rtss/pet 页面均可加载。

## 注意
- 普通浏览器预览会出现缺 Tauri runtime 的 `invoke/transformCallback` 报错，这是既有预览限制，不是这次拆包引入的问题。