### PR TITLE
fix(vdd): remove named pipe fallback

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
             vdd::get_vdd_edid_file_path,
             vdd::load_vdd_settings,
             vdd::save_vdd_settings,
-            vdd::exec_pipe_cmd,
+            vdd::exec_vdd_cmd,
             vdd::upload_edid_file,
             vdd::read_edid_file,
             vdd::delete_edid_file,

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -1044,7 +1044,7 @@ pub async fn save_vdd_settings(settings: VddSettings) -> Result<String, String> 
     #[cfg(target_os = "windows")]
     {
         debug!("🔄 通知 VDD 驱动重新加载...");
-        let _ = exec_pipe_cmd("RELOAD_DRIVER".to_string()).await;
+        let _ = exec_vdd_cmd("RELOAD_DRIVER".to_string()).await;
     }
 
     info!("✅ VDD 配置保存完成");
@@ -1095,7 +1095,7 @@ pub(crate) fn try_handle_elevated_ioctl_command() -> Option<i32> {
 }
 
 #[tauri::command]
-pub async fn exec_pipe_cmd(command: String) -> Result<bool, String> {
+pub async fn exec_vdd_cmd(command: String) -> Result<bool, String> {
     #[cfg(target_os = "windows")]
     {
         if !is_allowed_elevated_vdd_command(&command) {
@@ -1104,95 +1104,31 @@ pub async fn exec_pipe_cmd(command: String) -> Result<bool, String> {
         }
 
         use crate::vdd_ioctl;
-        use windows::Win32::Foundation::*;
-        use windows::Win32::Storage::FileSystem::*;
-        use windows::core::PCWSTR;
 
         let cmd_for_blocking = command.clone();
-        let in_process =
-            tokio::task::spawn_blocking(move || -> Result<bool, (bool, bool, String)> {
-                // Preferred path: IOCTL transport. Mirrors the C++ dispatch in
-                // `Sunshine/src/display_device/vdd_utils.cpp`: only fall through
-                // to the legacy pipe when the device interface is absent.
-                match vdd_ioctl::send_command(&cmd_for_blocking) {
-                    vdd_ioctl::IoctlResult::Success => return Ok(true),
-                    vdd_ioctl::IoctlResult::Failed(msg) => {
-                        // err=5 表示设备存在但当前权限打不开，可通过提权重试。
-                        let access_denied = msg.contains("(err=5)");
-                        return Err((access_denied, false, format!("vdd_ioctl: {msg}")));
-                    }
-                    vdd_ioctl::IoctlResult::InterfaceMissing => {
-                        // Driver too old / not installed; fall back to pipe.
-                    }
+        let in_process = tokio::task::spawn_blocking(move || -> Result<bool, (bool, String)> {
+            match vdd_ioctl::send_command(&cmd_for_blocking) {
+                vdd_ioctl::IoctlResult::Success => return Ok(true),
+                vdd_ioctl::IoctlResult::Failed(msg) => {
+                    let access_denied = msg.contains("(err=5)");
+                    Err((access_denied, format!("vdd_ioctl: {msg}")))
                 }
-
-                // [LEGACY-PIPE] Fallback for older driver builds.
-                unsafe {
-                    let pipe_name = r"\\.\pipe\ZakoVDDPipe";
-                    let wide: Vec<u16> =
-                        pipe_name.encode_utf16().chain(std::iter::once(0)).collect();
-
-                    let handle = CreateFileW(
-                        PCWSTR(wide.as_ptr()),
-                        FILE_GENERIC_WRITE.0,
-                        FILE_SHARE_NONE,
-                        None,
-                        OPEN_EXISTING,
-                        FILE_ATTRIBUTE_NORMAL | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
-                        Some(HANDLE::default()),
-                    );
-
-                    if handle.is_err() || handle.as_ref().unwrap().is_invalid() {
-                        let err = GetLastError().0;
-                        let access_denied = err == 5;
-                        return Err((access_denied, true, format!("无法连接到管道 (err={err})")));
-                    }
-
-                    let handle = handle.unwrap();
-
-                    // 转换为 UTF-16LE
-                    let cmd_wide: Vec<u16> = cmd_for_blocking
-                        .encode_utf16()
-                        .chain(std::iter::once(0))
-                        .collect();
-                    let buffer = cmd_wide.as_ptr() as *const u8;
-                    let buffer_len = (cmd_wide.len() * 2) as u32;
-
-                    let mut bytes_written = 0u32;
-                    let result = WriteFile(
-                        handle,
-                        Some(std::slice::from_raw_parts(buffer, buffer_len as usize)),
-                        Some(&mut bytes_written),
-                        None,
-                    );
-
-                    let _ = CloseHandle(handle);
-
-                    if result.is_ok() {
-                        Ok(true)
-                    } else {
-                        Err((false, true, "写入管道失败".to_string()))
-                    }
+                vdd_ioctl::IoctlResult::InterfaceMissing => {
+                    Err((false, "VDD IOCTL interface missing".to_string()))
                 }
-            })
-            .await
-            .map_err(|e| e.to_string())?;
+            }
+        })
+        .await
+        .map_err(|e| e.to_string())?;
 
         match in_process {
             Ok(v) => Ok(v),
-            Err((true, false, msg)) => {
-                // 新驱动存在但普通用户不能打开：提权后仍走 IOCTL，不回退到管道。
+            Err((true, msg)) => {
                 warn!("  ⚠️ VDD 命令在普通权限下被拒 ({msg})，回退到提权执行");
                 run_elevated_ioctl_command(&command).await?;
                 Ok(true)
             }
-            Err((true, true, msg)) => {
-                // 旧驱动没有 IOCTL，只能以管理员身份使用兼容管道。
-                warn!("  ⚠️ 旧版 VDD 管道拒绝普通用户 ({msg})，回退到提权兼容路径");
-                run_elevated_pipe_command(&command).await?;
-                Ok(true)
-            }
-            Err((false, _, msg)) => Err(msg),
+            Err((false, msg)) => Err(msg),
         }
     }
 
@@ -1218,21 +1154,6 @@ async fn run_elevated_ioctl_command(command: &str) -> Result<(), String> {
         executable, ELEVATED_VDD_IOCTL_ARG, encoded
     );
     run_elevated_powershell(&inner, "提权执行 VDD IOCTL").await
-}
-
-/// 通过提权 PowerShell 向 ZakoVDD 控制管道写入命令。
-#[cfg(target_os = "windows")]
-async fn run_elevated_pipe_command(command: &str) -> Result<(), String> {
-    if !is_allowed_elevated_vdd_command(command) {
-        return Err("不允许的 VDD 提权命令".to_string());
-    }
-
-    // The allowlist above also ensures command cannot become PowerShell syntax.
-    let inner = format!(
-        "$p = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'ZakoVDDPipe', [System.IO.Pipes.PipeDirection]::Out, [System.IO.Pipes.PipeOptions]::None, [System.Security.Principal.TokenImpersonationLevel]::Identification); $p.Connect(3000); $b = [System.Text.Encoding]::Unicode.GetBytes('{}' + [char]0); $p.Write($b, 0, $b.Length); $p.Flush(); $p.Dispose()",
-        command
-    );
-    run_elevated_powershell(&inner, "提权执行 VDD 命令").await
 }
 
 /// 验证 EDID 文件格式和 checksum

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -1090,7 +1090,7 @@ pub(crate) fn try_handle_elevated_ioctl_command() -> Option<i32> {
     match crate::vdd_ioctl::send_command(&command) {
         crate::vdd_ioctl::IoctlResult::Success => Some(0),
         crate::vdd_ioctl::IoctlResult::InterfaceMissing
-        | crate::vdd_ioctl::IoctlResult::Failed(_) => Some(1),
+        | crate::vdd_ioctl::IoctlResult::Failed { .. } => Some(1),
     }
 }
 
@@ -1104,14 +1104,18 @@ pub async fn exec_vdd_cmd(command: String) -> Result<bool, String> {
         }
 
         use crate::vdd_ioctl;
+        use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
 
         let cmd_for_blocking = command.clone();
         let in_process = tokio::task::spawn_blocking(move || -> Result<bool, (bool, String)> {
             match vdd_ioctl::send_command(&cmd_for_blocking) {
                 vdd_ioctl::IoctlResult::Success => return Ok(true),
-                vdd_ioctl::IoctlResult::Failed(msg) => {
-                    let access_denied = msg.contains("(err=5)");
-                    Err((access_denied, format!("vdd_ioctl: {msg}")))
+                vdd_ioctl::IoctlResult::Failed {
+                    message,
+                    win32_error,
+                } => {
+                    let access_denied = win32_error == Some(ERROR_ACCESS_DENIED.0);
+                    Err((access_denied, format!("vdd_ioctl: {message}")))
                 }
                 vdd_ioctl::IoctlResult::InterfaceMissing => {
                     Err((false, "VDD IOCTL interface missing".to_string()))

--- a/src-tauri/src/vdd_ioctl.rs
+++ b/src-tauri/src/vdd_ioctl.rs
@@ -44,7 +44,10 @@ pub enum IoctlResult {
     /// No registered device interface (driver too old / not installed).
     InterfaceMissing,
     /// Driver was reached but rejected the IOCTL or returned an error.
-    Failed(String),
+    Failed {
+        message: String,
+        win32_error: Option<u32>,
+    },
 }
 
 /// RAII for `HDEVINFO` returned by `SetupDiGetClassDevs*`.
@@ -174,7 +177,10 @@ pub fn interface_available() -> bool {
 /// Send a UTF-16 command buffer to the VDD driver via IOCTL.
 pub fn send_command(command: &str) -> IoctlResult {
     if command.is_empty() {
-        return IoctlResult::Failed("empty command".to_string());
+        return IoctlResult::Failed {
+            message: "empty command".to_string(),
+            win32_error: None,
+        };
     }
 
     unsafe {
@@ -200,7 +206,10 @@ pub fn send_command(command: &str) -> IoctlResult {
                 // present but unhappy. Surfacing as `Failed` matches the
                 // C++ behaviour and prevents a duplicate retry on pipe.
                 let err = GetLastError().0;
-                return IoctlResult::Failed(format!("CreateFileW failed (err={err})"));
+                return IoctlResult::Failed {
+                    message: format!("CreateFileW failed (err={err})"),
+                    win32_error: Some(err),
+                };
             }
         };
         let _h_guard = DeviceHandle(handle);
@@ -225,9 +234,10 @@ pub fn send_command(command: &str) -> IoctlResult {
             IoctlResult::Success
         } else {
             let err = GetLastError().0;
-            IoctlResult::Failed(format!(
-                "DeviceIoControl(IOCTL_VDD_COMMAND) failed (err={err})"
-            ))
+            IoctlResult::Failed {
+                message: format!("DeviceIoControl(IOCTL_VDD_COMMAND) failed (err={err})"),
+                win32_error: Some(err),
+            }
         }
     }
 }

--- a/src-tauri/src/vdd_ioctl.rs
+++ b/src-tauri/src/vdd_ioctl.rs
@@ -5,10 +5,8 @@
 //! (which is itself byte-identical with the driver-side mirror at
 //! `Virtual-Display-Driver/Common/Include/vdd_control_ioctl.h`).
 //!
-//! The driver-side dispatcher is shared verbatim between the IOCTL path and
-//! the legacy named pipe, so the command grammar is identical: UTF-16 LE,
-//! NUL-terminated (e.g. `"RELOAD_DRIVER"`, `"CREATEMONITOR {GUID}:[..][..]"`,
-//! `"DESTROYMONITOR"`).
+//! Commands use a UTF-16 LE, NUL-terminated buffer (e.g. `"RELOAD_DRIVER"`,
+//! `"CREATEMONITOR {GUID}:[..][..]"`, `"DESTROYMONITOR"`).
 
 #![cfg(target_os = "windows")]
 
@@ -44,11 +42,8 @@ pub enum IoctlResult {
     /// IOCTL completed with `STATUS_SUCCESS`.
     Success,
     /// No registered device interface (driver too old / not installed).
-    /// Safe to fall back to the legacy named pipe.
     InterfaceMissing,
     /// Driver was reached but rejected the IOCTL or returned an error.
-    /// Do **not** fall back: the request may have been partially applied
-    /// (e.g. CREATEMONITOR allocated state before failing).
     Failed(String),
 }
 

--- a/src/renderer/components/VddSettings.vue
+++ b/src/renderer/components/VddSettings.vue
@@ -1085,7 +1085,7 @@ const saveGpuEdit = () => {
 const reloadDriver = async () => {
   isReloadingDriver.value = true
   try {
-    const success = await vdd.execPipeCmd('RELOAD_DRIVER')
+    const success = await vdd.execVddCmd('RELOAD_DRIVER')
     if (!success) {
       throw new Error(t.value.vddSettings.reloadDriverFailed)
     }

--- a/src/renderer/tauri-adapter.js
+++ b/src/renderer/tauri-adapter.js
@@ -68,15 +68,15 @@ export const vdd = {
   stopTrace: () => wrapResult('stop_vdd_trace'),
   openTraceFolder: () => wrapResult('open_vdd_trace_folder'),
 
-  async execPipeCmd(command) {
+  async execVddCmd(command) {
     try {
-      await invoke('exec_pipe_cmd', { command })
+      await invoke('exec_vdd_cmd', { command })
       return true
     } catch (error) {
-      console.error('执行管道命令失败:', error)
+      console.error('执行 VDD 命令失败:', error)
       throw error instanceof Error
         ? error
-        : new Error(typeof error === 'string' && error.trim() ? error : '执行管道命令失败')
+        : new Error(typeof error === 'string' && error.trim() ? error : '执行 VDD 命令失败')
     }
   },
 }

--- a/src/renderer/tauri-polyfill.js
+++ b/src/renderer/tauri-polyfill.js
@@ -10,7 +10,7 @@ const IPC_HANDLERS = {
   'vdd:loadSettings': vdd.loadSettings,
   'vdd:saveSettings': vdd.saveSettings,
   'vdd:getGPUs': vdd.getGPUs,
-  'vdd:execPipeCmd': vdd.execPipeCmd,
+  'vdd:execVddCmd': vdd.execVddCmd,
   'dark-mode:toggle': darkMode.toggle,
   'dark-mode:system': darkMode.system,
   openExternalUrl,


### PR DESCRIPTION
## 改了什么

- 删除 GUI Rust 后端直接打开 `ZakoVDDPipe` 的兼容路径
- 删除提权 PowerShell 的 `NamedPipeClientStream` 路径，提权后也只走 IOCTL
- 将 `execPipeCmd` / `exec_pipe_cmd` 统一重命名为 `execVddCmd` / `exec_vdd_cmd`
- 清理 Pipe 迁移期注释，保留命令白名单和权限拒绝后的提权重试

## 为什么

同步 Named Pipe 服务会在驱动卸载时卡在 `ConnectNamedPipe`，让 WUDFHost 等满 60 秒后被系统终止。GUI 还留着回退的话，旧通道仍可能被重新走到；现在控制面统一使用可 PnP 唤醒设备的 IOCTL。

## 验证

- `cargo fmt --all -- --check`
- `cargo check`
- `npm run build:renderer`
- 全源码扫描确认无 `ZakoVDDPipe`、`NamedPipeClient`、`execPipeCmd` 残留
