### PR TITLE
fix(desktop): wait for proxy before loading apps

### DIFF
--- a/src/renderer/desktop/composables/useApps.js
+++ b/src/renderer/desktop/composables/useApps.js
@@ -9,7 +9,7 @@ export function useApps() {
   const proxyUrl = ref('http://localhost:48081')
   const apps = ref([])
   const loading = ref(true)
-  const loadError = ref('')
+  const loadFailed = ref(false)
   const searchQuery = ref('')
   const launchingApp = ref(null)
   const failedImages = ref(new Set())
@@ -24,6 +24,7 @@ export function useApps() {
   // 收藏和最近启动（持久化）
   const favorites = ref(JSON.parse(localStorage.getItem(`${STORAGE_KEY}-favorites`) || '[]'))
   const recentHistory = ref(JSON.parse(localStorage.getItem(`${STORAGE_KEY}-recent`) || '[]'))
+  let loadRequestId = 0
 
   // 持久化（防抖批量写入）
   let persistTimer = null
@@ -203,20 +204,28 @@ export function useApps() {
   }
 
   async function loadApps() {
+    const requestId = ++loadRequestId
     loading.value = true
-    loadError.value = ''
+    loadFailed.value = false
     try {
-      await initProxy()
-      const resp = await fetch(`${proxyUrl.value}/api/apps`)
+      const requestProxyUrl = await tauriInvoke('wait_for_proxy_ready')
+      if (requestId !== loadRequestId) return
+
+      proxyUrl.value = requestProxyUrl
+      const resp = await fetch(`${requestProxyUrl}/api/apps`)
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
 
       const data = await resp.json()
+      if (requestId !== loadRequestId) return
+
       apps.value = data.apps || data || []
     } catch (e) {
+      if (requestId !== loadRequestId) return
+
       console.error('Failed to load apps:', e)
-      loadError.value = t.value.apps.loadFailed
+      loadFailed.value = true
     } finally {
-      loading.value = false
+      if (requestId === loadRequestId) loading.value = false
     }
   }
 
@@ -253,16 +262,11 @@ export function useApps() {
     }
   }
 
-  async function initProxy() {
-    const url = await tauriInvoke('wait_for_proxy_ready')
-    if (url) proxyUrl.value = url
-  }
-
   return {
     proxyUrl,
     apps,
     loading,
-    loadError,
+    loadFailed,
     searchQuery,
     launchingApp,
     launchError,

--- a/src/renderer/desktop/composables/useApps.js
+++ b/src/renderer/desktop/composables/useApps.js
@@ -3,6 +3,7 @@ import { tauriInvoke } from './useTauri'
 import { useI18n } from '../i18n/index.js'
 
 const STORAGE_KEY = 'foundation-desktop-apps'
+const APP_LIST_REQUEST_TIMEOUT_MS = 10000
 
 export function useApps() {
   const { t } = useI18n()
@@ -207,24 +208,34 @@ export function useApps() {
     const requestId = ++loadRequestId
     loading.value = true
     loadFailed.value = false
+    let timeoutTimer = null
     try {
       const requestProxyUrl = await tauriInvoke('wait_for_proxy_ready')
       if (requestId !== loadRequestId) return
 
       proxyUrl.value = requestProxyUrl
-      const resp = await fetch(`${requestProxyUrl}/api/apps`)
+      const requestController = new AbortController()
+      timeoutTimer = setTimeout(() => {
+        requestController.abort('timeout')
+      }, APP_LIST_REQUEST_TIMEOUT_MS)
+
+      const resp = await fetch(`${requestProxyUrl}/api/apps`, { signal: requestController.signal })
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
 
       const data = await resp.json()
       if (requestId !== loadRequestId) return
 
-      apps.value = data.apps || data || []
+      const appList = Array.isArray(data) ? data : data?.apps
+      if (!Array.isArray(appList)) throw new Error('Invalid apps response: expected an array')
+
+      apps.value = appList
     } catch (e) {
       if (requestId !== loadRequestId) return
 
       console.error('Failed to load apps:', e)
       loadFailed.value = true
     } finally {
+      if (timeoutTimer !== null) clearTimeout(timeoutTimer)
       if (requestId === loadRequestId) loading.value = false
     }
   }

--- a/src/renderer/desktop/composables/useApps.js
+++ b/src/renderer/desktop/composables/useApps.js
@@ -9,6 +9,7 @@ export function useApps() {
   const proxyUrl = ref('http://localhost:48081')
   const apps = ref([])
   const loading = ref(true)
+  const loadError = ref('')
   const searchQuery = ref('')
   const launchingApp = ref(null)
   const failedImages = ref(new Set())
@@ -203,14 +204,17 @@ export function useApps() {
 
   async function loadApps() {
     loading.value = true
+    loadError.value = ''
     try {
+      await initProxy()
       const resp = await fetch(`${proxyUrl.value}/api/apps`)
-      if (resp.ok) {
-        const data = await resp.json()
-        apps.value = data.apps || data || []
-      }
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+
+      const data = await resp.json()
+      apps.value = data.apps || data || []
     } catch (e) {
       console.error('Failed to load apps:', e)
+      loadError.value = t.value.apps.loadFailed
     } finally {
       loading.value = false
     }
@@ -250,18 +254,15 @@ export function useApps() {
   }
 
   async function initProxy() {
-    try {
-      const url = await tauriInvoke('get_proxy_url_command')
-      if (url) proxyUrl.value = url
-    } catch (e) {
-      console.log('Tauri invoke not available:', e)
-    }
+    const url = await tauriInvoke('wait_for_proxy_ready')
+    if (url) proxyUrl.value = url
   }
 
   return {
     proxyUrl,
     apps,
     loading,
+    loadError,
     searchQuery,
     launchingApp,
     launchError,
@@ -285,6 +286,5 @@ export function useApps() {
     invalidateAppImage,
     loadApps,
     launchApp,
-    initProxy,
   }
 }

--- a/src/renderer/desktop/i18n/en.js
+++ b/src/renderer/desktop/i18n/en.js
@@ -372,6 +372,8 @@ export const en = {
   apps: {
     libraryTitle: 'Library',
     loading: 'Loading application list...',
+    loadFailed: 'Failed to load applications. Check Sunshine and try again.',
+    retry: 'Retry',
     searchPlaceholder: 'Search...',
     searchNoMatch: 'No matching applications found',
     noFavorites: 'No favorite applications yet',

--- a/src/renderer/desktop/i18n/zh.js
+++ b/src/renderer/desktop/i18n/zh.js
@@ -372,6 +372,8 @@ export const zh = {
   apps: {
     libraryTitle: '游戏库',
     loading: '加载应用列表...',
+    loadFailed: '应用列表加载失败，请检查 Sunshine 状态后重试',
+    retry: '重试',
     searchPlaceholder: '搜索...',
     searchNoMatch: '没有找到匹配的应用',
     noFavorites: '还没有收藏的应用',

--- a/src/renderer/desktop/views/AppsView.vue
+++ b/src/renderer/desktop/views/AppsView.vue
@@ -31,11 +31,11 @@
     </div>
 
     <!-- 加载失败状态 -->
-    <div v-else-if="loadError" class="apps-empty apps-error">
+    <div v-else-if="loadFailed" class="apps-empty apps-error" role="alert">
       <svg class="empty-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
         <circle cx="12" cy="12" r="9"/><path d="M12 7v6"/><path d="M12 17h.01"/>
       </svg>
-      <p>{{ loadError }}</p>
+      <p>{{ t.apps.loadFailed }}</p>
       <button class="retry-btn" type="button" @click="loadApps">{{ t.apps.retry }}</button>
     </div>
 
@@ -137,7 +137,7 @@ import CoverPickerModal from '../components/CoverPickerModal.vue'
 
 const {
   loading,
-  loadError,
+  loadFailed,
   searchQuery,
   launchingApp,
   launchError,

--- a/src/renderer/desktop/views/AppsView.vue
+++ b/src/renderer/desktop/views/AppsView.vue
@@ -30,6 +30,15 @@
       <span>{{ t.apps.loading }}</span>
     </div>
 
+    <!-- 加载失败状态 -->
+    <div v-else-if="loadError" class="apps-empty apps-error">
+      <svg class="empty-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <circle cx="12" cy="12" r="9"/><path d="M12 7v6"/><path d="M12 17h.01"/>
+      </svg>
+      <p>{{ loadError }}</p>
+      <button class="retry-btn" type="button" @click="loadApps">{{ t.apps.retry }}</button>
+    </div>
+
     <!-- 空状态 -->
     <div v-else-if="displayApps.length === 0 && !loading" class="apps-empty">
       <svg class="empty-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -128,6 +137,7 @@ import CoverPickerModal from '../components/CoverPickerModal.vue'
 
 const {
   loading,
+  loadError,
   searchQuery,
   launchingApp,
   launchError,
@@ -148,7 +158,6 @@ const {
   invalidateAppImage,
   loadApps,
   launchApp,
-  initProxy,
 } = useApps()
 
 // 右键菜单
@@ -243,7 +252,6 @@ function onDocClick() {
 
 onMounted(async () => {
   document.addEventListener('click', onDocClick)
-  await initProxy()
   await loadApps()
 })
 
@@ -290,7 +298,27 @@ onUnmounted(() => {
   .empty-icon { width: 56px; height: 56px; opacity: 0.25; margin-bottom: 8px; }
   p { margin: 0; font-size: 16px; }
   .empty-hint { font-size: 13px; color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.2); }
+
+  .retry-btn {
+    margin-top: 8px;
+    padding: 8px 20px;
+    border: 1px solid rgba(var(--fd-accent-rgb, 0, 255, 245), 0.45);
+    border-radius: 8px;
+    background: rgba(var(--fd-accent-rgb, 0, 255, 245), 0.1);
+    color: var(--fd-accent, #00fff5);
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+
+    &:hover,
+    &:focus-visible {
+      border-color: var(--fd-accent, #00fff5);
+      background: rgba(var(--fd-accent-rgb, 0, 255, 245), 0.18);
+      outline: none;
+    }
+  }
 }
+
+.apps-error { color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.55); }
 
 // === 启动错误 Toast ===
 .launch-error-toast {


### PR DESCRIPTION
## 改了啥呀

- 大屏应用列表加载前等待本地 Sunshine 代理真正就绪，并使用就绪命令返回的实际端口
- 请求失败时展示明确的错误和重试入口，不再把网络错误装成“0 个应用”
- 补充中英文错误与重试文案

## 为啥要改

冷启动时大屏窗口会先于本地代理完成初始化，第一次 `/api/apps` 请求可能撞上尚未监听的端口。异常又被原来的空状态吞掉了，于是这个小杂鱼竞态要第二次进入才肯交出应用列表。

## 验证

- `git diff --check`
- `npm run build:renderer`

生产构建通过；Rolldown 的依赖注释与大 chunk 提示为项目现有警告。
