### PR TITLE
feat(gui): 支持手指拖动主窗口

### DIFF
--- a/src/renderer/components/SidebarMenu.vue
+++ b/src/renderer/components/SidebarMenu.vue
@@ -215,7 +215,7 @@ const {
 } = useSidebarState()
 
 const { minimizeWindow, toggleMaximize, closeWindow } = useWindowControls(isMaximized)
-const { onTouchWindowDragStart } = useTouchWindowDrag()
+const { onTouchWindowDragStart } = useTouchWindowDrag(isMaximized)
 
 const {
   uninstallVdd,

--- a/src/renderer/components/SidebarMenu.vue
+++ b/src/renderer/components/SidebarMenu.vue
@@ -8,7 +8,11 @@
       </div>
 
       <!-- Logo 区域 (可拖动) -->
-      <div class="sidebar-header" data-tauri-drag-region>
+      <div
+        class="sidebar-header"
+        data-tauri-drag-region
+        @pointerdown="onTouchWindowDragStart"
+      >
         <div class="logo">
           <img src="../public/gura-pix.png" alt="Sunshine Logo" class="logo-img" />
         </div>
@@ -98,7 +102,11 @@
     <!-- 主内容区域 -->
     <div class="main-content" :class="{ expanded: isCollapsed }">
       <!-- 顶部拖动区域 -->
-      <div class="drag-region" data-tauri-drag-region></div>
+      <div
+        class="drag-region"
+        data-tauri-drag-region
+        @pointerdown="onTouchWindowDragStart"
+      ></div>
 
       <!-- Windows 经典窗口控制按钮 -->
       <div class="window-controls">
@@ -171,6 +179,7 @@ const UpdateDialog = defineAsyncComponent(() => import('./UpdateDialog.vue'))
 import { useSidebarState } from '../composables/useSidebarState.js'
 import { useWindowControls } from '../composables/useWindowControls.js'
 import { useTools } from '../composables/useTools.js'
+import { useTouchWindowDrag } from '../composables/useTouchWindowDrag.js'
 import {
   createManagementTools,
   createUtilityTools,
@@ -206,6 +215,7 @@ const {
 } = useSidebarState()
 
 const { minimizeWindow, toggleMaximize, closeWindow } = useWindowControls(isMaximized)
+const { onTouchWindowDragStart } = useTouchWindowDrag()
 
 const {
   uninstallVdd,

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -11,9 +11,16 @@ const RESTORE_RESIZE_TIMEOUT_MS = 500
  * Mouse dragging remains handled by `data-tauri-drag-region`. WebView2 touch
  * coordinates are viewport-relative while the window is moving, so touch
  * dragging uses the current window position and applies incremental updates.
+ *
+ * @param {{ value: boolean } | null} isMaximized reactive window state used by
+ * the custom maximize button
  */
-export function useTouchWindowDrag() {
+export function useTouchWindowDrag(isMaximized = null) {
   let appWindow = null
+  let unlistenScaleChanged = null
+  let scaleListenerPromise = null
+  let disposed = false
+  let dragGeneration = 0
   let pointerId = null
   let pointerTarget = null
   let hasMoved = false
@@ -24,10 +31,14 @@ export function useTouchWindowDrag() {
   let latestClientX = 0
   let latestClientY = 0
 
-  let baseLogicalX = Number.NaN
-  let baseLogicalY = Number.NaN
-  let pendingLogicalX = Number.NaN
-  let pendingLogicalY = Number.NaN
+  let basePhysicalX = Number.NaN
+  let basePhysicalY = Number.NaN
+  let pendingPhysicalX = Number.NaN
+  let pendingPhysicalY = Number.NaN
+  let activeScaleFactor = 1
+  let scaleFactorVersion = 0
+  let scaleRebasing = false
+  let scaleRebasePromise = null
 
   let initialPosition = null
   let initialMaximized = false
@@ -37,7 +48,15 @@ export function useTouchWindowDrag() {
   let settingPosition = false
   let positionRaf = null
 
-  const devicePixelRatio = () => window.devicePixelRatio || 1
+  const normalizeScaleFactor = (value) => (
+    Number.isFinite(value) && value > 0 ? value : 1
+  )
+
+  const isCurrentDrag = (generation, activePointerId) => (
+    !disposed &&
+    generation === dragGeneration &&
+    pointerId === activePointerId
+  )
 
   const getAppWindow = () => {
     if (appWindow) return appWindow
@@ -50,11 +69,10 @@ export function useTouchWindowDrag() {
     }
   }
 
-  const commitPosition = (logicalX, logicalY) => {
-    const dpr = devicePixelRatio()
+  const commitPosition = (physicalX, physicalY) => {
     return appWindow.setPosition(new PhysicalPosition(
-      Math.round(logicalX * dpr),
-      Math.round(logicalY * dpr),
+      Math.round(physicalX),
+      Math.round(physicalY),
     ))
   }
 
@@ -74,6 +92,9 @@ export function useTouchWindowDrag() {
       }
 
       await appWindow.unmaximize()
+      if (!disposed && isMaximized && typeof isMaximized === 'object' && 'value' in isMaximized) {
+        isMaximized.value = false
+      }
       await Promise.race([
         resizePromise,
         new Promise((resolve) => {
@@ -110,6 +131,7 @@ export function useTouchWindowDrag() {
   }
 
   const clearDragState = () => {
+    dragGeneration += 1
     if (positionRaf !== null) {
       cancelAnimationFrame(positionRaf)
       positionRaf = null
@@ -126,10 +148,89 @@ export function useTouchWindowDrag() {
     preparing = false
     preparationPromise = null
     settingPosition = false
-    baseLogicalX = Number.NaN
-    baseLogicalY = Number.NaN
-    pendingLogicalX = Number.NaN
-    pendingLogicalY = Number.NaN
+    scaleRebasing = false
+    scaleRebasePromise = null
+    basePhysicalX = Number.NaN
+    basePhysicalY = Number.NaN
+    pendingPhysicalX = Number.NaN
+    pendingPhysicalY = Number.NaN
+  }
+
+  const rebaseForScaleChange = (scaleFactor) => {
+    scaleFactorVersion += 1
+    activeScaleFactor = normalizeScaleFactor(scaleFactor)
+    if (
+      pointerId === null ||
+      dragEnding ||
+      !initialized ||
+      scaleRebasePromise
+    ) {
+      return
+    }
+
+    const activePointerId = pointerId
+    const generation = dragGeneration
+    scaleRebasing = true
+    if (positionRaf !== null) {
+      cancelAnimationFrame(positionRaf)
+      positionRaf = null
+    }
+
+    let rebasePromise
+    rebasePromise = (async () => {
+      while (settingPosition) {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        if (!isCurrentDrag(generation, activePointerId)) return
+      }
+
+      // Let WebView2 update viewport-relative pointer coordinates for the new DPI.
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+      if (!isCurrentDrag(generation, activePointerId) || dragEnding) return
+
+      const position = await appWindow.outerPosition()
+      if (!isCurrentDrag(generation, activePointerId) || dragEnding) return
+
+      basePhysicalX = position.x
+      basePhysicalY = position.y
+      pendingPhysicalX = position.x
+      pendingPhysicalY = position.y
+      startClientX = latestClientX
+      startClientY = latestClientY
+    })()
+      .catch(() => {
+        if (isCurrentDrag(generation, activePointerId)) {
+          clearDragState()
+        }
+      })
+      .finally(() => {
+        if (isCurrentDrag(generation, activePointerId)) {
+          scaleRebasing = false
+        }
+        if (scaleRebasePromise === rebasePromise) {
+          scaleRebasePromise = null
+        }
+      })
+    scaleRebasePromise = rebasePromise
+  }
+
+  const ensureScaleChangeListener = () => {
+    if (disposed || unlistenScaleChanged || scaleListenerPromise) return
+
+    scaleListenerPromise = appWindow
+      .onScaleChanged(({ payload }) => {
+        rebaseForScaleChange(payload.scaleFactor)
+      })
+      .then((unlisten) => {
+        scaleListenerPromise = null
+        if (disposed) {
+          unlisten()
+          return
+        }
+        unlistenScaleChanged = unlisten
+      })
+      .catch(() => {
+        scaleListenerPromise = null
+      })
   }
 
   const applyPendingPosition = async () => {
@@ -138,25 +239,34 @@ export function useTouchWindowDrag() {
       pointerId === null ||
       dragEnding ||
       preparing ||
+      scaleRebasing ||
       settingPosition ||
-      !Number.isFinite(pendingLogicalX) ||
-      !Number.isFinite(pendingLogicalY)
+      !Number.isFinite(pendingPhysicalX) ||
+      !Number.isFinite(pendingPhysicalY)
     ) {
       return
     }
 
     settingPosition = true
-    const nextLogicalX = pendingLogicalX
-    const nextLogicalY = pendingLogicalY
+    const generation = dragGeneration
+    const activePointerId = pointerId
+    const nextPhysicalX = pendingPhysicalX
+    const nextPhysicalY = pendingPhysicalY
 
     try {
-      await commitPosition(nextLogicalX, nextLogicalY)
-      baseLogicalX = nextLogicalX
-      baseLogicalY = nextLogicalY
+      await commitPosition(nextPhysicalX, nextPhysicalY)
+      if (!isCurrentDrag(generation, activePointerId)) return
+
+      basePhysicalX = nextPhysicalX
+      basePhysicalY = nextPhysicalY
     } catch {
-      clearDragState()
+      if (isCurrentDrag(generation, activePointerId)) {
+        clearDragState()
+      }
     } finally {
-      settingPosition = false
+      if (isCurrentDrag(generation, activePointerId)) {
+        settingPosition = false
+      }
     }
   }
 
@@ -165,16 +275,17 @@ export function useTouchWindowDrag() {
       pointerId === null ||
       dragEnding ||
       preparing ||
+      scaleRebasing ||
       settingPosition ||
       !initialized ||
-      !Number.isFinite(baseLogicalX) ||
-      !Number.isFinite(baseLogicalY)
+      !Number.isFinite(basePhysicalX) ||
+      !Number.isFinite(basePhysicalY)
     ) {
       return
     }
 
-    pendingLogicalX = baseLogicalX + (latestClientX - startClientX)
-    pendingLogicalY = baseLogicalY + (latestClientY - startClientY)
+    pendingPhysicalX = basePhysicalX + (latestClientX - startClientX) * activeScaleFactor
+    pendingPhysicalY = basePhysicalY + (latestClientY - startClientY) * activeScaleFactor
 
     if (positionRaf === null) {
       positionRaf = requestAnimationFrame(applyPendingPosition)
@@ -185,58 +296,73 @@ export function useTouchWindowDrag() {
     if (preparationPromise) return preparationPromise
 
     preparing = true
+    const generation = dragGeneration
+    const activePointerId = pointerId
     preparationPromise = (async () => {
-      const dpr = devicePixelRatio()
-      const pointerPhysicalX = initialPosition.x + latestClientX * dpr
-      const pointerPhysicalY = initialPosition.y + latestClientY * dpr
+      const scaleFactor = activeScaleFactor
+      const pointerPhysicalX = initialPosition.x + latestClientX * scaleFactor
+      const pointerPhysicalY = initialPosition.y + latestClientY * scaleFactor
       const horizontalAnchorRatio = Math.min(
         1,
         Math.max(0, startClientX / Math.max(window.innerWidth, 1)),
       )
 
       await waitForRestoreResize()
+      if (!isCurrentDrag(generation, activePointerId)) return
 
       const restoredSize = await appWindow.outerSize()
+      if (!isCurrentDrag(generation, activePointerId)) return
+
       const anchorPhysicalX = restoredSize.width * horizontalAnchorRatio
       const anchorPhysicalY = Math.min(
         restoredSize.height,
-        Math.max(0, startClientY * dpr),
+        Math.max(0, startClientY * scaleFactor),
       )
       const restoredPhysicalX = Math.round(pointerPhysicalX - anchorPhysicalX)
       const restoredPhysicalY = Math.round(pointerPhysicalY - anchorPhysicalY)
 
-      await commitPosition(restoredPhysicalX / dpr, restoredPhysicalY / dpr)
+      await commitPosition(restoredPhysicalX, restoredPhysicalY)
+      if (!isCurrentDrag(generation, activePointerId)) return
 
-      baseLogicalX = restoredPhysicalX / dpr
-      baseLogicalY = restoredPhysicalY / dpr
-      pendingLogicalX = baseLogicalX
-      pendingLogicalY = baseLogicalY
-      startClientX = anchorPhysicalX / dpr
-      startClientY = anchorPhysicalY / dpr
+      basePhysicalX = restoredPhysicalX
+      basePhysicalY = restoredPhysicalY
+      pendingPhysicalX = basePhysicalX
+      pendingPhysicalY = basePhysicalY
+      startClientX = anchorPhysicalX / scaleFactor
+      startClientY = anchorPhysicalY / scaleFactor
       initialized = true
       initialMaximized = false
     })()
       .catch(() => {
-        clearDragState()
+        if (isCurrentDrag(generation, activePointerId)) {
+          clearDragState()
+        }
       })
       .finally(() => {
-        preparing = false
+        if (isCurrentDrag(generation, activePointerId)) {
+          preparing = false
+        }
       })
 
     return preparationPromise
   }
 
-  const prepareWindowPosition = async (activePointerId) => {
+  const prepareWindowPosition = async (activePointerId, generation) => {
     try {
-      const [position, maximized] = await Promise.all([
+      const initialScaleFactorVersion = scaleFactorVersion
+      const [position, maximized, scaleFactor] = await Promise.all([
         appWindow.outerPosition(),
         appWindow.isMaximized(),
+        appWindow.scaleFactor(),
       ])
 
-      if (pointerId !== activePointerId || dragEnding) return
+      if (!isCurrentDrag(generation, activePointerId) || dragEnding) return
 
       initialPosition = position
       initialMaximized = maximized
+      if (scaleFactorVersion === initialScaleFactorVersion) {
+        activeScaleFactor = normalizeScaleFactor(scaleFactor)
+      }
 
       if (maximized) {
         if (hasMoved) {
@@ -245,18 +371,19 @@ export function useTouchWindowDrag() {
         return
       }
 
-      const dpr = devicePixelRatio()
-      baseLogicalX = position.x / dpr
-      baseLogicalY = position.y / dpr
-      pendingLogicalX = baseLogicalX
-      pendingLogicalY = baseLogicalY
+      basePhysicalX = position.x
+      basePhysicalY = position.y
+      pendingPhysicalX = basePhysicalX
+      pendingPhysicalY = basePhysicalY
       initialized = true
 
       if (hasMoved) {
         queueLatestPosition()
       }
     } catch {
-      clearDragState()
+      if (isCurrentDrag(generation, activePointerId)) {
+        clearDragState()
+      }
     }
   }
 
@@ -298,6 +425,8 @@ export function useTouchWindowDrag() {
   async function onPointerEnd(event) {
     if (pointerId === null || event.pointerId !== pointerId) return
 
+    const generation = dragGeneration
+    const activePointerId = pointerId
     dragEnding = true
     removeListeners()
     releasePointerCapture()
@@ -309,26 +438,36 @@ export function useTouchWindowDrag() {
 
     if (preparationPromise) {
       await preparationPromise
+      if (!isCurrentDrag(generation, activePointerId)) return
+    }
+
+    if (scaleRebasePromise) {
+      await scaleRebasePromise
+      if (!isCurrentDrag(generation, activePointerId)) return
     }
 
     while (settingPosition) {
       await new Promise((resolve) => setTimeout(resolve, 0))
+      if (!isCurrentDrag(generation, activePointerId)) return
     }
 
     if (
       hasMoved &&
       initialized &&
-      Number.isFinite(pendingLogicalX) &&
-      Number.isFinite(pendingLogicalY)
+      Number.isFinite(pendingPhysicalX) &&
+      Number.isFinite(pendingPhysicalY)
     ) {
       try {
-        await commitPosition(pendingLogicalX, pendingLogicalY)
+        await commitPosition(pendingPhysicalX, pendingPhysicalY)
+        if (!isCurrentDrag(generation, activePointerId)) return
       } catch {
         // Keep the last position accepted by the operating system.
       }
     }
 
-    clearDragState()
+    if (isCurrentDrag(generation, activePointerId)) {
+      clearDragState()
+    }
   }
 
   const onTouchWindowDragStart = (event) => {
@@ -343,6 +482,8 @@ export function useTouchWindowDrag() {
 
     if (!getAppWindow()) return
 
+    ensureScaleChangeListener()
+    const generation = ++dragGeneration
     event.preventDefault()
     event.stopPropagation()
 
@@ -365,10 +506,17 @@ export function useTouchWindowDrag() {
     document.addEventListener('pointerup', onPointerEnd)
     document.addEventListener('pointercancel', onPointerEnd)
 
-    void prepareWindowPosition(pointerId)
+    void prepareWindowPosition(pointerId, generation)
   }
 
-  onUnmounted(clearDragState)
+  onUnmounted(() => {
+    disposed = true
+    clearDragState()
+    if (unlistenScaleChanged) {
+      unlistenScaleChanged()
+      unlistenScaleChanged = null
+    }
+  })
 
   return {
     onTouchWindowDragStart,

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -3,6 +3,7 @@ import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 
 const DRAG_THRESHOLD = 4
+const RESTORE_RESIZE_TIMEOUT_MS = 500
 
 /**
  * Adds touch dragging to a custom Tauri title bar.
@@ -12,8 +13,7 @@ const DRAG_THRESHOLD = 4
  * dragging uses the current window position and applies incremental updates.
  */
 export function useTouchWindowDrag() {
-  const appWindow = getCurrentWindow()
-
+  let appWindow = null
   let pointerId = null
   let pointerTarget = null
   let hasMoved = false
@@ -38,6 +38,57 @@ export function useTouchWindowDrag() {
   let positionRaf = null
 
   const devicePixelRatio = () => window.devicePixelRatio || 1
+
+  const getAppWindow = () => {
+    if (appWindow) return appWindow
+
+    try {
+      appWindow = getCurrentWindow()
+      return appWindow
+    } catch {
+      return null
+    }
+  }
+
+  const commitPosition = (logicalX, logicalY) => {
+    const dpr = devicePixelRatio()
+    return appWindow.setPosition(new PhysicalPosition(
+      Math.round(logicalX * dpr),
+      Math.round(logicalY * dpr),
+    ))
+  }
+
+  const waitForRestoreResize = async () => {
+    let resolveResize
+    let unlistenResize = null
+    let timeoutId = null
+    const resizePromise = new Promise((resolve) => {
+      resolveResize = resolve
+    })
+
+    try {
+      try {
+        unlistenResize = await appWindow.onResized(() => resolveResize())
+      } catch {
+        // Fall back to the bounded delay if resize events are unavailable.
+      }
+
+      await appWindow.unmaximize()
+      await Promise.race([
+        resizePromise,
+        new Promise((resolve) => {
+          timeoutId = setTimeout(resolve, RESTORE_RESIZE_TIMEOUT_MS)
+        }),
+      ])
+    } finally {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+      if (unlistenResize) {
+        unlistenResize()
+      }
+    }
+  }
 
   const releasePointerCapture = () => {
     if (pointerTarget && pointerId !== null) {
@@ -97,13 +148,9 @@ export function useTouchWindowDrag() {
     settingPosition = true
     const nextLogicalX = pendingLogicalX
     const nextLogicalY = pendingLogicalY
-    const dpr = devicePixelRatio()
 
     try {
-      await appWindow.setPosition(new PhysicalPosition(
-        Math.round(nextLogicalX * dpr),
-        Math.round(nextLogicalY * dpr),
-      ))
+      await commitPosition(nextLogicalX, nextLogicalY)
       baseLogicalX = nextLogicalX
       baseLogicalY = nextLogicalY
     } catch {
@@ -147,8 +194,7 @@ export function useTouchWindowDrag() {
         Math.max(0, startClientX / Math.max(window.innerWidth, 1)),
       )
 
-      await appWindow.unmaximize()
-      await new Promise((resolve) => requestAnimationFrame(resolve))
+      await waitForRestoreResize()
 
       const restoredSize = await appWindow.outerSize()
       const anchorPhysicalX = restoredSize.width * horizontalAnchorRatio
@@ -159,10 +205,7 @@ export function useTouchWindowDrag() {
       const restoredPhysicalX = Math.round(pointerPhysicalX - anchorPhysicalX)
       const restoredPhysicalY = Math.round(pointerPhysicalY - anchorPhysicalY)
 
-      await appWindow.setPosition(new PhysicalPosition(
-        restoredPhysicalX,
-        restoredPhysicalY,
-      ))
+      await commitPosition(restoredPhysicalX / dpr, restoredPhysicalY / dpr)
 
       baseLogicalX = restoredPhysicalX / dpr
       baseLogicalY = restoredPhysicalY / dpr
@@ -278,12 +321,8 @@ export function useTouchWindowDrag() {
       Number.isFinite(pendingLogicalX) &&
       Number.isFinite(pendingLogicalY)
     ) {
-      const dpr = devicePixelRatio()
       try {
-        await appWindow.setPosition(new PhysicalPosition(
-          Math.round(pendingLogicalX * dpr),
-          Math.round(pendingLogicalY * dpr),
-        ))
+        await commitPosition(pendingLogicalX, pendingLogicalY)
       } catch {
         // Keep the last position accepted by the operating system.
       }
@@ -301,6 +340,8 @@ export function useTouchWindowDrag() {
     ) {
       return
     }
+
+    if (!getAppWindow()) return
 
     event.preventDefault()
     event.stopPropagation()

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -1,0 +1,335 @@
+import { onUnmounted } from 'vue'
+import { PhysicalPosition } from '@tauri-apps/api/dpi'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+const DRAG_THRESHOLD = 4
+
+/**
+ * Adds touch dragging to a custom Tauri title bar.
+ *
+ * Mouse dragging remains handled by `data-tauri-drag-region`. WebView2 touch
+ * coordinates are viewport-relative while the window is moving, so touch
+ * dragging uses the current window position and applies incremental updates.
+ */
+export function useTouchWindowDrag() {
+  const appWindow = getCurrentWindow()
+
+  let pointerId = null
+  let pointerTarget = null
+  let hasMoved = false
+  let dragEnding = false
+
+  let startClientX = 0
+  let startClientY = 0
+  let latestClientX = 0
+  let latestClientY = 0
+
+  let baseLogicalX = Number.NaN
+  let baseLogicalY = Number.NaN
+  let pendingLogicalX = Number.NaN
+  let pendingLogicalY = Number.NaN
+
+  let initialPosition = null
+  let initialMaximized = false
+  let initialized = false
+  let preparing = false
+  let preparationPromise = null
+  let settingPosition = false
+  let positionRaf = null
+
+  const devicePixelRatio = () => window.devicePixelRatio || 1
+
+  const releasePointerCapture = () => {
+    if (pointerTarget && pointerId !== null) {
+      try {
+        if (pointerTarget.hasPointerCapture(pointerId)) {
+          pointerTarget.releasePointerCapture(pointerId)
+        }
+      } catch {
+        // The WebView may already have released capture after pointercancel.
+      }
+    }
+    pointerTarget = null
+  }
+
+  const removeListeners = () => {
+    document.removeEventListener('pointermove', onPointerMove)
+    document.removeEventListener('pointerup', onPointerEnd)
+    document.removeEventListener('pointercancel', onPointerEnd)
+  }
+
+  const clearDragState = () => {
+    if (positionRaf !== null) {
+      cancelAnimationFrame(positionRaf)
+      positionRaf = null
+    }
+    removeListeners()
+    releasePointerCapture()
+
+    pointerId = null
+    hasMoved = false
+    dragEnding = false
+    initialPosition = null
+    initialMaximized = false
+    initialized = false
+    preparing = false
+    preparationPromise = null
+    settingPosition = false
+    baseLogicalX = Number.NaN
+    baseLogicalY = Number.NaN
+    pendingLogicalX = Number.NaN
+    pendingLogicalY = Number.NaN
+  }
+
+  const applyPendingPosition = async () => {
+    positionRaf = null
+    if (
+      pointerId === null ||
+      dragEnding ||
+      preparing ||
+      settingPosition ||
+      !Number.isFinite(pendingLogicalX) ||
+      !Number.isFinite(pendingLogicalY)
+    ) {
+      return
+    }
+
+    settingPosition = true
+    const nextLogicalX = pendingLogicalX
+    const nextLogicalY = pendingLogicalY
+    const dpr = devicePixelRatio()
+
+    try {
+      await appWindow.setPosition(new PhysicalPosition(
+        Math.round(nextLogicalX * dpr),
+        Math.round(nextLogicalY * dpr),
+      ))
+      baseLogicalX = nextLogicalX
+      baseLogicalY = nextLogicalY
+    } catch {
+      clearDragState()
+    } finally {
+      settingPosition = false
+    }
+  }
+
+  const queueLatestPosition = () => {
+    if (
+      pointerId === null ||
+      dragEnding ||
+      preparing ||
+      settingPosition ||
+      !initialized ||
+      !Number.isFinite(baseLogicalX) ||
+      !Number.isFinite(baseLogicalY)
+    ) {
+      return
+    }
+
+    pendingLogicalX = baseLogicalX + (latestClientX - startClientX)
+    pendingLogicalY = baseLogicalY + (latestClientY - startClientY)
+
+    if (positionRaf === null) {
+      positionRaf = requestAnimationFrame(applyPendingPosition)
+    }
+  }
+
+  const restoreForTouchDrag = () => {
+    if (preparationPromise) return preparationPromise
+
+    preparing = true
+    preparationPromise = (async () => {
+      const dpr = devicePixelRatio()
+      const pointerPhysicalX = initialPosition.x + latestClientX * dpr
+      const pointerPhysicalY = initialPosition.y + latestClientY * dpr
+      const horizontalAnchorRatio = Math.min(
+        1,
+        Math.max(0, startClientX / Math.max(window.innerWidth, 1)),
+      )
+
+      await appWindow.unmaximize()
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+
+      const restoredSize = await appWindow.outerSize()
+      const anchorPhysicalX = restoredSize.width * horizontalAnchorRatio
+      const anchorPhysicalY = Math.min(
+        restoredSize.height,
+        Math.max(0, startClientY * dpr),
+      )
+      const restoredPhysicalX = Math.round(pointerPhysicalX - anchorPhysicalX)
+      const restoredPhysicalY = Math.round(pointerPhysicalY - anchorPhysicalY)
+
+      await appWindow.setPosition(new PhysicalPosition(
+        restoredPhysicalX,
+        restoredPhysicalY,
+      ))
+
+      baseLogicalX = restoredPhysicalX / dpr
+      baseLogicalY = restoredPhysicalY / dpr
+      pendingLogicalX = baseLogicalX
+      pendingLogicalY = baseLogicalY
+      startClientX = anchorPhysicalX / dpr
+      startClientY = anchorPhysicalY / dpr
+      initialized = true
+      initialMaximized = false
+    })()
+      .catch(() => {
+        clearDragState()
+      })
+      .finally(() => {
+        preparing = false
+      })
+
+    return preparationPromise
+  }
+
+  const prepareWindowPosition = async (activePointerId) => {
+    try {
+      const [position, maximized] = await Promise.all([
+        appWindow.outerPosition(),
+        appWindow.isMaximized(),
+      ])
+
+      if (pointerId !== activePointerId || dragEnding) return
+
+      initialPosition = position
+      initialMaximized = maximized
+
+      if (maximized) {
+        if (hasMoved) {
+          await restoreForTouchDrag()
+        }
+        return
+      }
+
+      const dpr = devicePixelRatio()
+      baseLogicalX = position.x / dpr
+      baseLogicalY = position.y / dpr
+      pendingLogicalX = baseLogicalX
+      pendingLogicalY = baseLogicalY
+      initialized = true
+
+      if (hasMoved) {
+        queueLatestPosition()
+      }
+    } catch {
+      clearDragState()
+    }
+  }
+
+  function onPointerMove(event) {
+    if (
+      pointerId === null ||
+      event.pointerId !== pointerId ||
+      event.pointerType !== 'touch' ||
+      dragEnding
+    ) {
+      return
+    }
+
+    latestClientX = event.clientX
+    latestClientY = event.clientY
+
+    const deltaX = latestClientX - startClientX
+    const deltaY = latestClientY - startClientY
+    if (
+      !hasMoved &&
+      Math.abs(deltaX) < DRAG_THRESHOLD &&
+      Math.abs(deltaY) < DRAG_THRESHOLD
+    ) {
+      return
+    }
+
+    hasMoved = true
+    event.preventDefault()
+
+    if (!initialPosition) return
+    if (initialMaximized && !initialized) {
+      void restoreForTouchDrag()
+      return
+    }
+
+    queueLatestPosition()
+  }
+
+  async function onPointerEnd(event) {
+    if (pointerId === null || event.pointerId !== pointerId) return
+
+    dragEnding = true
+    removeListeners()
+    releasePointerCapture()
+
+    if (positionRaf !== null) {
+      cancelAnimationFrame(positionRaf)
+      positionRaf = null
+    }
+
+    if (preparationPromise) {
+      await preparationPromise
+    }
+
+    while (settingPosition) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
+    if (
+      hasMoved &&
+      initialized &&
+      Number.isFinite(pendingLogicalX) &&
+      Number.isFinite(pendingLogicalY)
+    ) {
+      const dpr = devicePixelRatio()
+      try {
+        await appWindow.setPosition(new PhysicalPosition(
+          Math.round(pendingLogicalX * dpr),
+          Math.round(pendingLogicalY * dpr),
+        ))
+      } catch {
+        // Keep the last position accepted by the operating system.
+      }
+    }
+
+    clearDragState()
+  }
+
+  const onTouchWindowDragStart = (event) => {
+    if (
+      event.pointerType !== 'touch' ||
+      !event.isPrimary ||
+      event.button !== 0 ||
+      pointerId !== null
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    pointerId = event.pointerId
+    pointerTarget = event.currentTarget
+    hasMoved = false
+    dragEnding = false
+    startClientX = event.clientX
+    startClientY = event.clientY
+    latestClientX = event.clientX
+    latestClientY = event.clientY
+
+    try {
+      pointerTarget.setPointerCapture(pointerId)
+    } catch {
+      // Document-level listeners still keep the drag active without capture.
+    }
+
+    document.addEventListener('pointermove', onPointerMove, { passive: false })
+    document.addEventListener('pointerup', onPointerEnd)
+    document.addEventListener('pointercancel', onPointerEnd)
+
+    void prepareWindowPosition(pointerId)
+  }
+
+  onUnmounted(clearDragState)
+
+  return {
+    onTouchWindowDragStart,
+  }
+}

--- a/src/renderer/styles/SidebarMenu.less
+++ b/src/renderer/styles/SidebarMenu.less
@@ -86,6 +86,7 @@
   margin-bottom: 20px;
   position: relative;
   z-index: 10; // 确保在 Gura 背景上方
+  touch-action: none;
 }
 
 .logo {
@@ -376,11 +377,12 @@
   position: absolute;
   top: 0;
   left: 0;
-  right: 80px; // 右侧留空给浮动按钮
-  height: 20px;
+  right: 138px; // 右侧留空给三个窗口控制按钮
+  height: 32px;
   z-index: 100;
   cursor: move;
   pointer-events: auto;
+  touch-action: none;
 
   // 调试模式可视化（可选，生产环境可移除）
   &:hover {


### PR DESCRIPTION
主窗口当前通过 `data-tauri-drag-region` 提供鼠标拖动，但触摸屏上的手指拖动无法稳定移动无边框窗口。

本次为侧栏标题区和顶部拖动区增加 PointerEvent 触摸处理，通过 Tauri 窗口位置 API 移动窗口。鼠标仍使用原生拖动；从最大化状态开始拖动时会先恢复窗口。顶部触摸区域调整为 32px，并避开窗口控制按钮。