### PR TITLE
fix(ai): preserve keys across proxy recovery

### DIFF
--- a/src/renderer/tool-window/tools/PetSettingsTool.vue
+++ b/src/renderer/tool-window/tools/PetSettingsTool.vue
@@ -265,6 +265,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
 import { useI18n } from '../../desktop/i18n/index.js'
 import { STORAGE_KEY, DEFAULT_CONFIG } from '../../composables/aiProviders.js'
 import { isApiKeyRequired } from '../../composables/aiClient.js'
@@ -322,6 +323,7 @@ const jitterPercent = ref(loadJitterPercent())
 const visionEnabled = ref(loadVisionEnabled())
 const visionIntervalSec = ref(loadVisionIntervalSec())
 const aiConfigVersion = ref(0)
+const serverAiConfig = ref(null)
 const visionConfirmPending = ref(false)
 const visionConfirmOpen = ref(false)
 let tabTouchStart = null
@@ -332,12 +334,24 @@ const aiConfigReady = computed(() => {
   if (!Number.isFinite(configVersion)) return false
   try {
     const saved = localStorage.getItem(STORAGE_KEY)
-    const cfg = saved ? { ...DEFAULT_CONFIG, ...JSON.parse(saved) } : { ...DEFAULT_CONFIG }
+    const localConfig = saved ? { ...DEFAULT_CONFIG, ...JSON.parse(saved) } : { ...DEFAULT_CONFIG }
+    const cfg = serverAiConfig.value || localConfig
     return !!(cfg.enabled && (cfg.apiKey?.trim() || cfg.apiKeyConfigured || !isApiKeyRequired(cfg)))
   } catch {
     return false
   }
 })
+
+async function refreshAiConfigStatus() {
+  try {
+    const proxyUrl = await invoke('get_proxy_url_command')
+    const response = await fetch(`${proxyUrl}/api/ai/config`)
+    if (!response.ok) throw new Error(`Failed to load AI configuration (${response.status})`)
+    serverAiConfig.value = { ...DEFAULT_CONFIG, ...(await response.json()), apiKey: '' }
+  } catch {
+    serverAiConfig.value = null
+  }
+}
 
 const visionToggleDisabled = computed(() => !masterEnabled.value || !aiConfigReady.value)
 
