### PR TITLE
fix(windows): handle elevated batch command quoting

### DIFF
--- a/src-tauri/src/bat_runner.rs
+++ b/src-tauri/src/bat_runner.rs
@@ -67,14 +67,12 @@ pub fn run_elevated(bat_path: &Path, log_prefix: &str, extra_args: &[&str]) -> R
     let args_cmd: String = extra_args.iter().map(|arg| format!(" \"{arg}\"")).collect();
 
     if is_elevated() {
-        let cmd_line = format!(
-            r#""{}"{} >> "{}" 2>&1"#,
-            bat_path.display(),
-            args_cmd,
-            log_str
-        );
-        let output = Command::new("cmd")
-            .args(["/c", &cmd_line])
+        let cmd_line = format!(r#"call "{}"{}"#, bat_path.display(), args_cmd);
+        let mut command = Command::new("cmd");
+        let output = command
+            .args(["/d", "/c"])
+            // cmd.exe does not use the C runtime argument parsing implemented by Command::args().
+            .raw_arg(&cmd_line)
             .creation_flags(CREATE_NO_WINDOW)
             .output()
             .map_err(|e| format!("启动脚本失败: {e}，日志: {log_str}"))?;


### PR DESCRIPTION
## 改了啥呀

- 修复 GUI 已处于管理员权限时，驱动批处理命令因 `cmd.exe` 引号解析失败而无法启动的问题。
- 使用 Windows `CommandExt::raw_arg()` 传递 `cmd /d /c call "..."`，并复用现有输出捕获写入日志。
- 保持普通 GUI 的 UAC wrapper 分支、退出码和错误处理不变。

## 为啥要改

自动升级器会以管理员权限重启 GUI。此时安装或修复驱动会走管理员直执行分支；旧实现使用 `Command::args()` 传递带嵌套引号的命令，而 `cmd.exe` 不遵循 C 运行时参数解析规则，脚本尚未启动就会返回 `exit 1` 和“文件名、目录名或卷标语法不正确”。

这只是一只引号解析小杂鱼，别再让它伪装成驱动安装失败啦。

## 验证

- 修复前使用相同的 Rust `Command` 调用稳定复现 `exit 1`。
- 修复后以带空格的 Sunshine 安装路径执行 `--resolve-only`，返回 `exit 0` 并完整解析 VDD payload。
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
