### PR TITLE
fix: complete VDD cursor migration and touch drag initialization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Build frontend
         run: npm run build:renderer
 
+      - name: Test renderer logic
+        run: npm run test:renderer
+
       - name: Test Tauri backend
         run: cargo test --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev-webui": "cross-env WEBUI_DEV_TARGET=https://localhost:3000 tauri dev",
     "dev:toolbar": "npm run build:renderer && cargo build --manifest-path src-tauri/Cargo.toml && src-tauri\\target\\debug\\sunshine-gui.exe --toolbar",
     "dev:renderer": "vite --config vite.config.js",
+    "test:renderer": "node --test src/renderer/composables/*.test.js",
     "build": "tauri build",
     "build:renderer": "vite build --config vite.config.js",
     "build:home": "vite build --config vite.home.config.js --mode production",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev-webui": "cross-env WEBUI_DEV_TARGET=https://localhost:3000 tauri dev",
     "dev:toolbar": "npm run build:renderer && cargo build --manifest-path src-tauri/Cargo.toml && src-tauri\\target\\debug\\sunshine-gui.exe --toolbar",
     "dev:renderer": "vite --config vite.config.js",
-    "test:renderer": "node --test src/renderer/composables/*.test.js",
+    "test:renderer": "node --test",
     "build": "tauri build",
     "build:renderer": "vite build --config vite.config.js",
     "build:home": "vite build --config vite.home.config.js --mode production",

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -36,6 +36,8 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     // 更新偏好属于应用级状态，必须在 `--hidden` 的纯托盘代理模式下也立即注册。
     // 自动联网检查仍在后面按窗口启动模式决定，避免把状态初始化和网络行为耦合。
     update::init_update_preferences(&app_handle)?;
+    #[cfg(target_os = "windows")]
+    crate::vdd::start_hardware_cursor_migration();
     let start_minimized = explicit_minimized || desktop_settings.start_minimized;
 
     // Agent-only startup keeps tray and session services alive without

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -348,7 +348,7 @@ async fn update_vdd_xml_extra_fields(settings: &VddSettings) -> Result<(), Strin
     write_vdd_xml(&vdd_xml_path, &full_xml).await?;
 
     // 验证文件是否更新
-    verify_vdd_xml(&vdd_xml_path)?;
+    verify_vdd_xml(&vdd_xml_path).await?;
 
     Ok(())
 }
@@ -427,17 +427,17 @@ fn prepare_hardware_cursor_migration(content: &str) -> Result<Option<String>, St
 async fn migrate_hardware_cursor_setting() -> Result<bool, String> {
     let _operation_guard = VDD_SETTINGS_OPERATION_LOCK.lock().await;
     let path = get_vdd_settings_path();
-    if !path.exists() {
-        return Ok(false);
-    }
-
-    let content = fs::read_to_string(&path).map_err(|e| format!("读取 VDD 配置文件失败: {}", e))?;
+    let content = match tokio::fs::read_to_string(&path).await {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("读取 VDD 配置文件失败: {}", error)),
+    };
     let Some(full_xml) = prepare_hardware_cursor_migration(&content)? else {
         return Ok(false);
     };
 
     write_vdd_xml(&path, &full_xml).await?;
-    verify_vdd_xml(&path)?;
+    verify_vdd_xml(&path).await?;
     info!("✅ 已在启动时将旧版 HardwareCursor=false 配置迁移为 true");
     Ok(true)
 }
@@ -457,7 +457,9 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
     // 写入临时文件
     let temp_path = std::env::temp_dir().join(format!("vdd_extra_{}.xml", std::process::id()));
     debug!("  📝 写入临时文件: {:?}", temp_path);
-    fs::write(&temp_path, content).map_err(|e| format!("写入临时文件失败: {}", e))?;
+    tokio::fs::write(&temp_path, content)
+        .await
+        .map_err(|e| format!("写入临时文件失败: {}", e))?;
 
     debug!("  📝 目标文件: {:?}", vdd_xml_path);
 