@@ -590,9 +604,9 @@ function syncSettingFromStorage(event) {
 
   if (event.key === STORAGE_KEY) {
     aiConfigVersion.value += 1
-    if (!aiConfigReady.value && visionEnabled.value) {
-      visionEnabled.value = false
-    }
+    void refreshAiConfigStatus().then(() => {
+      if (!aiConfigReady.value && visionEnabled.value) visionEnabled.value = false
+    })
     return
   }
 
@@ -610,7 +624,10 @@ function syncSettingFromStorage(event) {
   Promise.resolve().then(() => { suppressWatch = false })
 }
 
-onMounted(() => window.addEventListener('storage', syncSettingFromStorage))
+onMounted(() => {
+  window.addEventListener('storage', syncSettingFromStorage)
+  void refreshAiConfigStatus()
+})
 onUnmounted(() => window.removeEventListener('storage', syncSettingFromStorage))
 </script>
 

--- a/src/renderer/tool-window/tools/PetSettingsTool.vue
+++ b/src/renderer/tool-window/tools/PetSettingsTool.vue
@@ -327,6 +327,11 @@ const serverAiConfig = ref(null)
 const visionConfirmPending = ref(false)
 const visionConfirmOpen = ref(false)
 let tabTouchStart = null
+let aiConfigRefreshGeneration = 0
+
+function hasUsableApiKey(key) {
+  return typeof key === 'string' && Boolean(key.trim()) && !key.includes('****')
+}
 
 // AI 配置状态（决定桌面观察是否可用）
 const aiConfigReady = computed(() => {
@@ -336,21 +341,30 @@ const aiConfigReady = computed(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
     const localConfig = saved ? { ...DEFAULT_CONFIG, ...JSON.parse(saved) } : { ...DEFAULT_CONFIG }
     const cfg = serverAiConfig.value || localConfig
-    return !!(cfg.enabled && (cfg.apiKey?.trim() || cfg.apiKeyConfigured || !isApiKeyRequired(cfg)))
+    return !!(cfg.enabled && (hasUsableApiKey(cfg.apiKey) || cfg.apiKeyConfigured || !isApiKeyRequired(cfg)))
   } catch {
     return false
   }
 })
 
 async function refreshAiConfigStatus() {
+  const generation = ++aiConfigRefreshGeneration
   try {
     const proxyUrl = await invoke('get_proxy_url_command')
     const response = await fetch(`${proxyUrl}/api/ai/config`)
     if (!response.ok) throw new Error(`Failed to load AI configuration (${response.status})`)
-    serverAiConfig.value = { ...DEFAULT_CONFIG, ...(await response.json()), apiKey: '' }
+    const remoteConfig = await response.json()
+    if (generation !== aiConfigRefreshGeneration) return false
+    serverAiConfig.value = { ...DEFAULT_CONFIG, ...remoteConfig, apiKey: '' }
   } catch {
+    if (generation !== aiConfigRefreshGeneration) return false
     serverAiConfig.value = null
   }
+  return true
+}
+
+function correctVisionEnabled() {
+  if (!aiConfigReady.value && visionEnabled.value) visionEnabled.value = false
 }
 
 const visionToggleDisabled = computed(() => !masterEnabled.value || !aiConfigReady.value)
@@ -604,8 +618,8 @@ function syncSettingFromStorage(event) {
 
   if (event.key === STORAGE_KEY) {
     aiConfigVersion.value += 1
-    void refreshAiConfigStatus().then(() => {
-      if (!aiConfigReady.value && visionEnabled.value) visionEnabled.value = false
+    void refreshAiConfigStatus().then((applied) => {
+      if (applied) correctVisionEnabled()
     })
     return
   }
@@ -626,7 +640,9 @@ function syncSettingFromStorage(event) {
 
 onMounted(() => {
   window.addEventListener('storage', syncSettingFromStorage)
-  void refreshAiConfigStatus()
+  void refreshAiConfigStatus().then((applied) => {
+    if (applied) correctVisionEnabled()
+  })
 })
 onUnmounted(() => window.removeEventListener('storage', syncSettingFromStorage))
 </script>

--- a/src/renderer/toolbar/ToolbarApp.vue
+++ b/src/renderer/toolbar/ToolbarApp.vue
@@ -312,13 +312,15 @@ const rt = () => t.value.petTool?.runtime || {}
 const getAiConfig = async (signal) => {
   let localConfig
   let legacyKey = ''
+  let sanitizedStoredConfig = null
   try {
     const saved = localStorage.getItem(STORAGE_KEY)
     const parsed = saved ? JSON.parse(saved) : {}
     legacyKey = typeof parsed.apiKey === 'string' && !parsed.apiKey.includes('****') ? parsed.apiKey : ''
     delete parsed.apiKey
+    sanitizedStoredConfig = parsed
     localConfig = { ...DEFAULT_CONFIG, ...parsed, apiKey: '' }
-    if (saved) localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed))
+    if (saved && !legacyKey) localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed))
   } catch {
     localConfig = { ...DEFAULT_CONFIG, apiKey: '' }
   }
@@ -336,6 +338,7 @@ const getAiConfig = async (signal) => {
       if (!migration.ok || migrationResult.status === 'error') {
         throw new Error(migrationResult.error || `Failed to migrate AI credential (${migration.status})`)
       }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizedStoredConfig))
     }
     const response = await fetch(`${proxyUrl}/api/ai/config`, { signal })
     if (response.ok) return { ...localConfig, ...(await response.json()), apiKey: '' }


### PR DESCRIPTION
## 改了啥呀

- Toolbar 仅在服务端凭据迁移成功后清理旧 WebView key
- 迁移失败时保留原值供下次重试，但绝不把 key 交给 Vision 请求
- PetSettings 挂载和配置变化时读取服务端 AI 状态，环境变量或 DPAPI key 不再被误判为未配置

## 为啥要改

原来的迁移顺序在 Sunshine 暂时离线时可能先删掉唯一一份旧 key；独立工具窗口也可能只看见过期 localStorage。两个杂鱼边缘状态一起收掉啦。

## 验证

- `npm run build:renderer`
- `git diff --check`