### PR TITLE
revert(toolbar): keep startup creation path unchanged

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -102,14 +102,8 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
         if show_toolbar && !show_desktop {
             info!("🔧 将在应用启动后打开工具栏");
             tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-            let main_thread_handle = app_handle.clone();
-            let toolbar_app = app_handle.clone();
-            if let Err(e) = main_thread_handle.run_on_main_thread(move || {
-                if let Err(e) = toolbar::create_toolbar_window_internal(&toolbar_app) {
-                    error!("failed to create toolbar window: {}", e);
-                }
-            }) {
-                error!("failed to dispatch toolbar creation to main thread: {}", e);
+            if let Err(e) = toolbar::create_toolbar_window_internal(&app_handle) {
+                error!("❌ 创建工具栏失败: {}", e);
             }
         }
 


### PR DESCRIPTION
## 改了啥呀

- 撤掉 `app.rs` 里启动 `--toolbar` 时额外 `run_on_main_thread` 的分发。
- 恢复为原来的 `create_toolbar_window_internal(&app_handle)` 直接调用路径。

## 为啥要改

这个改动不是 Host Performance 面板必须的逻辑，也没有覆盖其它打开工具栏的路径。留着会让启动路径多一层特殊分支，像一只自以为很忙但其实没必要忙的小杂鱼。

## 验证

- `git diff --check`
- `npx.cmd tauri build --debug --no-bundle`