@@ -467,7 +469,7 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
             debug!("  🔧 已请求使用 ShellExecuteW 提权复制");
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-            match fs::read_to_string(vdd_xml_path) {
+            match tokio::fs::read_to_string(vdd_xml_path).await {
                 Ok(written) if written == content => {
                     info!("  ✅ ShellExecuteW 提权复制成功");
                     true
@@ -506,7 +508,7 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 
         let powershell_success = match run_elevated_powershell(&inner_command, "写入 VDD XML").await
         {
-            Ok(()) => match fs::read_to_string(vdd_xml_path) {
+            Ok(()) => match tokio::fs::read_to_string(vdd_xml_path).await {
                 Ok(written) if written == content => {
                     info!("  ✅ PowerShell 提权复制成功");
                     true
@@ -531,17 +533,16 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 
             // 尝试直接写入（可能会因权限不足而失败）
             warn!("  ⚠️ 尝试直接写入...");
-            fs::write(vdd_xml_path, content).map_err(|e| {
-                // 清理临时文件
-                let _ = fs::remove_file(&temp_path);
-                format!("写入失败，需要管理员权限: {}", e)
-            })?;
+            if let Err(error) = tokio::fs::write(vdd_xml_path, content).await {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+                return Err(format!("写入失败，需要管理员权限: {}", error));
+            }
             info!("  ✓ 直接写入成功");
         }
     }
 
     // 清理临时文件
-    let _ = fs::remove_file(&temp_path);
+    let _ = tokio::fs::remove_file(&temp_path).await;
 
     Ok(())
 }
@@ -560,10 +561,6 @@ fn elevated_copy_with_shell_execute(source: &Path, destination: &Path) -> Result
 
     let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
     let cmd_path: PathBuf = Path::new(&system_root).join("System32").join("cmd.exe");
-
-    if !cmd_path.exists() {
-        return Err(format!("找不到 cmd.exe: {:?}", cmd_path));
-    }
 
     let parameters = format!(
         r#"/C copy "{}" "{}" /Y"#,
@@ -595,9 +592,6 @@ fn elevated_copy_with_shell_execute(source: &Path, destination: &Path) -> Result
 
 #[cfg(target_os = "windows")]
 async fn run_elevated_powershell(inner_command: &str, action_label: &str) -> Result<(), String> {
-    use std::os::windows::process::CommandExt;
-    use std::process::Command;
-
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
     let escaped_command = inner_command.replace("'", "''");
@@ -606,10 +600,11 @@ async fn run_elevated_powershell(inner_command: &str, action_label: &str) -> Res
         escaped_command
     );
 
-    let status = Command::new("powershell")
+    let status = tokio::process::Command::new("powershell")
         .args(&["-NoProfile", "-Command", &ps_script])
         .creation_flags(CREATE_NO_WINDOW)
         .status()
+        .await
         .map_err(|e| format!("{}失败: {}", action_label, e))?;
 
     if !status.success() {
@@ -626,10 +621,14 @@ async fn run_elevated_powershell(inner_command: &str, action_label: &str) -> Res
 async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), String> {
     // 确保目录存在
     if let Some(parent) = vdd_xml_path.parent() {
-        fs::create_dir_all(parent).map_err(|e| format!("创建目录失败: {}", e))?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("创建目录失败: {}", e))?;
     }
 
-    fs::write(vdd_xml_path, content).map_err(|e| format!("写入 VDD XML 失败: {}", e))?;
+    tokio::fs::write(vdd_xml_path, content)
+        .await
+        .map_err(|e| format!("写入 VDD XML 失败: {}", e))?;
 
     debug!("  ✓ 已写入 VDD XML 扩展字段");
 
@@ -637,13 +636,14 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 }
 
 /// 验证 VDD XML 文件
-fn verify_vdd_xml(vdd_xml_path: &PathBuf) -> Result<(), String> {
-    if !vdd_xml_path.exists() {
-        return Err("验证失败: 文件不存在".to_string());
-    }
-
-    let verify_content =
-        fs::read_to_string(vdd_xml_path).map_err(|e| format!("验证文件失败: {}", e))?;
+async fn verify_vdd_xml(vdd_xml_path: &PathBuf) -> Result<(), String> {
+    let verify_content = match tokio::fs::read_to_string(vdd_xml_path).await {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err("验证失败: 文件不存在".to_string());
+        }
+        Err(error) => return Err(format!("验证文件失败: {}", error)),
+    };
 
     if verify_content.contains("<colour>")
         || verify_content.contains("<cursor>")

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 const VDD_TRACE_SESSION_NAME: &str = "ZakoVDD-Diagnostics";
 const VDD_TRACE_PROVIDER_GUID: &str = "{B254994F-46E6-4719-80A0-0A3AA50D6CE5}";
 const VDD_TRACE_FILE_PREFIX: &str = "zako-vdd";
+static VDD_SETTINGS_OPERATION_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VddTraceStatus {
@@ -373,6 +374,81 @@ fn normalize_hardware_cursor(settings: &mut VddSettings) -> bool {
 
     cursor.hardware_cursor = true;
     true
+}
+
+fn normalize_hardware_cursor_for_persistence(settings: &mut VddSettings) {
+    if settings.cursor.is_none() {
+        settings.cursor = default_cursor();
+    }
+    normalize_hardware_cursor(settings);
+}
+
+fn prepare_hardware_cursor_migration(content: &str) -> Result<Option<String>, String> {
+    let mut settings: VddSettings =
+        from_str(content).map_err(|e| format!("解析 VDD XML 失败: {}", e))?;
+    if !normalize_hardware_cursor(&mut settings) {
+        return Ok(None);
+    }
+
+    // Change only the existing value so driver fields unknown to this GUI are preserved.
+    const CURSOR_OPEN_TAG: &str = "<cursor>";
+    const CURSOR_CLOSE_TAG: &str = "</cursor>";
+    const OPEN_TAG: &str = "<HardwareCursor>";
+    const CLOSE_TAG: &str = "</HardwareCursor>";
+    let cursor_start = content
+        .find(CURSOR_OPEN_TAG)
+        .map(|index| index + CURSOR_OPEN_TAG.len())
+        .ok_or_else(|| "VDD XML 缺少 cursor 起始标签".to_string())?;
+    let cursor_end = content[cursor_start..]
+        .find(CURSOR_CLOSE_TAG)
+        .map(|index| cursor_start + index)
+        .ok_or_else(|| "VDD XML 缺少 cursor 结束标签".to_string())?;
+    let value_start = content[cursor_start..cursor_end]
+        .find(OPEN_TAG)
+        .map(|index| cursor_start + index + OPEN_TAG.len())
+        .ok_or_else(|| "VDD XML 缺少 HardwareCursor 起始标签".to_string())?;
+    let value_end = content[value_start..cursor_end]
+        .find(CLOSE_TAG)
+        .map(|index| value_start + index)
+        .ok_or_else(|| "VDD XML 缺少 HardwareCursor 结束标签".to_string())?;
+    let raw_value = &content[value_start..value_end];
+    let leading_whitespace = raw_value.len() - raw_value.trim_start().len();
+    let trailing_whitespace = raw_value.len() - raw_value.trim_end().len();
+    let replacement_start = value_start + leading_whitespace;
+    let replacement_end = value_end - trailing_whitespace;
+
+    let mut migrated = String::with_capacity(content.len());
+    migrated.push_str(&content[..replacement_start]);
+    migrated.push_str("true");
+    migrated.push_str(&content[replacement_end..]);
+    Ok(Some(migrated))
+}
+
+async fn migrate_hardware_cursor_setting() -> Result<bool, String> {
+    let _operation_guard = VDD_SETTINGS_OPERATION_LOCK.lock().await;
+    let path = get_vdd_settings_path();
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content = fs::read_to_string(&path).map_err(|e| format!("读取 VDD 配置文件失败: {}", e))?;
+    let Some(full_xml) = prepare_hardware_cursor_migration(&content)? else {
+        return Ok(false);
+    };
+
+    write_vdd_xml(&path, &full_xml).await?;
+    verify_vdd_xml(&path)?;
+    info!("✅ 已在启动时将旧版 HardwareCursor=false 配置迁移为 true");
+    Ok(true)
+}
+
+/// Persist the HardwareCursor invariant without blocking application startup.
+pub fn start_hardware_cursor_migration() {
+    tauri::async_runtime::spawn(async {
+        if let Err(error) = migrate_hardware_cursor_setting().await {
+            warn!("VDD HardwareCursor 配置迁移失败，将在下次启动时重试: {error}");
+        }
+    });
 }
 
 /// 写入 VDD XML 文件（Windows - 使用管理员权限）
@@ -1001,6 +1077,7 @@ fn get_default_settings() -> VddSettings {
 
 #[tauri::command]
 pub async fn load_vdd_settings() -> Result<VddSettings, String> {
+    let _operation_guard = VDD_SETTINGS_OPERATION_LOCK.lock().await;
     let path = get_vdd_settings_path();
 
     if !path.exists() {
@@ -1018,13 +1095,7 @@ pub async fn load_vdd_settings() -> Result<VddSettings, String> {
         format!("XML 解析失败: {}", e)
     })?;
 
-    if normalize_hardware_cursor(&mut settings) {
-        let xml = serialize_vdd_settings(&settings)?;
-        let full_xml = format!("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n{}", xml);
-        write_vdd_xml(&path, &full_xml).await?;
-        verify_vdd_xml(&path)?;
-        info!("✅ 已将旧版 HardwareCursor=false 配置迁移为 true");
-    }
+    normalize_hardware_cursor(&mut settings);
 
     info!("✅ XML 解析成功！");
     debug!("🔍 解析后的 VDD 设置: {:?}", settings);
@@ -1042,8 +1113,10 @@ pub async fn load_vdd_settings() -> Result<VddSettings, String> {
 }
 
 #[tauri::command]
-pub async fn save_vdd_settings(settings: VddSettings) -> Result<String, String> {
+pub async fn save_vdd_settings(mut settings: VddSettings) -> Result<String, String> {
     info!("💾 开始保存 VDD 配置...");
+    normalize_hardware_cursor_for_persistence(&mut settings);
+    let _operation_guard = VDD_SETTINGS_OPERATION_LOCK.lock().await;
 
     // 步骤1: 调用 Sunshine Config API 保存主要配置（resolutions, fps, adapter_name）
     // C++ 会写入 monitors, gpu, global, resolutions 字段
@@ -1658,6 +1731,56 @@ mod tests {
         assert!(xml.contains("<HardwareCursor>true</HardwareCursor>"));
         assert!(!xml.contains("<HardwareCursor>false</HardwareCursor>"));
         assert!(!normalize_hardware_cursor(&mut settings));
+    }
+
+    #[test]
+    fn persistence_restores_a_missing_cursor_section() {
+        let mut settings = get_default_settings();
+        settings.cursor = None;
+
+        normalize_hardware_cursor_for_persistence(&mut settings);
+
+        assert!(
+            settings
+                .cursor
+                .expect("persistence should restore cursor defaults")
+                .hardware_cursor
+        );
+    }
+
+    #[test]
+    fn startup_migration_rewrites_disabled_hardware_cursor_once() {
+        let old_xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<vdd_settings>
+    <monitors><count>1</count></monitors>
+    <gpu><friendlyname></friendlyname></gpu>
+    <global><g_refresh_rate>60</g_refresh_rate></global>
+    <resolutions>
+        <resolution><width>1920</width><height>1080</height></resolution>
+    </resolutions>
+    <FutureDriverSetting><HardwareCursor>false</HardwareCursor></FutureDriverSetting>
+    <cursor>
+        <HardwareCursor> false </HardwareCursor>
+        <CursorMaxY>64</CursorMaxY>
+        <CursorMaxX>64</CursorMaxX>
+        <AlphaCursorSupport>true</AlphaCursorSupport>
+        <XorCursorSupportLevel>2</XorCursorSupportLevel>
+    </cursor>
+    <FutureDriverSetting>keep-me</FutureDriverSetting>
+</vdd_settings>"#;
+
+        let migrated = prepare_hardware_cursor_migration(old_xml)
+            .unwrap()
+            .expect("disabled cursor should require migration");
+        assert!(migrated.contains("<HardwareCursor> true </HardwareCursor>"));
+        assert!(migrated.contains(
+            "<FutureDriverSetting><HardwareCursor>false</HardwareCursor></FutureDriverSetting>"
+        ));
+        assert!(
+            prepare_hardware_cursor_migration(&migrated)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -3,6 +3,7 @@ import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 
 const DRAG_THRESHOLD = 4
+const INITIAL_PREPARATION_TIMEOUT_MS = 1000
 const RESTORE_RESIZE_TIMEOUT_MS = 500
 
 /**
@@ -284,6 +285,22 @@ export function useTouchWindowDrag(isMaximized = null) {
     return Number.isFinite(pendingPhysicalX) && Number.isFinite(pendingPhysicalY)
   }
 
+  const waitForInitialPreparation = async (promise) => {
+    let timeoutId = null
+    try {
+      return await Promise.race([
+        promise.then(() => true, () => false),
+        new Promise((resolve) => {
+          timeoutId = setTimeout(() => resolve(false), INITIAL_PREPARATION_TIMEOUT_MS)
+        }),
+      ])
+    } finally {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+    }
+  }
+
   const queueLatestPosition = () => {
     if (
       pointerId === null ||
@@ -450,8 +467,12 @@ export function useTouchWindowDrag(isMaximized = null) {
     }
 
     if (initialPreparationPromise && hasMoved) {
-      await initialPreparationPromise
+      const prepared = await waitForInitialPreparation(initialPreparationPromise)
       if (!isCurrentDrag(generation, activePointerId)) return
+      if (!prepared) {
+        clearDragState()
+        return
+      }
     }
 
     if (preparationPromise) {

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -55,6 +55,9 @@ export function useTouchWindowDrag(isMaximized = null, options = {}) {
   let preparationPromise = null
   let settingPosition = false
   let positionRaf = null
+  let cancelRestoreResizeWait = null
+  let positionRequestSequence = 0
+  let latestRequestedPosition = null
 
   const normalizeScaleFactor = (value) => (
     Number.isFinite(value) && value > 0 ? value : 1
@@ -77,29 +80,78 @@ export function useTouchWindowDrag(isMaximized = null, options = {}) {
     }
   }
 
-  const commitPosition = (physicalX, physicalY) => {
-    return appWindow.setPosition(new PhysicalPosition(
-      Math.round(physicalX),
-      Math.round(physicalY),
-    ))
+  const commitPosition = async (physicalX, physicalY) => {
+    let requestSequence = ++positionRequestSequence
+    let requestedPosition = {
+      x: Math.round(physicalX),
+      y: Math.round(physicalY),
+    }
+    latestRequestedPosition = requestedPosition
+
+    // Tauri window IPC cannot be cancelled. If an older timed-out request
+    // finishes late, follow it with the newest requested position.
+    while (true) {
+      await appWindow.setPosition(new PhysicalPosition(
+        requestedPosition.x,
+        requestedPosition.y,
+      ))
+      if (requestSequence === positionRequestSequence) return
+
+      requestSequence = positionRequestSequence
+      requestedPosition = latestRequestedPosition
+    }
   }
 
-  const waitForRestoreResize = async () => {
+  const safelyUnlisten = (unlisten) => {
+    try {
+      const result = unlisten()
+      if (result && typeof result.catch === 'function') {
+        result.catch(() => {})
+      }
+    } catch {
+      // The window may already be closing.
+    }
+  }
+
+  const waitForRestoreResize = async (generation, activePointerId) => {
+    let cancelled = false
     let resolveResize
     let unlistenResize = null
     let timeoutId = null
     const resizePromise = new Promise((resolve) => {
       resolveResize = resolve
     })
+    const cancelWait = () => {
+      if (cancelled) return
+      cancelled = true
+      resolveResize()
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      if (unlistenResize) {
+        safelyUnlisten(unlistenResize)
+        unlistenResize = null
+      }
+    }
+    cancelRestoreResizeWait = cancelWait
 
     try {
       try {
-        unlistenResize = await appWindow.onResized(() => resolveResize())
+        const unlisten = await appWindow.onResized(() => resolveResize())
+        if (cancelled || !isCurrentDrag(generation, activePointerId)) {
+          safelyUnlisten(unlisten)
+          return false
+        }
+        unlistenResize = unlisten
       } catch {
         // Fall back to the bounded delay if resize events are unavailable.
       }
 
+      if (cancelled || !isCurrentDrag(generation, activePointerId)) return false
       await appWindow.unmaximize()
+      if (cancelled || !isCurrentDrag(generation, activePointerId)) return false
+
       if (!disposed && isMaximized && typeof isMaximized === 'object' && 'value' in isMaximized) {
         isMaximized.value = false
       }
@@ -109,13 +161,12 @@ export function useTouchWindowDrag(isMaximized = null, options = {}) {
           timeoutId = setTimeout(resolve, RESTORE_RESIZE_TIMEOUT_MS)
         }),
       ])
+      return !cancelled && isCurrentDrag(generation, activePointerId)
     } finally {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId)
+      if (cancelRestoreResizeWait === cancelWait) {
+        cancelRestoreResizeWait = null
       }
-      if (unlistenResize) {
-        unlistenResize()
-      }
+      cancelWait()
     }
   }
 
@@ -140,6 +191,11 @@ export function useTouchWindowDrag(isMaximized = null, options = {}) {
 
   const clearDragState = () => {
     dragGeneration += 1
+    if (cancelRestoreResizeWait) {
+      const cancelWait = cancelRestoreResizeWait
+      cancelRestoreResizeWait = null
+      cancelWait()
+    }
     if (positionRaf !== null) {
       cancelAnimationFrame(positionRaf)
       positionRaf = null
@@ -346,7 +402,7 @@ export function useTouchWindowDrag(isMaximized = null, options = {}) {
         Math.max(0, startClientX / Math.max(window.innerWidth, 1)),
       )
 
-      await waitForRestoreResize()
+      if (!(await waitForRestoreResize(generation, activePointerId))) return
       if (!isCurrentDrag(generation, activePointerId)) return
 
       const restoredSize = await appWindow.outerSize()

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -43,6 +43,7 @@ export function useTouchWindowDrag(isMaximized = null) {
   let initialPosition = null
   let initialMaximized = false
   let initialized = false
+  let initialPreparationPromise = null
   let preparing = false
   let preparationPromise = null
   let settingPosition = false
@@ -145,6 +146,7 @@ export function useTouchWindowDrag(isMaximized = null) {
     initialPosition = null
     initialMaximized = false
     initialized = false
+    initialPreparationPromise = null
     preparing = false
     preparationPromise = null
     settingPosition = false
@@ -270,6 +272,18 @@ export function useTouchWindowDrag(isMaximized = null) {
     }
   }
 
+  const updatePendingPosition = () => {
+    if (
+      !initialized ||
+      !Number.isFinite(basePhysicalX) ||
+      !Number.isFinite(basePhysicalY)
+    ) return false
+
+    pendingPhysicalX = basePhysicalX + (latestClientX - startClientX) * activeScaleFactor
+    pendingPhysicalY = basePhysicalY + (latestClientY - startClientY) * activeScaleFactor
+    return Number.isFinite(pendingPhysicalX) && Number.isFinite(pendingPhysicalY)
+  }
+
   const queueLatestPosition = () => {
     if (
       pointerId === null ||
@@ -277,15 +291,10 @@ export function useTouchWindowDrag(isMaximized = null) {
       preparing ||
       scaleRebasing ||
       settingPosition ||
-      !initialized ||
-      !Number.isFinite(basePhysicalX) ||
-      !Number.isFinite(basePhysicalY)
+      !updatePendingPosition()
     ) {
       return
     }
-
-    pendingPhysicalX = basePhysicalX + (latestClientX - startClientX) * activeScaleFactor
-    pendingPhysicalY = basePhysicalY + (latestClientY - startClientY) * activeScaleFactor
 
     if (positionRaf === null) {
       positionRaf = requestAnimationFrame(applyPendingPosition)
@@ -356,7 +365,7 @@ export function useTouchWindowDrag(isMaximized = null) {
         appWindow.scaleFactor(),
       ])
 
-      if (!isCurrentDrag(generation, activePointerId) || dragEnding) return
+      if (!isCurrentDrag(generation, activePointerId)) return
 
       initialPosition = position
       initialMaximized = maximized
@@ -378,7 +387,11 @@ export function useTouchWindowDrag(isMaximized = null) {
       initialized = true
 
       if (hasMoved) {
-        queueLatestPosition()
+        if (dragEnding) {
+          updatePendingPosition()
+        } else {
+          queueLatestPosition()
+        }
       }
     } catch {
       if (isCurrentDrag(generation, activePointerId)) {
@@ -434,6 +447,11 @@ export function useTouchWindowDrag(isMaximized = null) {
     if (positionRaf !== null) {
       cancelAnimationFrame(positionRaf)
       positionRaf = null
+    }
+
+    if (initialPreparationPromise && hasMoved) {
+      await initialPreparationPromise
+      if (!isCurrentDrag(generation, activePointerId)) return
     }
 
     if (preparationPromise) {
@@ -506,7 +524,14 @@ export function useTouchWindowDrag(isMaximized = null) {
     document.addEventListener('pointerup', onPointerEnd)
     document.addEventListener('pointercancel', onPointerEnd)
 
-    void prepareWindowPosition(pointerId, generation)
+    let initialPromise
+    initialPromise = prepareWindowPosition(pointerId, generation)
+      .finally(() => {
+        if (initialPreparationPromise === initialPromise) {
+          initialPreparationPromise = null
+        }
+      })
+    initialPreparationPromise = initialPromise
   }
 
   onUnmounted(() => {

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -3,7 +3,7 @@ import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 
 const DRAG_THRESHOLD = 4
-const INITIAL_PREPARATION_TIMEOUT_MS = 1000
+const DRAG_OPERATION_TIMEOUT_MS = 1000
 const RESTORE_RESIZE_TIMEOUT_MS = 500
 
 /**
@@ -285,13 +285,13 @@ export function useTouchWindowDrag(isMaximized = null) {
     return Number.isFinite(pendingPhysicalX) && Number.isFinite(pendingPhysicalY)
   }
 
-  const waitForInitialPreparation = async (promise) => {
+  const waitForDragOperation = async (promise) => {
     let timeoutId = null
     try {
       return await Promise.race([
         promise.then(() => true, () => false),
         new Promise((resolve) => {
-          timeoutId = setTimeout(() => resolve(false), INITIAL_PREPARATION_TIMEOUT_MS)
+          timeoutId = setTimeout(() => resolve(false), DRAG_OPERATION_TIMEOUT_MS)
         }),
       ])
     } finally {
@@ -299,6 +299,13 @@ export function useTouchWindowDrag(isMaximized = null) {
         clearTimeout(timeoutId)
       }
     }
+  }
+
+  const waitForCurrentDragOperation = async (promise, generation, activePointerId) => {
+    const completed = await waitForDragOperation(promise)
+    if (!isCurrentDrag(generation, activePointerId)) return false
+    if (!completed) clearDragState()
+    return completed
   }
 
   const queueLatestPosition = () => {
@@ -467,27 +474,39 @@ export function useTouchWindowDrag(isMaximized = null) {
     }
 
     if (initialPreparationPromise && hasMoved) {
-      const prepared = await waitForInitialPreparation(initialPreparationPromise)
-      if (!isCurrentDrag(generation, activePointerId)) return
-      if (!prepared) {
-        clearDragState()
-        return
-      }
+      if (!(await waitForCurrentDragOperation(
+        initialPreparationPromise,
+        generation,
+        activePointerId,
+      ))) return
     }
 
     if (preparationPromise) {
-      await preparationPromise
-      if (!isCurrentDrag(generation, activePointerId)) return
+      if (!(await waitForCurrentDragOperation(
+        preparationPromise,
+        generation,
+        activePointerId,
+      ))) return
     }
 
     if (scaleRebasePromise) {
-      await scaleRebasePromise
-      if (!isCurrentDrag(generation, activePointerId)) return
+      if (!(await waitForCurrentDragOperation(
+        scaleRebasePromise,
+        generation,
+        activePointerId,
+      ))) return
     }
 
-    while (settingPosition) {
-      await new Promise((resolve) => setTimeout(resolve, 0))
-      if (!isCurrentDrag(generation, activePointerId)) return
+    if (settingPosition) {
+      if (!(await waitForCurrentDragOperation(
+        (async () => {
+          while (settingPosition) {
+            await new Promise((resolve) => setTimeout(resolve, 0))
+          }
+        })(),
+        generation,
+        activePointerId,
+      ))) return
     }
 
     if (
@@ -496,12 +515,11 @@ export function useTouchWindowDrag(isMaximized = null) {
       Number.isFinite(pendingPhysicalX) &&
       Number.isFinite(pendingPhysicalY)
     ) {
-      try {
-        await commitPosition(pendingPhysicalX, pendingPhysicalY)
-        if (!isCurrentDrag(generation, activePointerId)) return
-      } catch {
-        // Keep the last position accepted by the operating system.
-      }
+      if (!(await waitForCurrentDragOperation(
+        commitPosition(pendingPhysicalX, pendingPhysicalY),
+        generation,
+        activePointerId,
+      ))) return
     }
 
     if (isCurrentDrag(generation, activePointerId)) {

--- a/src/renderer/composables/useTouchWindowDrag.js
+++ b/src/renderer/composables/useTouchWindowDrag.js
@@ -15,8 +15,14 @@ const RESTORE_RESIZE_TIMEOUT_MS = 500
  *
  * @param {{ value: boolean } | null} isMaximized reactive window state used by
  * the custom maximize button
+ * @param {{ operationTimeoutMs?: number }} options internal timing overrides
  */
-export function useTouchWindowDrag(isMaximized = null) {
+export function useTouchWindowDrag(isMaximized = null, options = {}) {
+  const operationTimeoutMs = (
+    Number.isFinite(options?.operationTimeoutMs) && options.operationTimeoutMs >= 0
+      ? options.operationTimeoutMs
+      : DRAG_OPERATION_TIMEOUT_MS
+  )
   let appWindow = null
   let unlistenScaleChanged = null
   let scaleListenerPromise = null
@@ -291,7 +297,7 @@ export function useTouchWindowDrag(isMaximized = null) {
       return await Promise.race([
         promise.then(() => true, () => false),
         new Promise((resolve) => {
-          timeoutId = setTimeout(() => resolve(false), DRAG_OPERATION_TIMEOUT_MS)
+          timeoutId = setTimeout(() => resolve(false), operationTimeoutMs)
         }),
       ])
     } finally {
@@ -500,7 +506,7 @@ export function useTouchWindowDrag(isMaximized = null) {
     if (settingPosition) {
       if (!(await waitForCurrentDragOperation(
         (async () => {
-          while (settingPosition) {
+          while (settingPosition && isCurrentDrag(generation, activePointerId)) {
             await new Promise((resolve) => setTimeout(resolve, 0))
           }
         })(),
@@ -548,6 +554,7 @@ export function useTouchWindowDrag(isMaximized = null) {
     pointerTarget = event.currentTarget
     hasMoved = false
     dragEnding = false
+    settingPosition = false
     startClientX = event.clientX
     startClientY = event.clientY
     latestClientX = event.clientX

--- a/src/renderer/composables/useTouchWindowDrag.test.js
+++ b/src/renderer/composables/useTouchWindowDrag.test.js
@@ -29,13 +29,16 @@ const installAnimationFrameMocks = () => {
 const installDragEnvironment = (invoke) => {
   const callbacks = new Map()
   const listeners = new Map()
+  const unregisteredListeners = []
   let callbackId = 0
-  const harness = { callbacks, listeners }
+  const harness = { callbacks, listeners, unregisteredListeners }
 
   globalThis.window = {
     innerWidth: 800,
     __TAURI_EVENT_PLUGIN_INTERNALS__: {
-      unregisterListener() {},
+      unregisterListener(event, eventId) {
+        unregisteredListeners.push({ event, eventId })
+      },
     },
     __TAURI_INTERNALS__: {
       metadata: { currentWindow: { label: 'main' } },
@@ -61,6 +64,7 @@ const installDragEnvironment = (invoke) => {
   return {
     callbacks,
     listeners,
+    unregisteredListeners,
     cleanup() {
       delete globalThis.window
       delete globalThis.document
@@ -301,8 +305,7 @@ test('releases touch drag state when restoring a maximized window never finishes
       return maximizedCalls === 1
     }
     if (command === 'plugin:window|scale_factor') return 2
-    if (command === 'plugin:window|unmaximize') return null
-    if (command === 'plugin:window|outer_size') return never
+    if (command === 'plugin:window|unmaximize') return never
     if (command === 'plugin:window|set_position') {
       committedPositions.push(args.value.toJSON().Physical)
       return null
@@ -323,6 +326,9 @@ test('releases touch drag state when restoring a maximized window never finishes
     moveTouchDrag(environment.listeners, 7, 35, 50)
     await environment.listeners.get('pointerup')({ pointerId: 7 })
     assert.deepEqual(committedPositions, [])
+    assert.deepEqual(environment.unregisteredListeners, [
+      { event: 'tauri://resize', eventId: 1 },
+    ])
 
     startTouchDrag(onTouchWindowDragStart, 8, 20, 30)
     moveTouchDrag(environment.listeners, 8, 45, 60)
@@ -390,10 +396,12 @@ test('releases touch drag state when DPI rebasing never finishes', async () => {
   }
 })
 
-test('releases touch drag state when a position commit never finishes', async () => {
+test('recovers from stalled position commits and corrects late writes', async () => {
   const never = new Promise(() => {})
+  const delayedSetPosition = deferred()
   const committedPositions = []
-  let hangNextSetPosition = false
+  let actualPosition = null
+  let nextSetPositionBehavior = null
   const environment = installDragEnvironment(async (command, args) => {
     if (command === 'plugin:event|listen') return 1
     if (command === 'plugin:event|unlisten') return null
@@ -401,11 +409,13 @@ test('releases touch drag state when a position commit never finishes', async ()
     if (command === 'plugin:window|is_maximized') return false
     if (command === 'plugin:window|scale_factor') return 2
     if (command === 'plugin:window|set_position') {
-      if (hangNextSetPosition) {
-        hangNextSetPosition = false
-        return never
-      }
-      committedPositions.push(args.value.toJSON().Physical)
+      const position = args.value.toJSON().Physical
+      const behavior = nextSetPositionBehavior
+      nextSetPositionBehavior = null
+      if (behavior === 'never') return never
+      if (behavior === 'delay') await delayedSetPosition.promise
+      actualPosition = position
+      committedPositions.push(position)
       return null
     }
     throw new Error(`Unexpected Tauri command: ${command}`)
@@ -419,7 +429,7 @@ test('releases touch drag state when a position commit never finishes', async ()
       operationTimeoutMs: TEST_OPERATION_TIMEOUT_MS,
     })
 
-    hangNextSetPosition = true
+    nextSetPositionBehavior = 'delay'
     startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
     await nextTask()
     moveTouchDrag(environment.listeners, 7, 35, 50)
@@ -428,13 +438,16 @@ test('releases touch drag state when a position commit never finishes', async ()
 
     startTouchDrag(onTouchWindowDragStart, 8, 20, 30)
     await nextTask()
-    moveTouchDrag(environment.listeners, 8, 45, 60)
+    moveTouchDrag(environment.listeners, 8, 65, 80)
     await nextTask()
-    assert.deepEqual(committedPositions.at(-1), { x: 150, y: 260 })
+    assert.deepEqual(actualPosition, { x: 190, y: 300 })
     await environment.listeners.get('pointerup')({ pointerId: 8 })
+    delayedSetPosition.resolve()
+    await nextTask()
+    assert.deepEqual(actualPosition, { x: 190, y: 300 })
     const commitsBeforeFinalHang = committedPositions.length
 
-    hangNextSetPosition = true
+    nextSetPositionBehavior = 'never'
     startTouchDrag(onTouchWindowDragStart, 9, 10, 20)
     moveTouchDrag(environment.listeners, 9, 35, 50)
     await environment.listeners.get('pointerup')({ pointerId: 9 })

--- a/src/renderer/composables/useTouchWindowDrag.test.js
+++ b/src/renderer/composables/useTouchWindowDrag.test.js
@@ -1,12 +1,29 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
+const TEST_OPERATION_TIMEOUT_MS = 20
+
 const deferred = () => {
   let resolve
   const promise = new Promise((next) => {
     resolve = next
   })
   return { promise, resolve }
+}
+
+const installAnimationFrameMocks = () => {
+  const cancelledFrames = new Set()
+  let frameId = 0
+  globalThis.requestAnimationFrame = (callback) => {
+    const id = ++frameId
+    queueMicrotask(() => {
+      if (!cancelledFrames.delete(id)) callback(0)
+    })
+    return id
+  }
+  globalThis.cancelAnimationFrame = (id) => {
+    cancelledFrames.add(id)
+  }
 }
 
 const installDragEnvironment = (invoke) => {
@@ -39,11 +56,7 @@ const installDragEnvironment = (invoke) => {
       if (listeners.get(type) === listener) listeners.delete(type)
     },
   }
-  globalThis.requestAnimationFrame = (callback) => {
-    queueMicrotask(() => callback(0))
-    return 1
-  }
-  globalThis.cancelAnimationFrame = () => {}
+  installAnimationFrameMocks()
 
   return {
     callbacks,
@@ -124,11 +137,7 @@ test('commits a quick touch drag after the initial window queries finish', async
       if (listeners.get(type) === listener) listeners.delete(type)
     },
   }
-  globalThis.requestAnimationFrame = (callback) => {
-    queueMicrotask(() => callback(0))
-    return 1
-  }
-  globalThis.cancelAnimationFrame = () => {}
+  installAnimationFrameMocks()
 
   const originalWarn = console.warn
   console.warn = () => {}
@@ -215,17 +224,15 @@ test('releases touch drag state when the initial window query never finishes', a
       if (listeners.get(type) === listener) listeners.delete(type)
     },
   }
-  globalThis.requestAnimationFrame = (callback) => {
-    queueMicrotask(() => callback(0))
-    return 1
-  }
-  globalThis.cancelAnimationFrame = () => {}
+  installAnimationFrameMocks()
 
   const originalWarn = console.warn
   console.warn = () => {}
   try {
     const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
-    const { onTouchWindowDragStart } = useTouchWindowDrag()
+    const { onTouchWindowDragStart } = useTouchWindowDrag(null, {
+      operationTimeoutMs: TEST_OPERATION_TIMEOUT_MS,
+    })
     const pointerTarget = {
       setPointerCapture() {},
       hasPointerCapture() { return true },
@@ -307,7 +314,9 @@ test('releases touch drag state when restoring a maximized window never finishes
   console.warn = () => {}
   try {
     const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
-    const { onTouchWindowDragStart } = useTouchWindowDrag()
+    const { onTouchWindowDragStart } = useTouchWindowDrag(null, {
+      operationTimeoutMs: TEST_OPERATION_TIMEOUT_MS,
+    })
 
     startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
     await nextTask()
@@ -355,7 +364,9 @@ test('releases touch drag state when DPI rebasing never finishes', async () => {
   console.warn = () => {}
   try {
     const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
-    const { onTouchWindowDragStart } = useTouchWindowDrag()
+    const { onTouchWindowDragStart } = useTouchWindowDrag(null, {
+      operationTimeoutMs: TEST_OPERATION_TIMEOUT_MS,
+    })
 
     startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
     await nextTask()
@@ -382,7 +393,7 @@ test('releases touch drag state when DPI rebasing never finishes', async () => {
 test('releases touch drag state when a position commit never finishes', async () => {
   const never = new Promise(() => {})
   const committedPositions = []
-  let setPositionCalls = 0
+  let hangNextSetPosition = false
   const environment = installDragEnvironment(async (command, args) => {
     if (command === 'plugin:event|listen') return 1
     if (command === 'plugin:event|unlisten') return null
@@ -390,8 +401,10 @@ test('releases touch drag state when a position commit never finishes', async ()
     if (command === 'plugin:window|is_maximized') return false
     if (command === 'plugin:window|scale_factor') return 2
     if (command === 'plugin:window|set_position') {
-      setPositionCalls += 1
-      if (setPositionCalls === 1 || setPositionCalls === 3) return never
+      if (hangNextSetPosition) {
+        hangNextSetPosition = false
+        return never
+      }
       committedPositions.push(args.value.toJSON().Physical)
       return null
     }
@@ -402,8 +415,11 @@ test('releases touch drag state when a position commit never finishes', async ()
   console.warn = () => {}
   try {
     const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
-    const { onTouchWindowDragStart } = useTouchWindowDrag()
+    const { onTouchWindowDragStart } = useTouchWindowDrag(null, {
+      operationTimeoutMs: TEST_OPERATION_TIMEOUT_MS,
+    })
 
+    hangNextSetPosition = true
     startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
     await nextTask()
     moveTouchDrag(environment.listeners, 7, 35, 50)
@@ -411,10 +427,14 @@ test('releases touch drag state when a position commit never finishes', async ()
     await environment.listeners.get('pointerup')({ pointerId: 7 })
 
     startTouchDrag(onTouchWindowDragStart, 8, 20, 30)
+    await nextTask()
     moveTouchDrag(environment.listeners, 8, 45, 60)
+    await nextTask()
+    assert.deepEqual(committedPositions.at(-1), { x: 150, y: 260 })
     await environment.listeners.get('pointerup')({ pointerId: 8 })
-    assert.deepEqual(committedPositions, [{ x: 150, y: 260 }])
+    const commitsBeforeFinalHang = committedPositions.length
 
+    hangNextSetPosition = true
     startTouchDrag(onTouchWindowDragStart, 9, 10, 20)
     moveTouchDrag(environment.listeners, 9, 35, 50)
     await environment.listeners.get('pointerup')({ pointerId: 9 })
@@ -422,10 +442,8 @@ test('releases touch drag state when a position commit never finishes', async ()
     startTouchDrag(onTouchWindowDragStart, 10, 20, 30)
     moveTouchDrag(environment.listeners, 10, 45, 60)
     await environment.listeners.get('pointerup')({ pointerId: 10 })
-    assert.deepEqual(committedPositions, [
-      { x: 150, y: 260 },
-      { x: 150, y: 260 },
-    ])
+    assert.equal(committedPositions.length, commitsBeforeFinalHang + 1)
+    assert.deepEqual(committedPositions.at(-1), { x: 150, y: 260 })
   } finally {
     console.warn = originalWarn
     environment.cleanup()

--- a/src/renderer/composables/useTouchWindowDrag.test.js
+++ b/src/renderer/composables/useTouchWindowDrag.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+test('commits a quick touch drag after the initial window queries finish', async () => {
+  const outerPosition = deferred()
+  const maximized = deferred()
+  const scaleFactor = deferred()
+  const committedPositions = []
+  const listeners = new Map()
+  let callbackId = 0
+
+  globalThis.window = {
+    innerWidth: 800,
+    __TAURI_INTERNALS__: {
+      metadata: { currentWindow: { label: 'main' } },
+      transformCallback: () => ++callbackId,
+      invoke: async (command, args) => {
+        if (command === 'plugin:event|listen') return 1
+        if (command === 'plugin:window|outer_position') return outerPosition.promise
+        if (command === 'plugin:window|is_maximized') return maximized.promise
+        if (command === 'plugin:window|scale_factor') return scaleFactor.promise
+        if (command === 'plugin:window|set_position') {
+          committedPositions.push(args.value.toJSON().Physical)
+          return null
+        }
+        throw new Error(`Unexpected Tauri command: ${command}`)
+      },
+    },
+  }
+  globalThis.document = {
+    createElement() { return {} },
+    addEventListener(type, listener) {
+      listeners.set(type, listener)
+    },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) listeners.delete(type)
+    },
+  }
+  globalThis.requestAnimationFrame = (callback) => {
+    queueMicrotask(() => callback(0))
+    return 1
+  }
+  globalThis.cancelAnimationFrame = () => {}
+
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
+    const { onTouchWindowDragStart } = useTouchWindowDrag()
+    const pointerTarget = {
+      setPointerCapture() {},
+      hasPointerCapture() { return true },
+      releasePointerCapture() {},
+    }
+
+    onTouchWindowDragStart({
+      pointerType: 'touch',
+      isPrimary: true,
+      button: 0,
+      pointerId: 7,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: pointerTarget,
+      preventDefault() {},
+      stopPropagation() {},
+    })
+    listeners.get('pointermove')({
+      pointerType: 'touch',
+      pointerId: 7,
+      clientX: 35,
+      clientY: 50,
+      preventDefault() {},
+    })
+
+    const endPromise = listeners.get('pointerup')({ pointerId: 7 })
+    assert.deepEqual(committedPositions, [])
+
+    outerPosition.resolve({ x: 100, y: 200 })
+    maximized.resolve(false)
+    scaleFactor.resolve(2)
+    await endPromise
+
+    assert.deepEqual(committedPositions, [{ x: 150, y: 260 }])
+  } finally {
+    console.warn = originalWarn
+    delete globalThis.window
+    delete globalThis.document
+    delete globalThis.requestAnimationFrame
+    delete globalThis.cancelAnimationFrame
+  }
+})

--- a/src/renderer/composables/useTouchWindowDrag.test.js
+++ b/src/renderer/composables/useTouchWindowDrag.test.js
@@ -9,6 +9,86 @@ const deferred = () => {
   return { promise, resolve }
 }
 
+const installDragEnvironment = (invoke) => {
+  const callbacks = new Map()
+  const listeners = new Map()
+  let callbackId = 0
+  const harness = { callbacks, listeners }
+
+  globalThis.window = {
+    innerWidth: 800,
+    __TAURI_EVENT_PLUGIN_INTERNALS__: {
+      unregisterListener() {},
+    },
+    __TAURI_INTERNALS__: {
+      metadata: { currentWindow: { label: 'main' } },
+      transformCallback: (callback) => {
+        const id = ++callbackId
+        callbacks.set(id, callback)
+        return id
+      },
+      invoke: (command, args) => invoke(command, args, harness),
+    },
+  }
+  globalThis.document = {
+    createElement() { return {} },
+    addEventListener(type, listener) {
+      listeners.set(type, listener)
+    },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) listeners.delete(type)
+    },
+  }
+  globalThis.requestAnimationFrame = (callback) => {
+    queueMicrotask(() => callback(0))
+    return 1
+  }
+  globalThis.cancelAnimationFrame = () => {}
+
+  return {
+    callbacks,
+    listeners,
+    cleanup() {
+      delete globalThis.window
+      delete globalThis.document
+      delete globalThis.requestAnimationFrame
+      delete globalThis.cancelAnimationFrame
+    },
+  }
+}
+
+const pointerTarget = {
+  setPointerCapture() {},
+  hasPointerCapture() { return true },
+  releasePointerCapture() {},
+}
+
+const startTouchDrag = (onTouchWindowDragStart, pointerId, clientX, clientY) => {
+  onTouchWindowDragStart({
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    pointerId,
+    clientX,
+    clientY,
+    currentTarget: pointerTarget,
+    preventDefault() {},
+    stopPropagation() {},
+  })
+}
+
+const moveTouchDrag = (listeners, pointerId, clientX, clientY) => {
+  listeners.get('pointermove')({
+    pointerType: 'touch',
+    pointerId,
+    clientX,
+    clientY,
+    preventDefault() {},
+  })
+}
+
+const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 test('commits a quick touch drag after the initial window queries finish', async () => {
   const outerPosition = deferred()
   const maximized = deferred()
@@ -193,5 +273,161 @@ test('releases touch drag state when the initial window query never finishes', a
     delete globalThis.document
     delete globalThis.requestAnimationFrame
     delete globalThis.cancelAnimationFrame
+  }
+})
+
+test('releases touch drag state when restoring a maximized window never finishes', async () => {
+  const never = new Promise(() => {})
+  const committedPositions = []
+  let maximizedCalls = 0
+  const environment = installDragEnvironment(async (command, args, { callbacks }) => {
+    if (command === 'plugin:event|listen') {
+      if (args.event === 'tauri://resize') {
+        queueMicrotask(() => callbacks.get(args.handler)?.({ payload: {} }))
+      }
+      return 1
+    }
+    if (command === 'plugin:event|unlisten') return null
+    if (command === 'plugin:window|outer_position') return { x: 100, y: 200 }
+    if (command === 'plugin:window|is_maximized') {
+      maximizedCalls += 1
+      return maximizedCalls === 1
+    }
+    if (command === 'plugin:window|scale_factor') return 2
+    if (command === 'plugin:window|unmaximize') return null
+    if (command === 'plugin:window|outer_size') return never
+    if (command === 'plugin:window|set_position') {
+      committedPositions.push(args.value.toJSON().Physical)
+      return null
+    }
+    throw new Error(`Unexpected Tauri command: ${command}`)
+  })
+
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
+    const { onTouchWindowDragStart } = useTouchWindowDrag()
+
+    startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
+    await nextTask()
+    moveTouchDrag(environment.listeners, 7, 35, 50)
+    await environment.listeners.get('pointerup')({ pointerId: 7 })
+    assert.deepEqual(committedPositions, [])
+
+    startTouchDrag(onTouchWindowDragStart, 8, 20, 30)
+    moveTouchDrag(environment.listeners, 8, 45, 60)
+    await environment.listeners.get('pointerup')({ pointerId: 8 })
+    assert.deepEqual(committedPositions, [{ x: 150, y: 260 }])
+  } finally {
+    console.warn = originalWarn
+    environment.cleanup()
+  }
+})
+
+test('releases touch drag state when DPI rebasing never finishes', async () => {
+  const never = new Promise(() => {})
+  const committedPositions = []
+  let outerPositionCalls = 0
+  let scaleChangeHandler = null
+  const environment = installDragEnvironment(async (command, args, { callbacks }) => {
+    if (command === 'plugin:event|listen') {
+      if (args.event === 'tauri://scale-change') {
+        scaleChangeHandler = callbacks.get(args.handler)
+      }
+      return 1
+    }
+    if (command === 'plugin:event|unlisten') return null
+    if (command === 'plugin:window|outer_position') {
+      outerPositionCalls += 1
+      return outerPositionCalls === 2 ? never : { x: 100, y: 200 }
+    }
+    if (command === 'plugin:window|is_maximized') return false
+    if (command === 'plugin:window|scale_factor') return 2
+    if (command === 'plugin:window|set_position') {
+      committedPositions.push(args.value.toJSON().Physical)
+      return null
+    }
+    throw new Error(`Unexpected Tauri command: ${command}`)
+  })
+
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
+    const { onTouchWindowDragStart } = useTouchWindowDrag()
+
+    startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
+    await nextTask()
+    moveTouchDrag(environment.listeners, 7, 35, 50)
+    await nextTask()
+    assert.equal(typeof scaleChangeHandler, 'function')
+    scaleChangeHandler({ payload: { scaleFactor: 1.5 } })
+    await nextTask()
+    await environment.listeners.get('pointerup')({ pointerId: 7 })
+
+    const commitsBeforeRetry = committedPositions.length
+    startTouchDrag(onTouchWindowDragStart, 8, 20, 30)
+    moveTouchDrag(environment.listeners, 8, 45, 60)
+    await environment.listeners.get('pointerup')({ pointerId: 8 })
+
+    assert.equal(committedPositions.length, commitsBeforeRetry + 1)
+    assert.deepEqual(committedPositions.at(-1), { x: 150, y: 260 })
+  } finally {
+    console.warn = originalWarn
+    environment.cleanup()
+  }
+})
+
+test('releases touch drag state when a position commit never finishes', async () => {
+  const never = new Promise(() => {})
+  const committedPositions = []
+  let setPositionCalls = 0
+  const environment = installDragEnvironment(async (command, args) => {
+    if (command === 'plugin:event|listen') return 1
+    if (command === 'plugin:event|unlisten') return null
+    if (command === 'plugin:window|outer_position') return { x: 100, y: 200 }
+    if (command === 'plugin:window|is_maximized') return false
+    if (command === 'plugin:window|scale_factor') return 2
+    if (command === 'plugin:window|set_position') {
+      setPositionCalls += 1
+      if (setPositionCalls === 1 || setPositionCalls === 3) return never
+      committedPositions.push(args.value.toJSON().Physical)
+      return null
+    }
+    throw new Error(`Unexpected Tauri command: ${command}`)
+  })
+
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
+    const { onTouchWindowDragStart } = useTouchWindowDrag()
+
+    startTouchDrag(onTouchWindowDragStart, 7, 10, 20)
+    await nextTask()
+    moveTouchDrag(environment.listeners, 7, 35, 50)
+    await nextTask()
+    await environment.listeners.get('pointerup')({ pointerId: 7 })
+
+    startTouchDrag(onTouchWindowDragStart, 8, 20, 30)
+    moveTouchDrag(environment.listeners, 8, 45, 60)
+    await environment.listeners.get('pointerup')({ pointerId: 8 })
+    assert.deepEqual(committedPositions, [{ x: 150, y: 260 }])
+
+    startTouchDrag(onTouchWindowDragStart, 9, 10, 20)
+    moveTouchDrag(environment.listeners, 9, 35, 50)
+    await environment.listeners.get('pointerup')({ pointerId: 9 })
+
+    startTouchDrag(onTouchWindowDragStart, 10, 20, 30)
+    moveTouchDrag(environment.listeners, 10, 45, 60)
+    await environment.listeners.get('pointerup')({ pointerId: 10 })
+    assert.deepEqual(committedPositions, [
+      { x: 150, y: 260 },
+      { x: 150, y: 260 },
+    ])
+  } finally {
+    console.warn = originalWarn
+    environment.cleanup()
   }
 })

--- a/src/renderer/composables/useTouchWindowDrag.test.js
+++ b/src/renderer/composables/useTouchWindowDrag.test.js
@@ -97,3 +97,101 @@ test('commits a quick touch drag after the initial window queries finish', async
     delete globalThis.cancelAnimationFrame
   }
 })
+
+test('releases touch drag state when the initial window query never finishes', async () => {
+  const never = new Promise(() => {})
+  const committedPositions = []
+  const listeners = new Map()
+  let outerPositionCalls = 0
+  let callbackId = 0
+
+  globalThis.window = {
+    innerWidth: 800,
+    __TAURI_INTERNALS__: {
+      metadata: { currentWindow: { label: 'main' } },
+      transformCallback: () => ++callbackId,
+      invoke: async (command, args) => {
+        if (command === 'plugin:event|listen') return 1
+        if (command === 'plugin:window|outer_position') {
+          outerPositionCalls += 1
+          return outerPositionCalls === 1 ? never : { x: 100, y: 200 }
+        }
+        if (command === 'plugin:window|is_maximized') return false
+        if (command === 'plugin:window|scale_factor') return 2
+        if (command === 'plugin:window|set_position') {
+          committedPositions.push(args.value.toJSON().Physical)
+          return null
+        }
+        throw new Error(`Unexpected Tauri command: ${command}`)
+      },
+    },
+  }
+  globalThis.document = {
+    createElement() { return {} },
+    addEventListener(type, listener) {
+      listeners.set(type, listener)
+    },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) listeners.delete(type)
+    },
+  }
+  globalThis.requestAnimationFrame = (callback) => {
+    queueMicrotask(() => callback(0))
+    return 1
+  }
+  globalThis.cancelAnimationFrame = () => {}
+
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    const { useTouchWindowDrag } = await import('./useTouchWindowDrag.js')
+    const { onTouchWindowDragStart } = useTouchWindowDrag()
+    const pointerTarget = {
+      setPointerCapture() {},
+      hasPointerCapture() { return true },
+      releasePointerCapture() {},
+    }
+    const startDrag = (pointerId, clientX, clientY) => {
+      onTouchWindowDragStart({
+        pointerType: 'touch',
+        isPrimary: true,
+        button: 0,
+        pointerId,
+        clientX,
+        clientY,
+        currentTarget: pointerTarget,
+        preventDefault() {},
+        stopPropagation() {},
+      })
+    }
+
+    startDrag(7, 10, 20)
+    listeners.get('pointermove')({
+      pointerType: 'touch',
+      pointerId: 7,
+      clientX: 35,
+      clientY: 50,
+      preventDefault() {},
+    })
+    await listeners.get('pointerup')({ pointerId: 7 })
+    assert.deepEqual(committedPositions, [])
+
+    startDrag(8, 20, 30)
+    listeners.get('pointermove')({
+      pointerType: 'touch',
+      pointerId: 8,
+      clientX: 45,
+      clientY: 60,
+      preventDefault() {},
+    })
+    await listeners.get('pointerup')({ pointerId: 8 })
+
+    assert.deepEqual(committedPositions, [{ x: 150, y: 260 }])
+  } finally {
+    console.warn = originalWarn
+    delete globalThis.window
+    delete globalThis.document
+    delete globalThis.requestAnimationFrame
+    delete globalThis.cancelAnimationFrame
+  }
+})


### PR DESCRIPTION
## 说明

这次修复两个已经合入但仍存在边界遗漏的问题：VDD 硬件光标旧配置只在打开设置页时迁移，以及主窗口快速触控拖动会在初始化完成前丢失。

### VDD 硬件光标迁移

旧版本可能保存了 `HardwareCursor=false`。此前只有进入 VDD 设置页、调用 `load_vdd_settings` 时才会改写该值；如果用户升级后没有打开这个页面，磁盘配置会继续保持关闭。保存接口也没有在后端强制该约束，传入 `false` 或缺少 cursor 节点时仍可能保留不兼容配置。

复现方式：

1. 准备一份包含 `<HardwareCursor>false</HardwareCursor>` 的旧版 `vdd_settings.xml`。
2. 升级并启动控制面板，但不要进入 VDD 设置页。
3. 检查配置文件，旧值不会被迁移；VDD 继续按关闭光标导出的配置启动。

不修复时，依赖 VDD cursor plane 的光标渲染切换可能失去基础数据，远端指针可能不可见，并需要重新加载驱动才能恢复。

现在应用启动后会异步执行一次旧配置迁移，且保存入口始终补齐 cursor 默认值并强制 `HardwareCursor=true`。迁移只替换 `<cursor>` 节点中的目标值，不会重新序列化整份 XML，因此驱动新增但 GUI 尚不识别的字段会原样保留。迁移、读取和保存使用同一操作锁，避免启动迁移覆盖用户同时保存的配置。

只在检测到旧值为 `false` 时写文件。由于目标配置需要管理员权限，受影响用户首次迁移时可能看到一次提权确认；取消不会阻止控制面板启动，下次启动会重试。已经是 `true`、字段缺失或配置文件不存在时不会触发写入。

### 快速触控拖动

主窗口开始触控拖动时会异步读取窗口位置、最大化状态和缩放比例，但此前没有记录这组初始化请求。用户在请求返回前滑动并抬手时，结束逻辑只会等待最大化恢复流程，随后在 `initialized=false` 的状态下清理拖动，窗口不会移动。

复现方式：

1. 在主窗口标题区域按下手指。
2. 快速移动超过拖动阈值并立即抬起，确保操作早于初始窗口查询返回。
3. 本次拖动会被忽略；首次启动或 IPC 响应较慢时更容易出现。

现在会跟踪初始查询 Promise，并仅在确实发生拖动时等待它完成。查询完成后会根据最后的触控坐标计算并提交最终位置，普通点击不需要等待。新增的 renderer 回归测试使用延迟的 Tauri 窗口查询复现该时序，并已接入 Windows CI。

## 验证

前端生产构建、renderer 7 项测试、Rust 80 项测试和格式检查通过。Windows MSVC 测试继续由 PR CI 按发布环境执行。