### PR TITLE
fix(vdd): preserve driver failure diagnostics

### DIFF
--- a/src-tauri/src/bat_runner.rs
+++ b/src-tauri/src/bat_runner.rs
@@ -1,21 +1,23 @@
 //! 提权运行 .bat 脚本的通用工具，被 `vmouse` / `vigem` 等驱动管理模块共享。
 //!
-//! 设计要点见 `run_elevated` 的注释。两个驱动模块只通过 `log_prefix` 区分
-//! 日志文件名，避免日志互相覆盖。
+//! 两个驱动模块只通过 `log_prefix` 区分日志文件名。
 
 #![cfg(target_os = "windows")]
 
+use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::os::windows::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
+const ELEVATION_LAUNCH_FAILED: i32 = 1223;
 
 /// 检查当前进程是否具有管理员权限
 pub fn is_elevated() -> bool {
     let output = Command::new("powershell")
-        .args(&[
+        .args([
             "-NoProfile",
             "-Command",
             "([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)",
@@ -25,92 +27,110 @@ pub fn is_elevated() -> bool {
     matches!(output, Ok(out) if String::from_utf8_lossy(&out.stdout).trim() == "True")
 }
 
+fn append_process_output(log_path: &Path, stdout: &[u8], stderr: &[u8]) {
+    let Ok(mut log) = OpenOptions::new().append(true).open(log_path) else {
+        return;
+    };
+    if !stdout.is_empty() {
+        let _ = log.write_all(stdout);
+    }
+    if !stderr.is_empty() {
+        let _ = log.write_all(stderr);
+    }
+}
+
 /// 以适当权限运行 bat 脚本：已有管理员权限则直接运行，否则提权。
 ///
-/// 关键点：必须把 bat 的真实 exit code 透传出来。
-/// `Start-Process -Verb RunAs -Wait` 默认**不会**让 PowerShell 进程的
-/// `$LASTEXITCODE` 反映子进程退出码，必须用 `-PassThru` 拿到 Process
-/// 对象再读 `.ExitCode` 并 `exit` 出去，否则 bat 即使 `exit /b 87` 上层
-/// 也会以为安装成功，前端只会看到“静默成功”。
-///
-/// 同时把 bat 的 stdout/stderr 落到 `%TEMP%\sunshine-<prefix>-<stem>.log`，
-/// 失败时 Err 字符串里带上 exit code + 日志路径，前端能直接展示给用户。
-///
-/// 实现细节：提权场景下 `Start-Process` 不允许 RedirectStandardOutput，
-/// 而把 `cmd /c "...bat... > log 2>&1"` 用 PowerShell 单字符串拼出来，
-/// 多层 cmd/PS 引号嵌套很容易解析失败（cmd 直接 exit 1 而 bat 根本没跑）。
-/// 因此走更稳的方式：在 `%TEMP%` 写一份只有几行的 wrapper.bat，里面自己
-/// 重定向 + exit /b %ERRORLEVEL%，然后让 PowerShell 直接 Start-Process
-/// 这份 wrapper（不需要任何引号嵌套）。
+/// bat 的输出和真实退出码都会透传。日志在请求 UAC 前创建，因此提权取消或
+/// 启动失败时，错误消息中给出的日志路径也仍然存在。
 pub fn run_elevated(bat_path: &Path, log_prefix: &str, extra_args: &[&str]) -> Result<(), String> {
     let stem = bat_path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("run");
-    let log_path = std::env::temp_dir().join(format!("sunshine-{}-{}.log", log_prefix, stem));
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let operation_id = format!("{}-{timestamp}", std::process::id());
+    let log_path =
+        std::env::temp_dir().join(format!("sunshine-{log_prefix}-{stem}-{operation_id}.log"));
     let log_str = log_path.to_string_lossy().into_owned();
+    writeln!(
+        File::create(&log_path).map_err(|e| format!("创建驱动日志失败: {e}"))?,
+        "Sunshine elevated task: {}",
+        bat_path.display()
+    )
+    .map_err(|e| format!("初始化驱动日志失败: {e}"))?;
 
     // 把额外参数拼成 cmd-safe 的字符串：每个参数用双引号包裹
-    let args_cmd: String = extra_args.iter().map(|a| format!(" \"{}\"", a)).collect();
+    let args_cmd: String = extra_args.iter().map(|arg| format!(" \"{arg}\"")).collect();
 
     if is_elevated() {
-        // 已有管理员权限，cmd 自己重定向把全部输出落盘
         let cmd_line = format!(
-            r#""{bat}"{args} > "{log}" 2>&1"#,
-            bat = bat_path.display(),
-            args = args_cmd,
-            log = log_str
+            r#""{}"{} >> "{}" 2>&1"#,
+            bat_path.display(),
+            args_cmd,
+            log_str
         );
         let output = Command::new("cmd")
-            .args(&["/c", &cmd_line])
+            .args(["/c", &cmd_line])
             .creation_flags(CREATE_NO_WINDOW)
             .output()
-            .map_err(|e| format!("启动脚本失败: {}", e))?;
+            .map_err(|e| format!("启动脚本失败: {e}，日志: {log_str}"))?;
 
+        append_process_output(&log_path, &output.stdout, &output.stderr);
         if !output.status.success() {
             let code = output.status.code().unwrap_or(-1);
-            return Err(format!("脚本执行失败 (exit {})，日志: {}", code, log_str));
+            return Err(format!("脚本执行失败 (exit {code})，日志: {log_str}"));
         }
     } else {
-        // 写一份 wrapper bat，避免 PS+cmd 多层引号嵌套
-        let wrapper_path =
-            std::env::temp_dir().join(format!("sunshine-{}-{}-wrap.bat", log_prefix, stem));
+        // 写一份唯一 wrapper，避免连续操作互相覆盖。
+        let wrapper_path = std::env::temp_dir().join(format!(
+            "sunshine-{log_prefix}-{stem}-{operation_id}-wrap.bat"
+        ));
         {
-            let mut f = std::fs::File::create(&wrapper_path)
-                .map_err(|e| format!("创建 wrapper 失败: {}", e))?;
-            // wrapper 内容：直接调原 bat，重定向输出到日志，把真 exit code 透传
-            // chcp 65001 让中文输出不乱码
-            writeln!(f, "@echo off").ok();
-            writeln!(f, "chcp 65001 >nul").ok();
-            writeln!(
-                f,
-                r#"call "{}"{} > "{}" 2>&1"#,
-                bat_path.display(),
-                args_cmd,
-                log_str
-            )
-            .ok();
-            writeln!(f, "exit /b %ERRORLEVEL%").ok();
+            let mut wrapper = File::create(&wrapper_path)
+                .map_err(|e| format!("创建 wrapper 失败: {e}，日志: {log_str}"))?;
+            writeln!(wrapper, "@echo off")
+                .and_then(|_| writeln!(wrapper, "chcp 65001 >nul"))
+                .and_then(|_| {
+                    writeln!(
+                        wrapper,
+                        r#"call "{}"{} >> "{}" 2>&1"#,
+                        bat_path.display(),
+                        args_cmd,
+                        log_str
+                    )
+                })
+                .and_then(|_| writeln!(wrapper, "exit /b %ERRORLEVEL%"))
+                .map_err(|e| format!("写入 wrapper 失败: {e}，日志: {log_str}"))?;
         }
 
+        let escaped_wrapper = wrapper_path.to_string_lossy().replace('\'', "''");
         let ps_cmd = format!(
-            r#"$p = Start-Process cmd -ArgumentList '/c','{wrap}' -Verb RunAs -WindowStyle Hidden -PassThru -Wait; exit $p.ExitCode"#,
-            wrap = wrapper_path.display()
+            r#"$ErrorActionPreference = 'Stop'; try {{ $p = Start-Process cmd -ArgumentList '/c','{escaped_wrapper}' -Verb RunAs -WindowStyle Hidden -PassThru -Wait; exit $p.ExitCode }} catch {{ [Console]::Error.WriteLine($_.Exception.Message); exit {ELEVATION_LAUNCH_FAILED} }}"#
         );
-
         let output = Command::new("powershell")
-            .args(&["-NoProfile", "-Command", &ps_cmd])
+            .args(["-NoProfile", "-Command", &ps_cmd])
             .creation_flags(CREATE_NO_WINDOW)
             .output()
-            .map_err(|e| format!("启动脚本失败: {}", e))?;
+            .map_err(|e| format!("无法启动提权脚本: {e}，日志: {log_str}"))?;
 
-        // 不立即清理 wrapper：失败时方便人工复现
+        append_process_output(&log_path, &output.stdout, &output.stderr);
         if !output.status.success() {
             let code = output.status.code().unwrap_or(-1);
-            return Err(format!("脚本执行失败 (exit {})，日志: {}", code, log_str));
+            if code == ELEVATION_LAUNCH_FAILED && !output.stderr.is_empty() {
+                return Err(format!(
+                    "无法启动提权脚本（管理员授权被取消或启动失败），请重试。日志: {log_str}"
+                ));
+            }
+            return Err(format!("脚本执行失败 (exit {code})，日志: {log_str}"));
         }
-        // 成功才清理 wrapper
         let _ = std::fs::remove_file(&wrapper_path);
     }
+
+    // 成功操作无需保留唯一日志；失败路径会在上方返回并保留现场。
+    let _ = std::fs::remove_file(&log_path);
     Ok(())
 }


### PR DESCRIPTION
## 改了啥呀

- 在弹出 UAC 前先创建本次操作的唯一日志，失败路径不会再指向空气啦。
- 区分管理员授权取消、提权启动失败和驱动脚本真实退出码。
- 连续操作使用独立 wrapper 和日志；成功后清理，失败时保留现场。

## 为啥要改

VDD 安装或修复若在 UAC/启动阶段失败，旧逻辑会返回一个尚未创建的日志路径。用户看到 `exit 1` 后却找不到日志，问题就只能和杂鱼状态猜谜啦。

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2024 src-tauri/src/bat_runner.rs`
- `git diff --check`