### PR TITLE
fix(tray): keep recovery controls available offline

### DIFF
--- a/src-tauri/src/sunshine.rs
+++ b/src-tauri/src/sunshine.rs
@@ -474,7 +474,7 @@ pub struct TrayOperationState {
     pub error: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct TrayState {
     #[serde(default)]
     pub protocol_version: u32,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -81,7 +81,6 @@ fn emit_tray_locale_changed<R: Runtime>(
 // Last icon name applied from the Sunshine core state. This avoids repeatedly
 // decoding the same .ico file during the polling loop.
 static CURRENT_CORE_ICON: Mutex<Option<String>> = Mutex::new(None);
-static CURRENT_TRAY_STATE: Mutex<Option<sunshine::TrayState>> = Mutex::new(None);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CoreConnectionState {
@@ -90,8 +89,95 @@ enum CoreConnectionState {
     Disconnected,
 }
 
-static CORE_CONNECTION_STATE: Mutex<CoreConnectionState> =
-    Mutex::new(CoreConnectionState::Connecting);
+#[derive(Default)]
+struct RecoveryState {
+    last_attempt: u64,
+    active_attempt: Option<u64>,
+}
+
+impl RecoveryState {
+    fn begin(&mut self) -> Option<u64> {
+        if self.active_attempt.is_some() {
+            return None;
+        }
+        self.last_attempt = self.last_attempt.wrapping_add(1).max(1);
+        self.active_attempt = Some(self.last_attempt);
+        self.active_attempt
+    }
+
+    fn finish(&mut self, attempt: u64) -> bool {
+        if self.active_attempt != Some(attempt) {
+            return false;
+        }
+        self.active_attempt = None;
+        true
+    }
+
+    fn complete_active(&mut self) -> bool {
+        self.active_attempt.take().is_some()
+    }
+
+    fn is_in_progress(&self) -> bool {
+        self.active_attempt.is_some()
+    }
+}
+
+struct TrayRuntimeState {
+    connection: CoreConnectionState,
+    tray_state: Option<sunshine::TrayState>,
+    recovery: RecoveryState,
+}
+
+impl TrayRuntimeState {
+    fn menu_snapshot(&self) -> (Option<sunshine::TrayState>, CoreConnectionState, bool) {
+        (
+            self.tray_state.clone(),
+            self.connection,
+            self.recovery.is_in_progress(),
+        )
+    }
+
+    fn begin_recovery_if_disconnected(&mut self) -> Option<u64> {
+        if self.connection != CoreConnectionState::Disconnected {
+            return None;
+        }
+        self.recovery.begin()
+    }
+
+    fn apply_connected_state(
+        &mut self,
+        state: &sunshine::TrayState,
+    ) -> (Option<sunshine::TrayState>, bool) {
+        // A state response from Core is the authoritative recovery-success signal.
+        let recovery_completed = self.recovery.complete_active();
+        let connection_changed = self.connection != CoreConnectionState::Connected;
+        self.connection = CoreConnectionState::Connected;
+
+        let previous_state = self.tray_state.clone();
+        let state_changed = self.tray_state.as_ref() != Some(state);
+        self.tray_state = Some(state.clone());
+
+        (
+            previous_state,
+            connection_changed || state_changed || recovery_completed,
+        )
+    }
+
+    fn mark_disconnected(&mut self) -> bool {
+        let connection_changed = self.connection != CoreConnectionState::Disconnected;
+        self.connection = CoreConnectionState::Disconnected;
+        connection_changed || self.tray_state.take().is_some()
+    }
+}
+
+static TRAY_RUNTIME_STATE: Mutex<TrayRuntimeState> = Mutex::new(TrayRuntimeState {
+    connection: CoreConnectionState::Connecting,
+    tray_state: None,
+    recovery: RecoveryState {
+        last_attempt: 0,
+        active_attempt: None,
+    },
+});
 
 static MAIN_PANEL_BRIDGE: main_panel::Bridge = main_panel::Bridge::new();
 
@@ -187,6 +273,8 @@ struct TrayStrings {
     visit_project_sunshine: &'static str,
     visit_project_moonlight: &'static str,
     restart: &'static str,
+    recover_service: &'static str,
+    recovery_timeout: &'static str,
     tooltip: &'static str,
     tooltip_admin: &'static str,
 }
@@ -257,6 +345,8 @@ const ZH_STRINGS: TrayStrings = TrayStrings {
     visit_project_sunshine: "Sunshine 源代码",
     visit_project_moonlight: "Moonlight 源代码",
     restart: "重启 Sunshine",
+    recover_service: "重新启动 Sunshine 服务",
+    recovery_timeout: "Sunshine 服务未能在等待时间内恢复，请检查服务日志后重试。",
     tooltip: "Sunshine GUI",
     tooltip_admin: "Sunshine GUI (管理员)",
 };
@@ -327,6 +417,8 @@ const EN_STRINGS: TrayStrings = TrayStrings {
     visit_project_sunshine: "Sunshine Source Code",
     visit_project_moonlight: "Moonlight Source Code",
     restart: "Restart Sunshine",
+    recover_service: "Restart Sunshine Service",
+    recovery_timeout: "The Sunshine service did not recover in time. Check the service log and try again.",
     tooltip: "Sunshine GUI",
     tooltip_admin: "Sunshine GUI (Admin)",
 };
@@ -397,6 +489,8 @@ const JA_STRINGS: TrayStrings = TrayStrings {
     visit_project_sunshine: "Sunshine ソースコード",
     visit_project_moonlight: "Moonlight ソースコード",
     restart: "Sunshine を再起動",
+    recover_service: "Sunshine サービスを再起動",
+    recovery_timeout: "Sunshine サービスが時間内に復旧しませんでした。サービスログを確認して再試行してください。",
     tooltip: "Sunshine GUI",
     tooltip_admin: "Sunshine GUI (管理者)",
 };
@@ -843,34 +937,55 @@ mod tests {
         assert_eq!(compact_menu_text("1234567890", 8), "12345...");
         assert_eq!(compact_menu_text("  short  ", 8), "short");
     }
+
+    #[test]
+    fn recovery_state_rejects_duplicate_and_stale_completion() {
+        let mut recovery = RecoveryState::default();
+
+        let first = recovery.begin().expect("first recovery should start");
+        assert!(recovery.is_in_progress());
+        assert_eq!(recovery.begin(), None);
+        assert!(!recovery.finish(first + 1));
+        assert!(recovery.finish(first));
+        assert!(!recovery.is_in_progress());
+
+        let second = recovery.begin().expect("second recovery should start");
+        assert_ne!(second, first);
+        assert!(!recovery.finish(first));
+        assert!(recovery.complete_active());
+        assert!(!recovery.complete_active());
+    }
+
+    #[test]
+    fn runtime_state_applies_connection_transitions_atomically() {
+        let mut runtime = TrayRuntimeState {
+            connection: CoreConnectionState::Connecting,
+            tray_state: None,
+            recovery: RecoveryState::default(),
+        };
+        assert_eq!(runtime.begin_recovery_if_disconnected(), None);
+
+        assert!(runtime.mark_disconnected());
+        assert!(!runtime.mark_disconnected());
+        assert!(runtime.begin_recovery_if_disconnected().is_some());
+
+        let state = tray_state("idle");
+        let (previous, should_rebuild) = runtime.apply_connected_state(&state);
+        assert!(previous.is_none());
+        assert!(should_rebuild);
+
+        let (_, connection, recovery_in_progress) = runtime.menu_snapshot();
+        assert_eq!(connection, CoreConnectionState::Connected);
+        assert!(!recovery_in_progress);
+        assert!(!runtime.apply_connected_state(&state).1);
+    }
 }
 
 fn apply_tray_state<R: Runtime + 'static>(app: &AppHandle<R>, state: &sunshine::TrayState) {
-    let connection_changed = {
-        let mut connection = CORE_CONNECTION_STATE.lock().unwrap();
-        let changed = *connection != CoreConnectionState::Connected;
-        *connection = CoreConnectionState::Connected;
-        changed
+    let (previous_state, should_rebuild_menu) = {
+        let mut runtime = TRAY_RUNTIME_STATE.lock().unwrap();
+        runtime.apply_connected_state(state)
     };
-    let state_changed = {
-        let mut current_state = CURRENT_TRAY_STATE.lock().unwrap();
-        let previous_state = current_state.clone();
-        let changed = current_state
-            .as_ref()
-            .map(|current_state| {
-                current_state.status != state.status
-                    || current_state.app_name != state.app_name
-                    || current_state.pairing_client_name != state.pairing_client_name
-                    || current_state.sessions != state.sessions
-                    || current_state.vdd != state.vdd
-                    || current_state.notification != state.notification
-            })
-            .unwrap_or(true);
-        *current_state = Some(state.clone());
-        (changed, previous_state)
-    };
-    let (state_changed, previous_state) = state_changed;
-    let should_rebuild_menu = connection_changed || state_changed;
 
     if state.owner != "gui" {
         if app.remove_tray_by_id(TRAY_ID).is_some() {
@@ -906,22 +1021,16 @@ fn apply_tray_state<R: Runtime + 'static>(app: &AppHandle<R>, state: &sunshine::
 }
 
 fn apply_core_disconnected<R: Runtime + 'static>(app: &AppHandle<R>) {
-    let connection_changed = {
-        let mut connection = CORE_CONNECTION_STATE.lock().unwrap();
-        let changed = *connection != CoreConnectionState::Disconnected;
-        *connection = CoreConnectionState::Disconnected;
-        changed
-    };
-    let had_state = CURRENT_TRAY_STATE.lock().unwrap().take().is_some();
+    let should_rebuild_menu = TRAY_RUNTIME_STATE.lock().unwrap().mark_disconnected();
 
     if let Err(e) = build_owned_system_tray(app) {
         error!(
-            "Failed to keep GUI tray available during the Core reconnect window: {}",
+            "Failed to keep GUI tray available while Core is unavailable: {}",
             e
         );
         return;
     }
-    if connection_changed || had_state {
+    if should_rebuild_menu {
         rebuild_tray_menu(app);
     }
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
@@ -929,7 +1038,7 @@ fn apply_core_disconnected<R: Runtime + 'static>(app: &AppHandle<R>) {
             tray_status_label(get_tray_strings(), None, CoreConnectionState::Disconnected);
         let _ = tray.set_tooltip(Some(tooltip.as_str()));
     }
-    icons::apply_tray_icon(app, "default");
+    icons::apply_disconnected_tray_icon(app);
 }
 
 fn apply_tray_state_on_main_thread<R: Runtime + 'static>(
@@ -1046,12 +1155,18 @@ fn rebuild_tray_menu<R: Runtime>(app: &AppHandle<R>) {
                     error!("❌ 重建托盘菜单失败: {}", e);
                 }
                 // 更新 tooltip
-                let tooltip = CURRENT_TRAY_STATE
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .map(tray_tooltip_from_state)
-                    .unwrap_or_else(|| default_tray_tooltip().to_string());
+                let tooltip = {
+                    let runtime = TRAY_RUNTIME_STATE.lock().unwrap();
+                    if runtime.connection == CoreConnectionState::Connected {
+                        runtime
+                            .tray_state
+                            .as_ref()
+                            .map(tray_tooltip_from_state)
+                            .unwrap_or_else(|| default_tray_tooltip().to_string())
+                    } else {
+                        tray_status_label(get_tray_strings(), None, runtime.connection)
+                    }
+                };
                 let _ = tray.set_tooltip(Some(tooltip));
             }
             Err(e) => error!("❌ 构建托盘菜单失败: {}", e),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -81,6 +81,7 @@ fn emit_tray_locale_changed<R: Runtime>(
 // Last icon name applied from the Sunshine core state. This avoids repeatedly
 // decoding the same .ico file during the polling loop.
 static CURRENT_CORE_ICON: Mutex<Option<String>> = Mutex::new(None);
+static MONITORED_STATE_RECEIPT: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CoreConnectionState {
@@ -92,29 +93,36 @@ enum CoreConnectionState {
 #[derive(Default)]
 struct RecoveryState {
     last_attempt: u64,
-    active_attempt: Option<u64>,
+    active_attempt: Option<(u64, u64)>,
 }
 
 impl RecoveryState {
-    fn begin(&mut self) -> Option<u64> {
+    fn begin(&mut self, monitored_state_baseline: u64) -> Option<u64> {
         if self.active_attempt.is_some() {
             return None;
         }
         self.last_attempt = self.last_attempt.wrapping_add(1).max(1);
-        self.active_attempt = Some(self.last_attempt);
-        self.active_attempt
+        self.active_attempt = Some((self.last_attempt, monitored_state_baseline));
+        Some(self.last_attempt)
     }
 
     fn finish(&mut self, attempt: u64) -> bool {
-        if self.active_attempt != Some(attempt) {
+        if self.active_attempt.map(|active| active.0) != Some(attempt) {
             return false;
         }
         self.active_attempt = None;
         true
     }
 
-    fn complete_active(&mut self) -> bool {
-        self.active_attempt.take().is_some()
+    fn complete_from_monitored_state(&mut self, receipt: u64) -> bool {
+        let Some((_, baseline)) = self.active_attempt else {
+            return false;
+        };
+        if receipt <= baseline {
+            return false;
+        }
+        self.active_attempt = None;
+        true
     }
 
     fn is_in_progress(&self) -> bool {
@@ -137,19 +145,25 @@ impl TrayRuntimeState {
         )
     }
 
-    fn begin_recovery_if_disconnected(&mut self) -> Option<u64> {
+    fn begin_recovery_if_disconnected(&mut self, monitored_state_baseline: u64) -> Option<u64> {
         if self.connection != CoreConnectionState::Disconnected {
             return None;
         }
-        self.recovery.begin()
+        self.recovery.begin(monitored_state_baseline)
     }
 
     fn apply_connected_state(
         &mut self,
         state: &sunshine::TrayState,
-    ) -> (Option<sunshine::TrayState>, bool) {
-        // A state response from Core is the authoritative recovery-success signal.
-        let recovery_completed = self.recovery.complete_active();
+        monitored_state_receipt: Option<u64>,
+    ) -> Option<(Option<sunshine::TrayState>, bool)> {
+        if monitored_state_receipt.is_none() && self.connection != CoreConnectionState::Connected {
+            return None;
+        }
+        // Only a monitor response accepted after recovery began is authoritative.
+        // Action responses may already be in flight when the attempt starts.
+        let recovery_completed = monitored_state_receipt
+            .is_some_and(|receipt| self.recovery.complete_from_monitored_state(receipt));
         let connection_changed = self.connection != CoreConnectionState::Connected;
         self.connection = CoreConnectionState::Connected;
 
@@ -157,10 +171,10 @@ impl TrayRuntimeState {
         let state_changed = self.tray_state.as_ref() != Some(state);
         self.tray_state = Some(state.clone());
 
-        (
+        Some((
             previous_state,
             connection_changed || state_changed || recovery_completed,
-        )
+        ))
     }
 
     fn mark_disconnected(&mut self) -> bool {
@@ -942,18 +956,19 @@ mod tests {
     fn recovery_state_rejects_duplicate_and_stale_completion() {
         let mut recovery = RecoveryState::default();
 
-        let first = recovery.begin().expect("first recovery should start");
+        let first = recovery.begin(7).expect("first recovery should start");
         assert!(recovery.is_in_progress());
-        assert_eq!(recovery.begin(), None);
+        assert_eq!(recovery.begin(7), None);
         assert!(!recovery.finish(first + 1));
         assert!(recovery.finish(first));
         assert!(!recovery.is_in_progress());
 
-        let second = recovery.begin().expect("second recovery should start");
+        let second = recovery.begin(11).expect("second recovery should start");
         assert_ne!(second, first);
         assert!(!recovery.finish(first));
-        assert!(recovery.complete_active());
-        assert!(!recovery.complete_active());
+        assert!(!recovery.complete_from_monitored_state(11));
+        assert!(recovery.complete_from_monitored_state(12));
+        assert!(!recovery.complete_from_monitored_state(13));
     }
 
     #[test]
@@ -963,28 +978,44 @@ mod tests {
             tray_state: None,
             recovery: RecoveryState::default(),
         };
-        assert_eq!(runtime.begin_recovery_if_disconnected(), None);
+        assert_eq!(runtime.begin_recovery_if_disconnected(3), None);
 
         assert!(runtime.mark_disconnected());
         assert!(!runtime.mark_disconnected());
-        assert!(runtime.begin_recovery_if_disconnected().is_some());
+        assert!(runtime.begin_recovery_if_disconnected(3).is_some());
 
         let state = tray_state("idle");
-        let (previous, should_rebuild) = runtime.apply_connected_state(&state);
+        assert!(runtime.apply_connected_state(&state, None).is_none());
+        let (previous, should_rebuild) = runtime
+            .apply_connected_state(&state, Some(4))
+            .expect("fresh monitor state should be accepted");
         assert!(previous.is_none());
         assert!(should_rebuild);
 
         let (_, connection, recovery_in_progress) = runtime.menu_snapshot();
         assert_eq!(connection, CoreConnectionState::Connected);
         assert!(!recovery_in_progress);
-        assert!(!runtime.apply_connected_state(&state).1);
+        assert!(
+            !runtime
+                .apply_connected_state(&state, Some(5))
+                .expect("connected monitor state should be accepted")
+                .1
+        );
     }
 }
 
-fn apply_tray_state<R: Runtime + 'static>(app: &AppHandle<R>, state: &sunshine::TrayState) {
-    let (previous_state, should_rebuild_menu) = {
+fn apply_tray_state<R: Runtime + 'static>(
+    app: &AppHandle<R>,
+    state: &sunshine::TrayState,
+    monitored_state_receipt: Option<u64>,
+) {
+    let applied = {
         let mut runtime = TRAY_RUNTIME_STATE.lock().unwrap();
-        runtime.apply_connected_state(state)
+        runtime.apply_connected_state(state, monitored_state_receipt)
+    };
+    let Some((previous_state, should_rebuild_menu)) = applied else {
+        debug!("Ignored non-monitor tray state while Core is unavailable");
+        return;
     };
 
     if state.owner != "gui" {
@@ -1047,9 +1078,25 @@ fn apply_tray_state_on_main_thread<R: Runtime + 'static>(
 ) {
     let app_handle = app.clone();
     if let Err(e) = app.run_on_main_thread(move || {
-        apply_tray_state(&app_handle, &state);
+        apply_tray_state(&app_handle, &state, None);
     }) {
         debug!("Failed to schedule tray state update on main thread: {}", e);
+    }
+}
+
+fn apply_monitored_tray_state_on_main_thread<R: Runtime + 'static>(
+    app: &AppHandle<R>,
+    state: sunshine::TrayState,
+) {
+    let receipt = MONITORED_STATE_RECEIPT.fetch_add(1, Ordering::AcqRel) + 1;
+    let app_handle = app.clone();
+    if let Err(e) = app.run_on_main_thread(move || {
+        apply_tray_state(&app_handle, &state, Some(receipt));
+    }) {
+        debug!(
+            "Failed to schedule monitored tray state update on main thread: {}",
+            e
+        );
     }
 }
 

--- a/src-tauri/src/tray/actions.rs
+++ b/src-tauri/src/tray/actions.rs
@@ -317,7 +317,7 @@ fn recover_sunshine_service<R: Runtime>(app: &AppHandle<R>) {
     let Some(attempt) = TRAY_RUNTIME_STATE
         .lock()
         .unwrap()
-        .begin_recovery_if_disconnected()
+        .begin_recovery_if_disconnected(MONITORED_STATE_RECEIPT.load(Ordering::Acquire))
     else {
         return;
     };

--- a/src-tauri/src/tray/actions.rs
+++ b/src-tauri/src/tray/actions.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(target_os = "windows")]
+const RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn handle_tray_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, menu_id: &str) {
     let s = get_tray_strings();
     match menu_id {
@@ -12,6 +15,8 @@ pub fn handle_tray_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, menu_id:
         }
         #[cfg(target_os = "windows")]
         "auto_start" => toggle_auto_start(app),
+        #[cfg(target_os = "windows")]
+        "recover_service" => recover_sunshine_service(app),
         "vdd_settings" => open_vdd_settings(app),
         "vdd_create" => run_vdd_create_action(app, s.vdd_create, s.vdd_create_confirm),
         "vdd_close" => run_tray_action(app, "vdd_destroy", None),
@@ -84,9 +89,10 @@ pub fn handle_tray_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, menu_id:
 
 /// 打开 VDD 设置
 fn handle_tray_notification_action<R: Runtime>(app: &AppHandle<R>) {
-    let (notification, supports_ack) = CURRENT_TRAY_STATE
+    let (notification, supports_ack) = TRAY_RUNTIME_STATE
         .lock()
         .unwrap()
+        .tray_state
         .as_ref()
         .map(|state| {
             (
@@ -182,9 +188,10 @@ fn run_vdd_toggle_action<R: Runtime + 'static>(
     enable_title: &'static str,
     enable_message: &'static str,
 ) {
-    let enabled = CURRENT_TRAY_STATE
+    let enabled = TRAY_RUNTIME_STATE
         .lock()
         .unwrap()
+        .tray_state
         .as_ref()
         .map(|state| !current_value(state));
 
@@ -302,6 +309,63 @@ fn restart_sunshine<R: Runtime>(app: &AppHandle<R>) {
                 emit_message(&app_handle, "error", &error);
             }
         }
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn recover_sunshine_service<R: Runtime>(app: &AppHandle<R>) {
+    let Some(attempt) = TRAY_RUNTIME_STATE
+        .lock()
+        .unwrap()
+        .begin_recovery_if_disconnected()
+    else {
+        return;
+    };
+    rebuild_tray_menu(app);
+
+    let app_handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = sunshine::restart_sunshine_service().await {
+            if finish_recovery_attempt(attempt) {
+                error!("Failed to recover Sunshine service from tray: {}", error);
+                refresh_recovery_menu(&app_handle);
+                let error_handle = app_handle.clone();
+                let _ = app_handle.run_on_main_thread(move || {
+                    emit_message(&error_handle, "error", &error);
+                });
+            }
+            return;
+        }
+
+        tokio::time::sleep(RECOVERY_TIMEOUT).await;
+        if finish_recovery_attempt(attempt) {
+            warn!(
+                "Sunshine service recovery attempt {} timed out after {:?}",
+                attempt, RECOVERY_TIMEOUT
+            );
+            refresh_recovery_menu(&app_handle);
+            let timeout_handle = app_handle.clone();
+            let _ = app_handle.run_on_main_thread(move || {
+                emit_message(
+                    &timeout_handle,
+                    "error",
+                    get_tray_strings().recovery_timeout,
+                );
+            });
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn finish_recovery_attempt(attempt: u64) -> bool {
+    TRAY_RUNTIME_STATE.lock().unwrap().recovery.finish(attempt)
+}
+
+#[cfg(target_os = "windows")]
+fn refresh_recovery_menu<R: Runtime>(app: &AppHandle<R>) {
+    let recovery_handle = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        rebuild_tray_menu(&recovery_handle);
     });
 }
 

--- a/src-tauri/src/tray/events.rs
+++ b/src-tauri/src/tray/events.rs
@@ -1,28 +1,23 @@
 use super::*;
 use futures_util::StreamExt as _;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 const RECONNECT_DELAY: Duration = Duration::from_secs(3);
 const LEGACY_POLL_INTERVAL: Duration = Duration::from_secs(3);
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(30);
-const CORE_DISCONNECT_GRACE_PERIOD: Duration = Duration::from_secs(15);
-
 pub(super) fn start_tray_state_monitoring<R: Runtime + 'static>(app: &AppHandle<R>) {
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         let mut last_state_key: Option<(String, u64)> = None;
         let mut contract_error_visible = false;
-        let mut disconnected_since: Option<Instant> = None;
-        let mut tray_removed_for_disconnect = false;
+        let mut disconnected = false;
 
         loop {
             match sunshine::get_tray_state().await {
                 Ok(state) => {
                     contract_error_visible = false;
-                    let recovered = disconnected_since.is_some();
-                    let force_reconcile = recovered || tray_removed_for_disconnect;
-                    disconnected_since = None;
-                    tray_removed_for_disconnect = false;
+                    let force_reconcile = disconnected;
+                    disconnected = false;
                     let supports_events = state
                         .capabilities
                         .iter()
@@ -40,17 +35,9 @@ pub(super) fn start_tray_state_monitoring<R: Runtime + 'static>(app: &AppHandle<
                     }
                 }
                 Err(e) => {
-                    if disconnected_since.is_none() {
-                        disconnected_since = Some(Instant::now());
+                    if !disconnected {
+                        disconnected = true;
                         mark_core_disconnected(&app_handle);
-                    }
-
-                    if !tray_removed_for_disconnect
-                        && disconnected_since
-                            .is_some_and(|since| since.elapsed() >= CORE_DISCONNECT_GRACE_PERIOD)
-                    {
-                        remove_tray_after_core_disconnect(&app_handle);
-                        tray_removed_for_disconnect = true;
                     }
 
                     let is_contract_error = e.contains("tray protocol")
@@ -121,14 +108,12 @@ fn apply_if_new<R: Runtime + 'static>(
     state: sunshine::TrayState,
     force_reconcile: bool,
 ) {
-    let is_new = match last_state_key.as_ref() {
-        Some((instance_id, revision)) if instance_id == &state.instance_id => {
-            state.revision > *revision
-        }
-        _ => true,
-    };
-    if is_new || force_reconcile {
-        *last_state_key = Some((state.instance_id.clone(), state.revision));
+    if accept_state_revision(
+        last_state_key,
+        &state.instance_id,
+        state.revision,
+        force_reconcile,
+    ) {
         #[cfg(target_os = "windows")]
         if state.vdd.awaiting_confirmation && state.vdd.confirmation_operation_id != 0 {
             vdd_confirmation::show(app, state.vdd.confirmation_operation_id);
@@ -137,30 +122,31 @@ fn apply_if_new<R: Runtime + 'static>(
     }
 }
 
+fn accept_state_revision(
+    last_state_key: &mut Option<(String, u64)>,
+    instance_id: &str,
+    revision: u64,
+    force_reconcile: bool,
+) -> bool {
+    let is_new = match last_state_key.as_ref() {
+        Some((current_instance_id, current_revision)) if current_instance_id == instance_id => {
+            revision > *current_revision
+        }
+        _ => true,
+    };
+    if !is_new && !force_reconcile {
+        return false;
+    }
+    *last_state_key = Some((instance_id.to_string(), revision));
+    true
+}
+
 fn mark_core_disconnected<R: Runtime + 'static>(app: &AppHandle<R>) {
     let disconnect_handle = app.clone();
     if let Err(e) = app.run_on_main_thread(move || {
         apply_core_disconnected(&disconnect_handle);
     }) {
         debug!("Failed to schedule disconnected tray state: {}", e);
-    }
-}
-
-fn remove_tray_after_core_disconnect<R: Runtime + 'static>(app: &AppHandle<R>) {
-    let app_handle = app.clone();
-    if let Err(e) = app.run_on_main_thread(move || {
-        // A successful Core response may already be queued on the main thread.
-        // Do not remove a tray that has been restored in the meantime.
-        if *CORE_CONNECTION_STATE.lock().unwrap() != CoreConnectionState::Disconnected {
-            return;
-        }
-
-        if app_handle.remove_tray_by_id(TRAY_ID).is_some() {
-            info!("Removed GUI tray because Sunshine Core did not recover");
-        }
-        *CURRENT_CORE_ICON.lock().unwrap() = None;
-    }) {
-        debug!("Failed to remove disconnected GUI tray: {}", e);
     }
 }
 
@@ -237,5 +223,22 @@ mod tests {
                 .expect("valid comment")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn revision_cursor_handles_reconnect_and_core_restart() {
+        let mut cursor = None;
+
+        assert!(accept_state_revision(&mut cursor, "core-a", 7, false));
+        assert!(!accept_state_revision(&mut cursor, "core-a", 7, false));
+        assert!(!accept_state_revision(&mut cursor, "core-a", 6, false));
+        assert!(accept_state_revision(&mut cursor, "core-a", 8, false));
+
+        // A restarted Core has a new instance id and may restart its revision at zero.
+        assert!(accept_state_revision(&mut cursor, "core-b", 0, false));
+        assert_eq!(cursor, Some(("core-b".to_string(), 0)));
+
+        // After an observed disconnect, equal state is applied to reconcile the UI.
+        assert!(accept_state_revision(&mut cursor, "core-b", 0, true));
     }
 }

--- a/src-tauri/src/tray/events.rs
+++ b/src-tauri/src/tray/events.rs
@@ -118,7 +118,7 @@ fn apply_if_new<R: Runtime + 'static>(
         if state.vdd.awaiting_confirmation && state.vdd.confirmation_operation_id != 0 {
             vdd_confirmation::show(app, state.vdd.confirmation_operation_id);
         }
-        apply_tray_state_on_main_thread(app, state);
+        apply_monitored_tray_state_on_main_thread(app, state);
     }
 }
 

--- a/src-tauri/src/tray/icons.rs
+++ b/src-tauri/src/tray/icons.rs
@@ -57,10 +57,7 @@ pub(super) fn apply_disconnected_tray_icon<R: Runtime>(app: &AppHandle<R>) {
     };
     let file_name = "sunshine.ico";
     let icon_path = core_tray_icon_path(file_name);
-    let bytes =
-        std::fs::read(&icon_path).unwrap_or_else(|_| bundled_tray_icon_bytes(file_name).to_vec());
-
-    match decode_tray_icon(&bytes) {
+    match load_disconnected_icon(&icon_path, file_name) {
         Ok(mut image) => {
             grayscale(&mut image);
             if let Err(e) = tray.set_icon(Some(rgba_to_tauri_image(image))) {
@@ -71,6 +68,32 @@ pub(super) fn apply_disconnected_tray_icon<R: Runtime>(app: &AppHandle<R>) {
         }
         Err(e) => debug!("Failed to load disconnected tray icon: {}", e),
     }
+}
+
+fn load_disconnected_icon(path: &PathBuf, file_name: &str) -> Result<image::RgbaImage, String> {
+    if path.exists() {
+        match std::fs::read(path).map_err(|error| error.to_string()) {
+            Ok(bytes) => {
+                return decode_tray_icon_with_fallback(&bytes, bundled_tray_icon_bytes(file_name));
+            }
+            Err(error) => debug!(
+                "Failed to load disconnected core tray icon '{}': {}",
+                path.display(),
+                error
+            ),
+        }
+    }
+    decode_tray_icon(bundled_tray_icon_bytes(file_name))
+}
+
+fn decode_tray_icon_with_fallback(
+    bytes: &[u8],
+    fallback: &[u8],
+) -> Result<image::RgbaImage, String> {
+    decode_tray_icon(bytes).or_else(|error| {
+        debug!("Failed to decode custom tray icon: {}", error);
+        decode_tray_icon(fallback)
+    })
 }
 
 fn tray_icon_file_name(icon: &str) -> &'static str {
@@ -118,20 +141,21 @@ fn load_tray_icon_from_bytes(bytes: &'static [u8]) -> Result<Image<'static>, Str
 }
 
 fn decode_tray_icon(bytes: &[u8]) -> Result<image::RgbaImage, String> {
-    match select_small_ico_frame(bytes) {
-        Ok(selected_ico) => {
-            image::ImageReader::with_format(Cursor::new(selected_ico), image::ImageFormat::Ico)
-                .decode()
-                .map_err(|e| e.to_string())
-                .map(|image| image.to_rgba8())
-        }
-        Err(ico_error) => {
-            debug!("Failed to select small ICO frame: {}", ico_error);
+    let preferred_frame = select_small_ico_frame(bytes).and_then(|selected_ico| {
+        image::ImageReader::with_format(Cursor::new(selected_ico), image::ImageFormat::Ico)
+            .decode()
+            .map_err(|error| error.to_string())
+            .map(|image| image.to_rgba8())
+    });
+    match preferred_frame {
+        Ok(image) => Ok(image),
+        Err(error) => {
+            debug!("Failed to decode preferred ICO frame: {}", error);
             image::ImageReader::new(Cursor::new(bytes))
                 .with_guessed_format()
-                .map_err(|e| e.to_string())?
+                .map_err(|error| error.to_string())?
                 .decode()
-                .map_err(|e| e.to_string())
+                .map_err(|error| error.to_string())
                 .map(|image| image.to_rgba8())
         }
     }
@@ -249,5 +273,15 @@ mod tests {
         assert_eq!(pixel[0], pixel[1]);
         assert_eq!(pixel[1], pixel[2]);
         assert_eq!(pixel[3], 123);
+    }
+
+    #[test]
+    fn invalid_custom_icon_falls_back_to_bundled_icon() {
+        let image =
+            decode_tray_icon_with_fallback(b"not an icon", bundled_tray_icon_bytes("sunshine.ico"))
+                .expect("bundled icon should be used");
+
+        assert!(image.width() > 0);
+        assert!(image.height() > 0);
     }
 }

--- a/src-tauri/src/tray/icons.rs
+++ b/src-tauri/src/tray/icons.rs
@@ -43,6 +43,36 @@ pub(super) fn apply_tray_icon<R: Runtime>(app: &AppHandle<R>, icon: &str) {
     }
 }
 
+pub(super) fn apply_disconnected_tray_icon<R: Runtime>(app: &AppHandle<R>) {
+    const ICON_STATE: &str = "disconnected";
+    {
+        let current_icon = CURRENT_CORE_ICON.lock().unwrap();
+        if current_icon.as_deref() == Some(ICON_STATE) {
+            return;
+        }
+    }
+
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    let file_name = "sunshine.ico";
+    let icon_path = core_tray_icon_path(file_name);
+    let bytes =
+        std::fs::read(&icon_path).unwrap_or_else(|_| bundled_tray_icon_bytes(file_name).to_vec());
+
+    match decode_tray_icon(&bytes) {
+        Ok(mut image) => {
+            grayscale(&mut image);
+            if let Err(e) = tray.set_icon(Some(rgba_to_tauri_image(image))) {
+                debug!("Failed to apply disconnected tray icon: {}", e);
+                return;
+            }
+            *CURRENT_CORE_ICON.lock().unwrap() = Some(ICON_STATE.to_string());
+        }
+        Err(e) => debug!("Failed to load disconnected tray icon: {}", e),
+    }
+}
+
 fn tray_icon_file_name(icon: &str) -> &'static str {
     match icon {
         "playing" => "sunshine-playing.ico",
@@ -80,43 +110,40 @@ fn load_tray_icon(path: &PathBuf, file_name: &str) -> Result<Image<'static>, Str
 
 fn load_tray_icon_from_path(path: &PathBuf) -> Result<Image<'static>, String> {
     let bytes = std::fs::read(path).map_err(|e| e.to_string())?;
-    load_tray_icon_from_ico_bytes(&bytes).or_else(|e| {
-        debug!(
-            "Failed to select small ICO frame from '{}': {}",
-            path.display(),
-            e
-        );
-        let image = image::ImageReader::open(path)
-            .map_err(|e| e.to_string())?
-            .with_guessed_format()
-            .map_err(|e| e.to_string())?
-            .decode()
-            .map_err(|e| e.to_string())?
-            .to_rgba8();
-        Ok(rgba_to_tauri_image(image))
-    })
+    decode_tray_icon(&bytes).map(rgba_to_tauri_image)
 }
 
 fn load_tray_icon_from_bytes(bytes: &'static [u8]) -> Result<Image<'static>, String> {
-    load_tray_icon_from_ico_bytes(bytes).or_else(|e| {
-        debug!("Failed to select small bundled ICO frame: {}", e);
-        let image = image::ImageReader::new(Cursor::new(bytes))
-            .with_guessed_format()
-            .map_err(|e| e.to_string())?
-            .decode()
-            .map_err(|e| e.to_string())?
-            .to_rgba8();
-        Ok(rgba_to_tauri_image(image))
-    })
+    decode_tray_icon(bytes).map(rgba_to_tauri_image)
 }
 
-fn load_tray_icon_from_ico_bytes(bytes: &[u8]) -> Result<Image<'static>, String> {
-    let selected_ico = select_small_ico_frame(bytes)?;
-    let image = image::ImageReader::with_format(Cursor::new(selected_ico), image::ImageFormat::Ico)
-        .decode()
-        .map_err(|e| e.to_string())?
-        .to_rgba8();
-    Ok(rgba_to_tauri_image(image))
+fn decode_tray_icon(bytes: &[u8]) -> Result<image::RgbaImage, String> {
+    match select_small_ico_frame(bytes) {
+        Ok(selected_ico) => {
+            image::ImageReader::with_format(Cursor::new(selected_ico), image::ImageFormat::Ico)
+                .decode()
+                .map_err(|e| e.to_string())
+                .map(|image| image.to_rgba8())
+        }
+        Err(ico_error) => {
+            debug!("Failed to select small ICO frame: {}", ico_error);
+            image::ImageReader::new(Cursor::new(bytes))
+                .with_guessed_format()
+                .map_err(|e| e.to_string())?
+                .decode()
+                .map_err(|e| e.to_string())
+                .map(|image| image.to_rgba8())
+        }
+    }
+}
+
+fn grayscale(image: &mut image::RgbaImage) {
+    for pixel in image.pixels_mut() {
+        let [red, green, blue, alpha] = pixel.0;
+        let luminance =
+            ((u16::from(red) * 54 + u16::from(green) * 183 + u16::from(blue) * 19) >> 8) as u8;
+        pixel.0 = [luminance, luminance, luminance, alpha];
+    }
 }
 
 fn select_small_ico_frame(bytes: &[u8]) -> Result<Vec<u8>, String> {
@@ -206,4 +233,21 @@ fn ico_dimension(value: u8) -> u16 {
 fn rgba_to_tauri_image(image: image::RgbaImage) -> Image<'static> {
     let (width, height) = image.dimensions();
     Image::new_owned(image.into_raw(), width, height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grayscale_preserves_alpha_and_equalizes_color_channels() {
+        let mut image = image::RgbaImage::from_pixel(1, 1, image::Rgba([240, 80, 20, 123]));
+
+        grayscale(&mut image);
+
+        let pixel = image.get_pixel(0, 0).0;
+        assert_eq!(pixel[0], pixel[1]);
+        assert_eq!(pixel[1], pixel[2]);
+        assert_eq!(pixel[3], 123);
+    }
 }

--- a/src-tauri/src/tray/menu.rs
+++ b/src-tauri/src/tray/menu.rs
@@ -98,6 +98,7 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
         let runtime = TRAY_RUNTIME_STATE.lock().unwrap();
         runtime.menu_snapshot()
     };
+    let core_connected = connection == CoreConnectionState::Connected;
     let active_notification = tray_state
         .as_ref()
         .filter(|state| state.notification.active)
@@ -113,7 +114,7 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
         .as_ref()
         .map(|state| {
             (
-                true,
+                core_connected,
                 state
                     .capabilities
                     .iter()
@@ -172,8 +173,13 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
         desktop_settings::is_combined_auto_start_enabled(),
         None::<&str>,
     )?;
-    let open_sunshine =
-        MenuItem::with_id(app, "open_sunshine", s.open_sunshine, true, None::<&str>)?;
+    let open_sunshine = MenuItem::with_id(
+        app,
+        "open_sunshine",
+        s.open_sunshine,
+        core_connected,
+        None::<&str>,
+    )?;
     let interfaces_submenu = Submenu::with_id_and_items(
         app,
         "interfaces",
@@ -315,11 +321,27 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
         None::<&str>,
     )?;
 
-    let import_config =
-        MenuItem::with_id(app, "import_config", s.import_config, true, None::<&str>)?;
-    let export_config =
-        MenuItem::with_id(app, "export_config", s.export_config, true, None::<&str>)?;
-    let reset_config = MenuItem::with_id(app, "reset_config", s.reset_config, true, None::<&str>)?;
+    let import_config = MenuItem::with_id(
+        app,
+        "import_config",
+        s.import_config,
+        core_connected,
+        None::<&str>,
+    )?;
+    let export_config = MenuItem::with_id(
+        app,
+        "export_config",
+        s.export_config,
+        core_connected,
+        None::<&str>,
+    )?;
+    let reset_config = MenuItem::with_id(
+        app,
+        "reset_config",
+        s.reset_config,
+        core_connected,
+        None::<&str>,
+    )?;
     let clear_cache = MenuItem::with_id(
         app,
         "clear_cache",

--- a/src-tauri/src/tray/menu.rs
+++ b/src-tauri/src/tray/menu.rs
@@ -64,6 +64,10 @@ pub(super) fn tray_status_label(
     format!("Sunshine · {}", status)
 }
 
+fn recovery_action_enabled(connection: CoreConnectionState, recovery_in_progress: bool) -> bool {
+    connection == CoreConnectionState::Disconnected && !recovery_in_progress
+}
+
 pub(super) fn tray_notification_label(s: &TrayStrings, state: &sunshine::TrayState) -> String {
     let notification = &state.notification;
     if notification.action == "open_pin" {
@@ -90,8 +94,10 @@ pub(super) fn tray_notification_label(s: &TrayStrings, state: &sunshine::TraySta
 pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let s = get_tray_strings();
     let current_locale = get_current_locale();
-    let tray_state = CURRENT_TRAY_STATE.lock().unwrap().clone();
-    let connection = *CORE_CONNECTION_STATE.lock().unwrap();
+    let (tray_state, connection, recovery_in_progress) = {
+        let runtime = TRAY_RUNTIME_STATE.lock().unwrap();
+        runtime.menu_snapshot()
+    };
     let active_notification = tray_state
         .as_ref()
         .filter(|state| state.notification.active)
@@ -132,6 +138,14 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
         "open_main_panel",
         s.open_main_panel,
         true,
+        None::<&str>,
+    )?;
+    #[cfg(target_os = "windows")]
+    let recover_service = MenuItem::with_id(
+        app,
+        "recover_service",
+        s.recover_service,
+        recovery_action_enabled(connection, recovery_in_progress),
         None::<&str>,
     )?;
     let notification_label = tray_state
@@ -383,6 +397,10 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
     )?;
 
     let mut items: Vec<&dyn tauri::menu::IsMenuItem<R>> = vec![&status];
+    #[cfg(target_os = "windows")]
+    if connection == CoreConnectionState::Disconnected {
+        items.push(&recover_service);
+    }
     if active_notification.is_some() {
         items.push(&notification_item);
     }
@@ -401,4 +419,29 @@ pub(super) fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<M
     items.push(&shutdown);
 
     Menu::with_items(app, &items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_is_available_only_while_core_is_disconnected() {
+        assert!(recovery_action_enabled(
+            CoreConnectionState::Disconnected,
+            false
+        ));
+        assert!(!recovery_action_enabled(
+            CoreConnectionState::Disconnected,
+            true
+        ));
+        assert!(!recovery_action_enabled(
+            CoreConnectionState::Connecting,
+            false
+        ));
+        assert!(!recovery_action_enabled(
+            CoreConnectionState::Connected,
+            false
+        ));
+    }
 }


### PR DESCRIPTION
## 改了啥呀

- Core 断线后保留托盘，并切换为灰度离线图标和明确的未连接状态
- 禁用依赖 Core 的菜单项，同时保留本地界面、诊断入口和 Windows 服务恢复操作
- 用统一的 `TrayRuntimeState` 原子管理连接、快照与恢复尝试，避免几把互不协调的锁偷偷打架
- 服务恢复只在收到新的 Core 状态后判定成功，30 秒无响应则恢复按钮并给出提示
- 补上 SSE revision 重连、恢复状态机、菜单可用性和灰度图标测试

## 为啥要改

之前 Core 长时间不可用时会移除托盘。这样虽然不会展示陈旧状态，但用户也失去了最需要的恢复入口——杂鱼断线状态反而把救命按钮藏起来了。现在托盘明确表现为离线，同时仍能启动本地恢复流程。

## 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml`（85 passed）
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --message-format short`：本 PR 改动文件无 warning
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` 仍被仓库既有的 102 项 warning 阻塞，首项位于未改动的 `src/vdd_ioctl.rs`
