### PR TITLE
fix(toolbar): 优化桌宠窗口拖动

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,7 @@ windows = { version = "0.62.2", features = [
     "Win32_Graphics_Imaging",
     "Win32_UI",
     "Win32_UI_Controls",
+    "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
     "Win32_UI_Shell_Common",
     "Win32_UI_HiDpi",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -123,6 +123,7 @@ fn main() {
             commands::toggle_dark_mode,
             toolbar::handle_toolbar_menu_action,
             toolbar::save_toolbar_position,
+            toolbar::is_primary_mouse_button_pressed,
             system::get_current_dpi,
             system::set_desktop_dpi,
             commands::open_tool_window,

--- a/src-tauri/src/toolbar.rs
+++ b/src-tauri/src/toolbar.rs
@@ -77,9 +77,17 @@ pub async fn save_toolbar_position(app: AppHandle, x: f64, y: f64) -> Result<(),
 pub fn is_primary_mouse_button_pressed() -> Option<bool> {
     #[cfg(target_os = "windows")]
     {
-        use ::windows::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, VK_LBUTTON};
+        use ::windows::Win32::UI::Input::KeyboardAndMouse::{
+            GetAsyncKeyState, VK_LBUTTON, VK_RBUTTON,
+        };
+        use ::windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_SWAPBUTTON};
 
-        Some(unsafe { GetAsyncKeyState(VK_LBUTTON.0 as i32) < 0 })
+        let primary_button = if unsafe { GetSystemMetrics(SM_SWAPBUTTON) } != 0 {
+            VK_RBUTTON
+        } else {
+            VK_LBUTTON
+        };
+        Some(unsafe { GetAsyncKeyState(primary_button.0 as i32) < 0 })
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/toolbar.rs
+++ b/src-tauri/src/toolbar.rs
@@ -73,6 +73,21 @@ pub async fn save_toolbar_position(app: AppHandle, x: f64, y: f64) -> Result<(),
     Ok(())
 }
 
+#[tauri::command]
+pub fn is_primary_mouse_button_pressed() -> Option<bool> {
+    #[cfg(target_os = "windows")]
+    {
+        use ::windows::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, VK_LBUTTON};
+
+        Some(unsafe { GetAsyncKeyState(VK_LBUTTON.0 as i32) < 0 })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        None
+    }
+}
+
 // 加载工具栏位置
 fn load_toolbar_position<R: Runtime>(app: &AppHandle<R>) -> Option<(f64, f64)> {
     let config_path = match get_toolbar_config_path(app) {

--- a/src/renderer/toolbar/ToolbarApp.vue
+++ b/src/renderer/toolbar/ToolbarApp.vue
@@ -890,12 +890,16 @@ let touchPreparationPromise = null
 let touchScaleRebasing = false
 let touchScaleRebasePromise = null
 let touchIsSettingPos = false
+let touchFailed = false
 let touchRafId = null
 let unlistenDragScaleChanged = null
 let dragScaleListenerPromise = null
+let nativeDragPollTimer = null
+let nativeDragPollResolve = null
 let toolbarPositionSaveGeneration = 0
 let toolbarPositionSavePromise = Promise.resolve()
 const DRAG_THRESHOLD = 3
+const NATIVE_DRAG_POLL_INTERVAL_MS = 32
 
 const normalizeDragScaleFactor = (value) => (
   Number.isFinite(value) && value > 0 ? value : 1
@@ -924,12 +928,25 @@ const releaseDragPointerCapture = () => {
   dragPointerTarget = null
 }
 
+const cancelNativeDragPoll = () => {
+  if (nativeDragPollTimer !== null) {
+    clearTimeout(nativeDragPollTimer)
+    nativeDragPollTimer = null
+  }
+  if (nativeDragPollResolve) {
+    const resolve = nativeDragPollResolve
+    nativeDragPollResolve = null
+    resolve()
+  }
+}
+
 const clearDragState = ({ preserveMoved = false } = {}) => {
   dragGeneration += 1
   if (touchRafId !== null) {
     cancelAnimationFrame(touchRafId)
     touchRafId = null
   }
+  cancelNativeDragPoll()
   removeDragListeners()
   releaseDragPointerCapture()
 
@@ -943,6 +960,7 @@ const clearDragState = ({ preserveMoved = false } = {}) => {
   touchScaleRebasing = false
   touchScaleRebasePromise = null
   touchIsSettingPos = false
+  touchFailed = false
   touchBasePhysicalX = Number.NaN
   touchBasePhysicalY = Number.NaN
   touchPendingPhysicalX = Number.NaN
@@ -982,11 +1000,49 @@ const queueToolbarPositionSave = (position) => {
   toolbarPositionSavePromise = toolbarPositionSavePromise
     .catch(() => {})
     .then(async () => {
-      if (dragDisposed || generation !== toolbarPositionSaveGeneration) return
+      if (generation !== toolbarPositionSaveGeneration) return
 
       await invoke('save_toolbar_position', { x: position.x, y: position.y })
     })
     .catch(() => {})
+}
+
+const markTouchDragFailed = (generation, pointerId) => {
+  if (!isCurrentDrag(generation, pointerId)) return
+
+  touchFailed = true
+  if (touchRafId !== null) {
+    cancelAnimationFrame(touchRafId)
+    touchRafId = null
+  }
+}
+
+const waitForNativeDragPoll = () => new Promise((resolve) => {
+  nativeDragPollResolve = resolve
+  nativeDragPollTimer = setTimeout(() => {
+    nativeDragPollTimer = null
+    nativeDragPollResolve = null
+    resolve()
+  }, NATIVE_DRAG_POLL_INTERVAL_MS)
+})
+
+const finishNativeDrag = async (generation, pointerId) => {
+  // startDragging() resolves after dispatching the native command, not when
+  // the Windows move loop ends. Keep the session active until the button lifts.
+  while (isCurrentDrag(generation, pointerId)) {
+    const pressed = await invoke('is_primary_mouse_button_pressed')
+    if (!isCurrentDrag(generation, pointerId)) return
+    if (pressed !== true) break
+
+    await waitForNativeDragPoll()
+  }
+  if (!isCurrentDrag(generation, pointerId)) return
+
+  const finalPos = await appWindow.outerPosition()
+  if (!isCurrentDrag(generation, pointerId)) return
+
+  queueToolbarPositionSave(finalPos)
+  finishDrag(generation, pointerId, true)
 }
 
 const rebaseTouchDragForScaleChange = (scaleFactor) => {
@@ -996,6 +1052,7 @@ const rebaseTouchDragForScaleChange = (scaleFactor) => {
     dragPointerType !== 'touch' ||
     dragPointerId === null ||
     dragEnding ||
+    touchFailed ||
     !touchInitialized ||
     touchScaleRebasePromise
   ) {
@@ -1031,9 +1088,7 @@ const rebaseTouchDragForScaleChange = (scaleFactor) => {
     touchStartClientY = touchLatestClientY
   })()
     .catch(() => {
-      if (isCurrentDrag(generation, pointerId)) {
-        clearDragState()
-      }
+      markTouchDragFailed(generation, pointerId)
     })
     .finally(() => {
       if (isCurrentDrag(generation, pointerId)) {
@@ -1073,6 +1128,7 @@ const queueTouchPosition = () => {
   if (
     dragPointerId === null ||
     dragEnding ||
+    touchFailed ||
     touchPreparing ||
     touchScaleRebasing ||
     touchIsSettingPos ||
@@ -1083,14 +1139,28 @@ const queueTouchPosition = () => {
     return
   }
 
-  touchPendingPhysicalX = touchBasePhysicalX +
-    (touchLatestClientX - touchStartClientX) * touchScaleFactor
-  touchPendingPhysicalY = touchBasePhysicalY +
-    (touchLatestClientY - touchStartClientY) * touchScaleFactor
+  updatePendingTouchPosition()
 
   if (touchRafId === null) {
     touchRafId = requestAnimationFrame(touchApplyPosition)
   }
+}
+
+const updatePendingTouchPosition = () => {
+  if (
+    !touchInitialized ||
+    !Number.isFinite(touchBasePhysicalX) ||
+    !Number.isFinite(touchBasePhysicalY)
+  ) {
+    return false
+  }
+
+  touchPendingPhysicalX = touchBasePhysicalX +
+    (touchLatestClientX - touchStartClientX) * touchScaleFactor
+  touchPendingPhysicalY = touchBasePhysicalY +
+    (touchLatestClientY - touchStartClientY) * touchScaleFactor
+  return Number.isFinite(touchPendingPhysicalX) &&
+    Number.isFinite(touchPendingPhysicalY)
 }
 
 const prepareTouchDrag = async (generation, pointerId) => {
@@ -1099,7 +1169,7 @@ const prepareTouchDrag = async (generation, pointerId) => {
     appWindow.outerPosition(),
     appWindow.scaleFactor(),
   ])
-  if (!isCurrentDrag(generation, pointerId) || dragEnding) return
+  if (!isCurrentDrag(generation, pointerId)) return
 
   if (touchScaleFactorVersion === initialScaleFactorVersion) {
     touchScaleFactor = normalizeDragScaleFactor(scaleFactor)
@@ -1110,7 +1180,7 @@ const prepareTouchDrag = async (generation, pointerId) => {
   touchPendingPhysicalY = position.y
   touchInitialized = true
 
-  if (hasMoved) {
+  if (hasMoved && !dragEnding) {
     queueTouchPosition()
   }
 }
@@ -1164,14 +1234,13 @@ const onDragStart = (e) => {
     touchInitialized = false
     touchPreparing = true
     touchIsSettingPos = false
+    touchFailed = false
     touchScaleRebasing = false
 
     let preparationPromise
     preparationPromise = prepareTouchDrag(generation, pointerId)
       .catch(() => {
-        if (isCurrentDrag(generation, pointerId)) {
-          clearDragState()
-        }
+        markTouchDragFailed(generation, pointerId)
       })
       .finally(() => {
         if (isCurrentDrag(generation, pointerId)) {
@@ -1190,6 +1259,7 @@ const touchApplyPosition = async () => {
   if (
     !isDragging ||
     dragEnding ||
+    touchFailed ||
     touchPreparing ||
     touchScaleRebasing ||
     touchIsSettingPos ||
@@ -1213,9 +1283,7 @@ const touchApplyPosition = async () => {
     touchBasePhysicalX = nextPhysicalX
     touchBasePhysicalY = nextPhysicalY
   } catch {
-    if (isCurrentDrag(generation, pointerId)) {
-      clearDragState()
-    }
+    markTouchDragFailed(generation, pointerId)
   } finally {
     if (isCurrentDrag(generation, pointerId)) {
       touchIsSettingPos = false
@@ -1245,17 +1313,11 @@ const onDragMove = (e) => {
     dragEnding = true
     removeDragListeners()
     releaseDragPointerCapture()
-    appWindow.startDragging().then(async () => {
-      try {
-        const finalPos = await appWindow.outerPosition()
-        if (!isCurrentDrag(generation, pointerId)) return
-
-        queueToolbarPositionSave(finalPos)
-      } catch {}
-      finishDrag(generation, pointerId, true)
-    }).catch(() => {
-      finishDrag(generation, pointerId, true)
-    })
+    appWindow.startDragging()
+      .then(() => finishNativeDrag(generation, pointerId))
+      .catch(() => {
+        finishDrag(generation, pointerId, true)
+      })
     return
   }
 
@@ -1288,6 +1350,16 @@ const onDragEnd = async (e) => {
   const generation = dragGeneration
   const pointerId = dragPointerId
   const wasDragged = isDragging && hasMoved
+  // A sample received during setPosition belongs to the previous viewport
+  // coordinate frame and cannot be safely reapplied after that call completes.
+  const canRefreshFinalTouchPosition =
+    dragPointerType === 'touch' &&
+    !touchIsSettingPos
+  if (dragPointerType === 'touch') {
+    touchLatestClientX = e.clientX
+    touchLatestClientY = e.clientY
+  }
+
   isDragging = false
   dragEnding = true
   removeDragListeners()
@@ -1312,6 +1384,15 @@ const onDragEnd = async (e) => {
     }
 
     if (
+      !touchFailed &&
+      canRefreshFinalTouchPosition &&
+      isCurrentDrag(generation, pointerId)
+    ) {
+      updatePendingTouchPosition()
+    }
+
+    if (
+      !touchFailed &&
       touchInitialized &&
       Number.isFinite(touchPendingPhysicalX) &&
       Number.isFinite(touchPendingPhysicalY)
@@ -1431,7 +1512,6 @@ onMounted(async () => {
 
 onUnmounted(() => {
   dragDisposed = true
-  toolbarPositionSaveGeneration += 1
   clearDragState()
   if (unlistenDragScaleChanged) {
     unlistenDragScaleChanged()

--- a/src/renderer/toolbar/ToolbarApp.vue
+++ b/src/renderer/toolbar/ToolbarApp.vue
@@ -864,31 +864,257 @@ const startResourceRefresh = () => {
 // 自定义拖拽（使用 PointerEvent 统一处理鼠标和触摸，替代 data-tauri-drag-region）
 const appWindow = getCurrentWindow()
 let isDragging = false
-let hasMoved = false            // 是否实际产生了移动（区分点击和拖拽）
-let dragPointerType = ''        // 发起拖拽的指针类型（mouse/pen/touch）
-let dragStartScreenX = 0        // 按下时的屏幕坐标（用于鼠标阈值检测）
+let hasMoved = false
+let dragPointerType = ''
+let dragPointerId = null
+let dragPointerTarget = null
+let dragEnding = false
+let dragDisposed = false
+let dragGeneration = 0
+let dragStartScreenX = 0
 let dragStartScreenY = 0
-// 触摸拖拽专用变量
-// 核心思路：WebView2 触摸的 screenX ≈ clientX（视口相对坐标，非屏幕绝对坐标）
-// 移动窗口会导致 screenX 偏移→反馈震荡，因此用 clientX + 已知窗口位置 + 串行 await setPosition
-let touchStartClientX = 0       // 触摸开始时的 clientX（抓取偏移量）
-let touchStartClientY = 0
-let touchBaseLogX = NaN         // 当前已确认的窗口逻辑位置（setPosition 完成后更新）
-let touchBaseLogY = NaN
-let touchPendingLogX = 0        // 待应用的逻辑坐标
-let touchPendingLogY = 0
-let touchIsSettingPos = false   // setPosition 正在执行中，跳过中间事件
-let touchRafId = null           // requestAnimationFrame ID
-const DRAG_THRESHOLD = 3        // 移动超过 3px 才算拖拽
 
-// 移除所有拖拽相关事件监听（复用于多处清理）
+let touchStartClientX = 0
+let touchStartClientY = 0
+let touchLatestClientX = 0
+let touchLatestClientY = 0
+let touchBasePhysicalX = Number.NaN
+let touchBasePhysicalY = Number.NaN
+let touchPendingPhysicalX = Number.NaN
+let touchPendingPhysicalY = Number.NaN
+let touchScaleFactor = 1
+let touchScaleFactorVersion = 0
+let touchInitialized = false
+let touchPreparing = false
+let touchPreparationPromise = null
+let touchScaleRebasing = false
+let touchScaleRebasePromise = null
+let touchIsSettingPos = false
+let touchRafId = null
+let unlistenDragScaleChanged = null
+let dragScaleListenerPromise = null
+let toolbarPositionSaveGeneration = 0
+let toolbarPositionSavePromise = Promise.resolve()
+const DRAG_THRESHOLD = 3
+
+const normalizeDragScaleFactor = (value) => (
+  Number.isFinite(value) && value > 0 ? value : 1
+)
+
+const isCurrentDrag = (generation, pointerId) => (
+  !dragDisposed &&
+  generation === dragGeneration &&
+  dragPointerId === pointerId
+)
+
 const removeDragListeners = () => {
   document.removeEventListener('pointermove', onDragMove)
   document.removeEventListener('pointerup', onDragEnd)
   document.removeEventListener('pointercancel', onDragEnd)
 }
 
-// 容器拖拽：仅在菜单展开时响应（空白区域拖拽）
+const releaseDragPointerCapture = () => {
+  if (dragPointerTarget && dragPointerId !== null) {
+    try {
+      if (dragPointerTarget.hasPointerCapture(dragPointerId)) {
+        dragPointerTarget.releasePointerCapture(dragPointerId)
+      }
+    } catch {}
+  }
+  dragPointerTarget = null
+}
+
+const clearDragState = ({ preserveMoved = false } = {}) => {
+  dragGeneration += 1
+  if (touchRafId !== null) {
+    cancelAnimationFrame(touchRafId)
+    touchRafId = null
+  }
+  removeDragListeners()
+  releaseDragPointerCapture()
+
+  isDragging = false
+  dragEnding = false
+  dragPointerType = ''
+  dragPointerId = null
+  touchInitialized = false
+  touchPreparing = false
+  touchPreparationPromise = null
+  touchScaleRebasing = false
+  touchScaleRebasePromise = null
+  touchIsSettingPos = false
+  touchBasePhysicalX = Number.NaN
+  touchBasePhysicalY = Number.NaN
+  touchPendingPhysicalX = Number.NaN
+  touchPendingPhysicalY = Number.NaN
+  if (!preserveMoved) {
+    hasMoved = false
+  }
+}
+
+const resetMovedAfterClick = () => {
+  const generation = dragGeneration
+  requestAnimationFrame(() => {
+    if (generation === dragGeneration) {
+      hasMoved = false
+    }
+  })
+}
+
+const finishDrag = (generation, pointerId, preserveMoved = false) => {
+  if (!isCurrentDrag(generation, pointerId)) return
+
+  clearDragState({ preserveMoved })
+  if (preserveMoved) {
+    resetMovedAfterClick()
+  }
+}
+
+const commitTouchPosition = (physicalX, physicalY) => (
+  appWindow.setPosition(new PhysicalPosition(
+    Math.round(physicalX),
+    Math.round(physicalY),
+  ))
+)
+
+const queueToolbarPositionSave = (position) => {
+  const generation = ++toolbarPositionSaveGeneration
+  toolbarPositionSavePromise = toolbarPositionSavePromise
+    .catch(() => {})
+    .then(async () => {
+      if (dragDisposed || generation !== toolbarPositionSaveGeneration) return
+
+      await invoke('save_toolbar_position', { x: position.x, y: position.y })
+    })
+    .catch(() => {})
+}
+
+const rebaseTouchDragForScaleChange = (scaleFactor) => {
+  touchScaleFactorVersion += 1
+  touchScaleFactor = normalizeDragScaleFactor(scaleFactor)
+  if (
+    dragPointerType !== 'touch' ||
+    dragPointerId === null ||
+    dragEnding ||
+    !touchInitialized ||
+    touchScaleRebasePromise
+  ) {
+    return
+  }
+
+  const generation = dragGeneration
+  const pointerId = dragPointerId
+  touchScaleRebasing = true
+  if (touchRafId !== null) {
+    cancelAnimationFrame(touchRafId)
+    touchRafId = null
+  }
+
+  let rebasePromise
+  rebasePromise = (async () => {
+    while (touchIsSettingPos) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      if (!isCurrentDrag(generation, pointerId)) return
+    }
+
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+    if (!isCurrentDrag(generation, pointerId) || dragEnding) return
+
+    const position = await appWindow.outerPosition()
+    if (!isCurrentDrag(generation, pointerId) || dragEnding) return
+
+    touchBasePhysicalX = position.x
+    touchBasePhysicalY = position.y
+    touchPendingPhysicalX = position.x
+    touchPendingPhysicalY = position.y
+    touchStartClientX = touchLatestClientX
+    touchStartClientY = touchLatestClientY
+  })()
+    .catch(() => {
+      if (isCurrentDrag(generation, pointerId)) {
+        clearDragState()
+      }
+    })
+    .finally(() => {
+      if (isCurrentDrag(generation, pointerId)) {
+        touchScaleRebasing = false
+      }
+      if (touchScaleRebasePromise === rebasePromise) {
+        touchScaleRebasePromise = null
+      }
+    })
+
+  touchScaleRebasePromise = rebasePromise
+}
+
+const ensureDragScaleListener = () => {
+  if (dragDisposed || unlistenDragScaleChanged || dragScaleListenerPromise) return
+
+  dragScaleListenerPromise = appWindow
+    .onScaleChanged(({ payload }) => {
+      rebaseTouchDragForScaleChange(payload.scaleFactor)
+    })
+    .then((unlisten) => {
+      dragScaleListenerPromise = null
+      if (dragDisposed) {
+        unlisten()
+        return
+      }
+      unlistenDragScaleChanged = unlisten
+    })
+    .catch(() => {
+      dragScaleListenerPromise = null
+    })
+}
+
+const queueTouchPosition = () => {
+  // WebView2 touch coordinates are relative to the moving viewport. Keep only
+  // one position IPC in flight so the next pointer sample uses the new baseline.
+  if (
+    dragPointerId === null ||
+    dragEnding ||
+    touchPreparing ||
+    touchScaleRebasing ||
+    touchIsSettingPos ||
+    !touchInitialized ||
+    !Number.isFinite(touchBasePhysicalX) ||
+    !Number.isFinite(touchBasePhysicalY)
+  ) {
+    return
+  }
+
+  touchPendingPhysicalX = touchBasePhysicalX +
+    (touchLatestClientX - touchStartClientX) * touchScaleFactor
+  touchPendingPhysicalY = touchBasePhysicalY +
+    (touchLatestClientY - touchStartClientY) * touchScaleFactor
+
+  if (touchRafId === null) {
+    touchRafId = requestAnimationFrame(touchApplyPosition)
+  }
+}
+
+const prepareTouchDrag = async (generation, pointerId) => {
+  const initialScaleFactorVersion = touchScaleFactorVersion
+  const [position, scaleFactor] = await Promise.all([
+    appWindow.outerPosition(),
+    appWindow.scaleFactor(),
+  ])
+  if (!isCurrentDrag(generation, pointerId) || dragEnding) return
+
+  if (touchScaleFactorVersion === initialScaleFactorVersion) {
+    touchScaleFactor = normalizeDragScaleFactor(scaleFactor)
+  }
+  touchBasePhysicalX = position.x
+  touchBasePhysicalY = position.y
+  touchPendingPhysicalX = position.x
+  touchPendingPhysicalY = position.y
+  touchInitialized = true
+
+  if (hasMoved) {
+    queueTouchPosition()
+  }
+}
+
 const onContainerDragStart = (e) => {
   if (menuVisible.value) {
     onDragStart(e)
@@ -896,118 +1122,215 @@ const onContainerDragStart = (e) => {
 }
 
 const onDragStart = (e) => {
-  if (e.button !== 0) return
+  if (
+    e.button !== 0 ||
+    isDragging ||
+    dragPointerId !== null ||
+    (e.pointerType === 'touch' && !e.isPrimary)
+  ) {
+    return
+  }
+
+  const generation = ++dragGeneration
+  const pointerId = e.pointerId
   e.preventDefault()
   isDragging = true
   hasMoved = false
+  dragEnding = false
   dragPointerType = e.pointerType
+  dragPointerId = pointerId
+  dragPointerTarget = e.currentTarget
   dragStartScreenX = e.screenX
   dragStartScreenY = e.screenY
-  
-  document.addEventListener('pointermove', onDragMove)
+
+  try {
+    dragPointerTarget.setPointerCapture(dragPointerId)
+  } catch {}
+
+  document.addEventListener('pointermove', onDragMove, { passive: false })
   document.addEventListener('pointerup', onDragEnd)
   document.addEventListener('pointercancel', onDragEnd)
-  
+
   if (e.pointerType === 'touch') {
+    ensureDragScaleListener()
     touchStartClientX = e.clientX
     touchStartClientY = e.clientY
-    touchBaseLogX = NaN
-    touchBaseLogY = NaN
+    touchLatestClientX = e.clientX
+    touchLatestClientY = e.clientY
+    touchBasePhysicalX = Number.NaN
+    touchBasePhysicalY = Number.NaN
+    touchPendingPhysicalX = Number.NaN
+    touchPendingPhysicalY = Number.NaN
+    touchInitialized = false
+    touchPreparing = true
     touchIsSettingPos = false
-    const dpr = window.devicePixelRatio || 1
-    appWindow.outerPosition().then((pos) => {
-      touchBaseLogX = pos.x / dpr
-      touchBaseLogY = pos.y / dpr
-    }).catch(() => { isDragging = false })
+    touchScaleRebasing = false
+
+    let preparationPromise
+    preparationPromise = prepareTouchDrag(generation, pointerId)
+      .catch(() => {
+        if (isCurrentDrag(generation, pointerId)) {
+          clearDragState()
+        }
+      })
+      .finally(() => {
+        if (isCurrentDrag(generation, pointerId)) {
+          touchPreparing = false
+        }
+        if (touchPreparationPromise === preparationPromise) {
+          touchPreparationPromise = null
+        }
+      })
+    touchPreparationPromise = preparationPromise
   }
 }
 
-// 触摸拖拽：rAF 回调，串行 await setPosition 避免竞态
 const touchApplyPosition = async () => {
   touchRafId = null
-  if (!isDragging || touchIsSettingPos) return
+  if (
+    !isDragging ||
+    dragEnding ||
+    touchPreparing ||
+    touchScaleRebasing ||
+    touchIsSettingPos ||
+    !touchInitialized ||
+    !Number.isFinite(touchPendingPhysicalX) ||
+    !Number.isFinite(touchPendingPhysicalY)
+  ) {
+    return
+  }
+
+  const generation = dragGeneration
+  const pointerId = dragPointerId
+  const nextPhysicalX = touchPendingPhysicalX
+  const nextPhysicalY = touchPendingPhysicalY
   touchIsSettingPos = true
-  const dpr = window.devicePixelRatio || 1
-  const physX = Math.round(touchPendingLogX * dpr)
-  const physY = Math.round(touchPendingLogY * dpr)
+
   try {
-    await appWindow.setPosition(new PhysicalPosition(physX, physY))
-    // 更新 baseline（用物理→逻辑避免累积舍入误差）
-    touchBaseLogX = physX / dpr
-    touchBaseLogY = physY / dpr
-  } catch {} finally {
-    touchIsSettingPos = false
+    await commitTouchPosition(nextPhysicalX, nextPhysicalY)
+    if (!isCurrentDrag(generation, pointerId)) return
+
+    touchBasePhysicalX = nextPhysicalX
+    touchBasePhysicalY = nextPhysicalY
+  } catch {
+    if (isCurrentDrag(generation, pointerId)) {
+      clearDragState()
+    }
+  } finally {
+    if (isCurrentDrag(generation, pointerId)) {
+      touchIsSettingPos = false
+    }
   }
 }
 
 const onDragMove = (e) => {
-  if (!isDragging) return
-  // 过滤非同类型指针（避免 Windows 触摸模拟鼠标事件）
-  if (e.pointerType !== dragPointerType) return
-  
+  if (
+    !isDragging ||
+    e.pointerId !== dragPointerId ||
+    e.pointerType !== dragPointerType ||
+    dragEnding
+  ) {
+    return
+  }
+
   if (dragPointerType === 'mouse' || dragPointerType === 'pen') {
     const dx = e.screenX - dragStartScreenX
     const dy = e.screenY - dragStartScreenY
     if (!hasMoved && Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) return
     hasMoved = true
     e.preventDefault()
-    // 超过阈值 → 切换为 OS 原生拖拽（完美处理跨 DPI 显示器）
+    const generation = dragGeneration
+    const pointerId = dragPointerId
     isDragging = false
+    dragEnding = true
     removeDragListeners()
+    releaseDragPointerCapture()
     appWindow.startDragging().then(async () => {
       try {
         const finalPos = await appWindow.outerPosition()
-        await invoke('save_toolbar_position', { x: finalPos.x, y: finalPos.y })
+        if (!isCurrentDrag(generation, pointerId)) return
+
+        queueToolbarPositionSave(finalPos)
       } catch {}
-    }).catch(() => {})
+      finishDrag(generation, pointerId, true)
+    }).catch(() => {
+      finishDrag(generation, pointerId, true)
+    })
     return
   }
-  
-  // === 触摸拖拽 ===
-  if (Number.isNaN(touchBaseLogX) || touchIsSettingPos) return
-  
-  const dcx = e.clientX - touchStartClientX
-  const dcy = e.clientY - touchStartClientY
-  if (!hasMoved && Math.abs(dcx) < DRAG_THRESHOLD && Math.abs(dcy) < DRAG_THRESHOLD) return
+
+  touchLatestClientX = e.clientX
+  touchLatestClientY = e.clientY
+  const deltaX = touchLatestClientX - touchStartClientX
+  const deltaY = touchLatestClientY - touchStartClientY
+  if (
+    !hasMoved &&
+    Math.abs(deltaX) < DRAG_THRESHOLD &&
+    Math.abs(deltaY) < DRAG_THRESHOLD
+  ) {
+    return
+  }
+
   hasMoved = true
   e.preventDefault()
-  
-  // 目标 = 已确认位置 + clientX delta（详见 docs/toolbar_interaction.md）
-  touchPendingLogX = touchBaseLogX + dcx
-  touchPendingLogY = touchBaseLogY + dcy
-  if (!touchRafId) {
-    touchRafId = requestAnimationFrame(touchApplyPosition)
-  }
+  queueTouchPosition()
 }
 
 const onDragEnd = async (e) => {
+  if (
+    dragPointerId === null ||
+    e.pointerId !== dragPointerId ||
+    e.pointerType !== dragPointerType
+  ) {
+    return
+  }
+
+  const generation = dragGeneration
+  const pointerId = dragPointerId
   const wasDragged = isDragging && hasMoved
   isDragging = false
-  if (touchRafId) {
+  dragEnding = true
+  removeDragListeners()
+  releaseDragPointerCapture()
+  if (touchRafId !== null) {
     cancelAnimationFrame(touchRafId)
     touchRafId = null
   }
-  removeDragListeners()
-  
+
   if (wasDragged && dragPointerType === 'touch') {
-    // 等待 flight 中的 setPosition 完成
-    while (touchIsSettingPos) {
-      await new Promise(r => setTimeout(r, 10))
+    if (touchPreparationPromise) {
+      await touchPreparationPromise
+      if (!isCurrentDrag(generation, pointerId)) return
     }
-    try {
-      const dpr = window.devicePixelRatio || 1
-      await appWindow.setPosition(new PhysicalPosition(
-        Math.round(touchPendingLogX * dpr),
-        Math.round(touchPendingLogY * dpr)
-      ))
-      const finalPos = await appWindow.outerPosition()
-      await invoke('save_toolbar_position', { x: finalPos.x, y: finalPos.y })
-    } catch {}
+    if (touchScaleRebasePromise) {
+      await touchScaleRebasePromise
+      if (!isCurrentDrag(generation, pointerId)) return
+    }
+    while (touchIsSettingPos) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      if (!isCurrentDrag(generation, pointerId)) return
+    }
+
+    if (
+      touchInitialized &&
+      Number.isFinite(touchPendingPhysicalX) &&
+      Number.isFinite(touchPendingPhysicalY)
+    ) {
+      try {
+        await commitTouchPosition(touchPendingPhysicalX, touchPendingPhysicalY)
+        if (!isCurrentDrag(generation, pointerId)) return
+
+        const finalPos = await appWindow.outerPosition()
+        if (!isCurrentDrag(generation, pointerId)) return
+
+        queueToolbarPositionSave(finalPos)
+      } catch {}
+    }
   }
-  requestAnimationFrame(() => { hasMoved = false })
+
+  finishDrag(generation, pointerId, wasDragged)
 }
 
-// 点击切换菜单（鼠标 click + 触摸合成 click 都走这里）
 const onIconClick = () => {
   if (!hasMoved) toggleMenu()
 }
@@ -1037,8 +1360,8 @@ const setCursorIgnore = (ignore) => {
 }
 
 const hitTestTick = async () => {
-  // 拖拽期间维持非穿透，避免打断 startDragging
-  if (isDragging) {
+  // 拖拽会话结束前维持非穿透，避免打断原生拖拽或触摸收尾。
+  if (dragPointerId !== null) {
     setCursorIgnore(false)
     return
   }
@@ -1048,6 +1371,11 @@ const hitTestTick = async () => {
       appWindow.outerSize(),
       cursorPosition(),
     ])
+    if (dragPointerId !== null) {
+      setCursorIgnore(false)
+      return
+    }
+
     // PhysicalPosition: 物理像素
     const relX = cur.x - winPos.x
     const relY = cur.y - winPos.y
@@ -1081,7 +1409,7 @@ const initBubbleClickThrough = () => {
       if (!hitTestEnabled) return
       await hitTestTick()
       if (!hitTestEnabled) return
-      const active = isDragging || menuVisible.value || !cursorIgnoreState
+      const active = dragPointerId !== null || menuVisible.value || !cursorIgnoreState
       scheduleNextHitTest(active ? HIT_TEST_ACTIVE_INTERVAL_MS : HIT_TEST_IDLE_INTERVAL_MS)
     }, delay)
   }
@@ -1102,6 +1430,13 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  dragDisposed = true
+  toolbarPositionSaveGeneration += 1
+  clearDragState()
+  if (unlistenDragScaleChanged) {
+    unlistenDragScaleChanged()
+    unlistenDragScaleChanged = null
+  }
   if (refreshTimer) {
     clearInterval(refreshTimer)
     refreshTimer = null
@@ -1116,8 +1451,6 @@ onUnmounted(() => {
   }
   cleanupPixiApp()
   // 清理拖拽
-  removeDragListeners()
-  if (touchRafId) { cancelAnimationFrame(touchRafId); touchRafId = null }
   hitTestEnabled = false
   if (hitTestTimer) { clearTimeout(hitTestTimer); hitTestTimer = null }
   if (speechBroadcast) {


### PR DESCRIPTION
桌宠窗口仍使用旧的触摸拖动实现。跨缩放比例显示器拖动、连续发起拖动或窗口销毁时，异步窗口调用可能继续使用过期状态；位置保存也会占用拖动收尾流程。

本次将触摸位置统一按物理坐标计算，并在缩放比例变化时重新建立拖动基准。通过指针标识和拖动代际隔离过期任务，窗口卸载时释放监听器和指针捕获。拖动位置改为后台串行保存，命中测试会在完整拖动会话结束前保持窗口可交互。鼠标和触控笔仍使用系统原生拖动。

用户在不同缩放比例的显示器之间拖动桌宠时，窗口位置不会因 DPI 换算发生跳变；连续拖动也不会被较慢的位置保存阻塞。