### PR TITLE
feat(pet): 增加桌宠快捷键开关

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -7,6 +7,8 @@ use crate::windows;
 use log::{debug, error, info, warn};
 use tauri::{App, AppHandle, Manager};
 
+const TOOLBAR_SHORTCUT: &str = "CmdOrCtrl+Shift+Alt+T";
+
 /// 应用程序状态
 pub struct AppState {
     #[allow(dead_code)]
@@ -71,7 +73,7 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
             warn!("install file mapping context menu failed: {}", e);
         }
     }
-    register_global_shortcuts(app)?;
+    register_global_shortcuts(app, desktop_settings.toolbar_shortcut_enabled)?;
     setup_menu_event_handler(app);
 
     // 剪贴板同步：用户会话 agent 默认随面板启动；服务端如果禁用了则 SSE 自然失败，
@@ -123,33 +125,72 @@ pub fn shutdown_application() {
 }
 
 /// 注册全局快捷键
-fn register_global_shortcuts(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
-    use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+fn register_global_shortcuts(
+    app: &mut App,
+    toolbar_shortcut_enabled: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !toolbar_shortcut_enabled {
+        info!("Desktop pet shortcut is disabled; skipping registration");
+        return Ok(());
+    }
 
-    let app_handle = app.handle().clone();
-
-    match app.handle().global_shortcut().on_shortcut(
-        "CmdOrCtrl+Shift+Alt+T",
-        move |_app, _shortcut, event| {
-            if event.state == ShortcutState::Pressed {
-                debug!("⌨️ 全局快捷键触发: CTRL+SHIFT+ALT+T");
-                toggle_toolbar_window(&app_handle);
-            }
-        },
-    ) {
-        Ok(_) => {
-            info!("⌨️ 全局快捷键已注册: CTRL+SHIFT+ALT+T");
-        }
-        Err(e) => {
-            log::warn!(
-                "⚠️  全局快捷键 CTRL+SHIFT+ALT+T 注册失败（可能已被其他程序占用）: {}",
-                e
-            );
-            log::warn!("⚠️  工具栏快捷键不可用，但应用程序将继续正常运行");
-        }
+    let registered = sync_toolbar_shortcut(app.handle(), true).map_err(std::io::Error::other)?;
+    if !registered {
+        warn!("Desktop pet shortcut is currently unavailable; the application will continue normally");
     }
 
     Ok(())
+}
+
+/// 返回桌宠快捷键是否已由当前 GUI 注册。
+pub fn toolbar_shortcut_is_registered(app_handle: &AppHandle) -> bool {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+    app_handle.global_shortcut().is_registered(TOOLBAR_SHORTCUT)
+}
+
+/// 按用户设置注册或注销桌宠快捷键。
+///
+/// 启用时若组合键被其他程序占用，会保留用户的启用意图并返回 `Ok(false)`，
+/// 让后续打开设置页或重启 GUI 时可以再次尝试注册。
+pub fn sync_toolbar_shortcut(app_handle: &AppHandle, enabled: bool) -> Result<bool, String> {
+    use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+
+    let shortcut_manager = app_handle.global_shortcut();
+    if !enabled {
+        if !shortcut_manager.is_registered(TOOLBAR_SHORTCUT) {
+            return Ok(false);
+        }
+
+        shortcut_manager
+            .unregister(TOOLBAR_SHORTCUT)
+            .map_err(|error| format!("failed to unregister toolbar shortcut: {error}"))?;
+        info!("Desktop pet shortcut unregistered: CTRL+SHIFT+ALT+T");
+        return Ok(false);
+    }
+
+    if shortcut_manager.is_registered(TOOLBAR_SHORTCUT) {
+        return Ok(true);
+    }
+
+    let app_handle = app_handle.clone();
+    match shortcut_manager.on_shortcut(TOOLBAR_SHORTCUT, move |_app, _shortcut, event| {
+        if event.state == ShortcutState::Pressed {
+            debug!("Global shortcut triggered: CTRL+SHIFT+ALT+T");
+            toggle_toolbar_window(&app_handle);
+        }
+    }) {
+        Ok(_) => {
+            info!("Desktop pet shortcut registered: CTRL+SHIFT+ALT+T");
+            Ok(true)
+        }
+        Err(error) => {
+            warn!(
+                "Desktop pet shortcut registration failed; it may be used by another application: {error}"
+            );
+            Ok(false)
+        }
+    }
 }
 
 /// 切换工具栏窗口显示/隐藏

--- a/src-tauri/src/desktop_settings.rs
+++ b/src-tauri/src/desktop_settings.rs
@@ -43,6 +43,7 @@ pub struct DesktopSettings {
     pub update_notify: bool,
     pub dev_mode: bool,
     pub log_level: String,
+    pub toolbar_shortcut_enabled: bool,
 }
 
 impl Default for DesktopSettings {
@@ -57,6 +58,7 @@ impl Default for DesktopSettings {
             update_notify: true,
             dev_mode: false,
             log_level: "info".to_string(),
+            toolbar_shortcut_enabled: true,
         }
     }
 }
@@ -73,6 +75,13 @@ pub struct DesktopSettingsStatus {
 pub struct DesktopSettingsResponse {
     pub settings: DesktopSettings,
     pub status: DesktopSettingsStatus,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolbarShortcutStatus {
+    pub enabled: bool,
+    pub registered: bool,
 }
 
 fn settings_dir() -> Result<PathBuf, String> {
@@ -361,6 +370,8 @@ pub async fn save_desktop_settings(
     app: AppHandle,
     mut settings: DesktopSettings,
 ) -> Result<DesktopSettingsResponse, String> {
+    // 桌宠快捷键只由桌宠设置页的独立命令修改，避免普通设置页保存旧快照时覆盖它。
+    settings.toolbar_shortcut_enabled = load_desktop_settings_from_disk().toolbar_shortcut_enabled;
     normalize(&mut settings);
     save_desktop_settings_to_disk(&settings)?;
     apply_auto_start(&settings)?;
@@ -376,6 +387,45 @@ pub async fn save_desktop_settings(
         settings,
         status: status(),
     })
+}
+
+fn toolbar_shortcut_status(app: &AppHandle, enabled: bool) -> ToolbarShortcutStatus {
+    ToolbarShortcutStatus {
+        enabled,
+        registered: crate::app::toolbar_shortcut_is_registered(app),
+    }
+}
+
+/// 读取桌宠快捷键状态；若用户已启用，会顺便重试之前因冲突而失败的注册。
+#[tauri::command]
+pub fn load_toolbar_shortcut_status(app: AppHandle) -> ToolbarShortcutStatus {
+    let settings = load_desktop_settings_from_disk();
+    if let Err(error) = crate::app::sync_toolbar_shortcut(&app, settings.toolbar_shortcut_enabled) {
+        log::warn!("Failed to synchronize toolbar shortcut while loading settings: {error}");
+    }
+    toolbar_shortcut_status(&app, settings.toolbar_shortcut_enabled)
+}
+
+#[tauri::command]
+pub fn set_toolbar_shortcut_enabled(
+    app: AppHandle,
+    enabled: bool,
+) -> Result<ToolbarShortcutStatus, String> {
+    let previous = load_desktop_settings_from_disk();
+    crate::app::sync_toolbar_shortcut(&app, enabled)?;
+
+    let mut settings = previous.clone();
+    settings.toolbar_shortcut_enabled = enabled;
+    if let Err(error) = save_desktop_settings_to_disk(&settings) {
+        if let Err(rollback_error) =
+            crate::app::sync_toolbar_shortcut(&app, previous.toolbar_shortcut_enabled)
+        {
+            log::warn!("Failed to restore toolbar shortcut after save failure: {rollback_error}");
+        }
+        return Err(error);
+    }
+
+    Ok(toolbar_shortcut_status(&app, enabled))
 }
 
 pub fn apply_startup_settings(app: &AppHandle, settings: &DesktopSettings) {
@@ -494,6 +544,24 @@ mod tests {
         assert!(settings.notifications);
         assert!(settings.connection_notify);
         assert!(settings.update_notify);
+    }
+
+    #[test]
+    fn toolbar_shortcut_is_enabled_by_default_and_for_legacy_settings() {
+        assert!(DesktopSettings::default().toolbar_shortcut_enabled);
+
+        let settings: DesktopSettings = serde_json::from_str(r#"{"autoStart":false}"#)
+            .expect("legacy desktop settings should deserialize");
+        assert!(settings.toolbar_shortcut_enabled);
+    }
+
+    #[test]
+    fn toolbar_shortcut_can_be_disabled_explicitly() {
+        let settings: DesktopSettings =
+            serde_json::from_str(r#"{"toolbarShortcutEnabled":false}"#)
+                .expect("toolbar shortcut setting should deserialize");
+
+        assert!(!settings.toolbar_shortcut_enabled);
     }
 
     #[test]

--- a/src-tauri/src/desktop_settings.rs
+++ b/src-tauri/src/desktop_settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
 use tauri::AppHandle;
 #[cfg(debug_assertions)]
 use tauri::Manager;
@@ -8,6 +9,11 @@ use tauri::Manager;
 const SETTINGS_FILE: &str = "desktop-settings.json";
 const RUN_VALUE_NAME: &str = "Sunshine GUI Desktop";
 const REMOVE_AUTO_START_ARG: &str = "--remove-autostart";
+static DESKTOP_SETTINGS_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_desktop_settings() -> MutexGuard<'static, ()> {
+    DESKTOP_SETTINGS_LOCK.lock().unwrap()
+}
 
 pub fn try_remove_auto_start_from_args() -> bool {
     if !std::env::args().any(|arg| arg == REMOVE_AUTO_START_ARG) {
@@ -122,6 +128,7 @@ fn save_desktop_settings_to_disk(settings: &DesktopSettings) -> Result<(), Strin
 }
 
 pub fn set_file_mapping_menu_enabled(enabled: bool) -> Result<(), String> {
+    let _settings_guard = lock_desktop_settings();
     let mut settings = load_desktop_settings_from_disk();
     settings.file_mapping_menu_enabled = enabled;
     save_desktop_settings_to_disk(&settings)
@@ -306,7 +313,7 @@ fn configure_sunshine_service_start(mode: ServiceStartMode) -> Result<(), String
 }
 
 pub fn set_combined_auto_start_enabled(enabled: bool) -> Result<(), String> {
-    let previous = load_desktop_settings_from_disk();
+    let mut previous = load_desktop_settings_from_disk();
     let mut settings = previous.clone();
     settings.auto_start = enabled;
     settings.auto_start_sunshine = enabled;
@@ -327,6 +334,11 @@ pub fn set_combined_auto_start_enabled(enabled: bool) -> Result<(), String> {
             service_changed = true;
         }
     }
+
+    let _settings_guard = lock_desktop_settings();
+    let toolbar_shortcut_enabled = load_desktop_settings_from_disk().toolbar_shortcut_enabled;
+    settings.toolbar_shortcut_enabled = toolbar_shortcut_enabled;
+    previous.toolbar_shortcut_enabled = toolbar_shortcut_enabled;
 
     if let Err(error) = save_desktop_settings_to_disk(&settings) {
         #[cfg(target_os = "windows")]
@@ -370,10 +382,13 @@ pub async fn save_desktop_settings(
     app: AppHandle,
     mut settings: DesktopSettings,
 ) -> Result<DesktopSettingsResponse, String> {
-    // 桌宠快捷键只由桌宠设置页的独立命令修改，避免普通设置页保存旧快照时覆盖它。
-    settings.toolbar_shortcut_enabled = load_desktop_settings_from_disk().toolbar_shortcut_enabled;
-    normalize(&mut settings);
-    save_desktop_settings_to_disk(&settings)?;
+    {
+        let _settings_guard = lock_desktop_settings();
+        // 桌宠快捷键只由桌宠设置页的独立命令修改，避免普通设置页保存旧快照时覆盖它。
+        settings.toolbar_shortcut_enabled = load_desktop_settings_from_disk().toolbar_shortcut_enabled;
+        normalize(&mut settings);
+        save_desktop_settings_to_disk(&settings)?;
+    }
     apply_auto_start(&settings)?;
     crate::tray::refresh_menu(&app);
     crate::logger::set_log_level(&settings.log_level);
@@ -399,6 +414,7 @@ fn toolbar_shortcut_status(app: &AppHandle, enabled: bool) -> ToolbarShortcutSta
 /// 读取桌宠快捷键状态；若用户已启用，会顺便重试之前因冲突而失败的注册。
 #[tauri::command]
 pub fn load_toolbar_shortcut_status(app: AppHandle) -> ToolbarShortcutStatus {
+    let _settings_guard = lock_desktop_settings();
     let settings = load_desktop_settings_from_disk();
     if let Err(error) = crate::app::sync_toolbar_shortcut(&app, settings.toolbar_shortcut_enabled) {
         log::warn!("Failed to synchronize toolbar shortcut while loading settings: {error}");
@@ -411,6 +427,7 @@ pub fn set_toolbar_shortcut_enabled(
     app: AppHandle,
     enabled: bool,
 ) -> Result<ToolbarShortcutStatus, String> {
+    let _settings_guard = lock_desktop_settings();
     let previous = load_desktop_settings_from_disk();
     crate::app::sync_toolbar_shortcut(&app, enabled)?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -138,6 +138,8 @@ fn main() {
             commands::capture_screenshot,
             desktop_settings::get_desktop_settings,
             desktop_settings::save_desktop_settings,
+            desktop_settings::load_toolbar_shortcut_status,
+            desktop_settings::set_toolbar_shortcut_enabled,
             vdd::get_vdd_status,
             vdd::install_vdd_driver,
             vdd::set_vdd_keep_enabled,

--- a/src/renderer/desktop/i18n/en.js
+++ b/src/renderer/desktop/i18n/en.js
@@ -504,8 +504,13 @@ export const en = {
     tabs: {
       speech: 'Speech',
       animation: 'Animation',
+      shortcuts: 'Shortcuts',
     },
     animationMore: 'More animation options coming soon…',
+    toolbarShortcut: 'Enable desktop pet shortcut',
+    toolbarShortcutDesc: 'Ctrl + Shift + Alt + T shows or hides the desktop pet toolbar. When disabled, the foreground application receives the shortcut instead.',
+    toolbarShortcutUnavailable: 'This shortcut may already be used by another application and is currently unavailable. Open this page again after the other application releases it to retry registration.',
+    toolbarShortcutStateError: 'Could not update the shortcut state. Please try again.',
     master: 'Pet Speech (Master)',
     masterDesc: 'When off, the pet stays silent and the options below have no effect',
     random: 'Random Talk',

--- a/src/renderer/desktop/i18n/en.js
+++ b/src/renderer/desktop/i18n/en.js
@@ -508,7 +508,7 @@ export const en = {
     },
     animationMore: 'More animation options coming soon…',
     toolbarShortcut: 'Enable desktop pet shortcut',
-    toolbarShortcutDesc: 'Ctrl + Shift + Alt + T shows or hides the desktop pet toolbar. When disabled, the foreground application receives the shortcut instead.',
+    toolbarShortcutDesc: 'Ctrl + Shift + Alt + T shows or hides the desktop pet toolbar. When disabled, Sunshine GUI stops registering the shortcut and other applications may use it when permitted by the operating system.',
     toolbarShortcutUnavailable: 'This shortcut may already be used by another application and is currently unavailable. Open this page again after the other application releases it to retry registration.',
     toolbarShortcutStateError: 'Could not update the shortcut state. Please try again.',
     master: 'Pet Speech (Master)',

--- a/src/renderer/desktop/i18n/zh.js
+++ b/src/renderer/desktop/i18n/zh.js
@@ -508,7 +508,7 @@ export const zh = {
     },
     animationMore: '更多动画选项后续加入…',
     toolbarShortcut: '启用桌宠快捷键',
-    toolbarShortcutDesc: 'Ctrl + Shift + Alt + T 用于显示或隐藏桌宠工具栏。关闭后，该组合键将交给当前软件处理。',
+    toolbarShortcutDesc: 'Ctrl + Shift + Alt + T 用于显示或隐藏桌宠工具栏。关闭后，Sunshine GUI 不再注册该组合键，其他程序可在系统允许时使用它。',
     toolbarShortcutUnavailable: '该组合键当前可能已被其他程序占用，暂未生效。关闭占用程序后重新打开此设置页即可再次尝试注册。',
     toolbarShortcutStateError: '快捷键状态更新失败，请稍后重试。',
     master: '桌宠对话总开关',

--- a/src/renderer/desktop/i18n/zh.js
+++ b/src/renderer/desktop/i18n/zh.js
@@ -504,8 +504,13 @@ export const zh = {
     tabs: {
       speech: '对话',
       animation: '动画',
+      shortcuts: '快捷键',
     },
     animationMore: '更多动画选项后续加入…',
+    toolbarShortcut: '启用桌宠快捷键',
+    toolbarShortcutDesc: 'Ctrl + Shift + Alt + T 用于显示或隐藏桌宠工具栏。关闭后，该组合键将交给当前软件处理。',
+    toolbarShortcutUnavailable: '该组合键当前可能已被其他程序占用，暂未生效。关闭占用程序后重新打开此设置页即可再次尝试注册。',
+    toolbarShortcutStateError: '快捷键状态更新失败，请稍后重试。',
     master: '桌宠对话总开关',
     masterDesc: '关闭后桌宠不会说话，下面选项均不生效',
     random: '随机对话',

--- a/src/renderer/tool-window/tools/PetSettingsTool.vue
+++ b/src/renderer/tool-window/tools/PetSettingsTool.vue
@@ -269,6 +269,7 @@
                 <input
                   type="checkbox"
                   :checked="toolbarShortcutEnabled"
+                  :aria-label="t.petTool.toolbarShortcut"
                   :disabled="toolbarShortcutPending"
                   @change="onToolbarShortcutToggle"
                 />

--- a/src/renderer/tool-window/tools/PetSettingsTool.vue
+++ b/src/renderer/tool-window/tools/PetSettingsTool.vue
@@ -251,6 +251,32 @@
         <div v-else-if="activeTab === 'animation'" class="panel-content">
           <div class="empty-hint">{{ t.petTool.animationMore }}</div>
         </div>
+
+        <div v-else-if="activeTab === 'shortcuts'" class="panel-content">
+          <div class="row row-master">
+            <div class="row-info">
+              <div class="row-name">{{ t.petTool.toolbarShortcut }}</div>
+              <div class="row-desc">{{ t.petTool.toolbarShortcutDesc }}</div>
+              <div v-if="toolbarShortcutUnavailable" class="row-desc warn">
+                {{ t.petTool.toolbarShortcutUnavailable }}
+              </div>
+              <div v-else-if="toolbarShortcutStateError" class="row-desc warn">
+                {{ t.petTool.toolbarShortcutStateError }}
+              </div>
+            </div>
+            <div class="row-control">
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  :checked="toolbarShortcutEnabled"
+                  :disabled="toolbarShortcutPending"
+                  @change="onToolbarShortcutToggle"
+                />
+                <span class="slider"></span>
+              </label>
+            </div>
+          </div>
+        </div>
       </section>
     </div>
 
@@ -309,6 +335,10 @@ const TABS = Object.freeze([
     id: 'animation',
     icon: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"/></svg>',
   },
+  {
+    id: 'shortcuts',
+    icon: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8 14H7v-2h4v2zm6-4H7v-2h10v2zm0-4H7V7h10v2z"/></svg>',
+  },
 ])
 
 const INTERVAL_PRESETS = Object.freeze([15, 30, 60, 120, 300])
@@ -326,8 +356,51 @@ const aiConfigVersion = ref(0)
 const serverAiConfig = ref(null)
 const visionConfirmPending = ref(false)
 const visionConfirmOpen = ref(false)
+const toolbarShortcutEnabled = ref(true)
+const toolbarShortcutRegistered = ref(false)
+const toolbarShortcutPending = ref(true)
+const toolbarShortcutStateError = ref(false)
 let tabTouchStart = null
 let aiConfigRefreshGeneration = 0
+
+const toolbarShortcutUnavailable = computed(
+  () => !toolbarShortcutPending.value
+    && !toolbarShortcutStateError.value
+    && toolbarShortcutEnabled.value
+    && !toolbarShortcutRegistered.value,
+)
+
+async function loadToolbarShortcutStatus() {
+  toolbarShortcutPending.value = true
+  toolbarShortcutStateError.value = false
+  try {
+    const status = await invoke('load_toolbar_shortcut_status')
+    toolbarShortcutEnabled.value = Boolean(status.enabled)
+    toolbarShortcutRegistered.value = Boolean(status.registered)
+  } catch (error) {
+    console.warn('[桌宠设置] 加载快捷键状态失败:', error)
+    toolbarShortcutStateError.value = true
+  } finally {
+    toolbarShortcutPending.value = false
+  }
+}
+
+async function onToolbarShortcutToggle(event) {
+  const enabled = event.currentTarget.checked
+  toolbarShortcutPending.value = true
+  toolbarShortcutStateError.value = false
+  try {
+    const status = await invoke('set_toolbar_shortcut_enabled', { enabled })
+    toolbarShortcutEnabled.value = Boolean(status.enabled)
+    toolbarShortcutRegistered.value = Boolean(status.registered)
+  } catch (error) {
+    console.warn('[桌宠设置] 保存快捷键状态失败:', error)
+    event.currentTarget.checked = toolbarShortcutEnabled.value
+    toolbarShortcutStateError.value = true
+  } finally {
+    toolbarShortcutPending.value = false
+  }
+}
 
 function hasUsableApiKey(key) {
   return typeof key === 'string' && Boolean(key.trim()) && !key.includes('****')
@@ -640,6 +713,7 @@ function syncSettingFromStorage(event) {
 
 onMounted(() => {
   window.addEventListener('storage', syncSettingFromStorage)
+  void loadToolbarShortcutStatus()
   void refreshAiConfigStatus().then((applied) => {
     if (applied) correctVisionEnabled()
   })


### PR DESCRIPTION
## 说明

`Ctrl + Shift + Alt + T` 会作为全局快捷键抢占前台软件的组合键，影响 Photoshop 等应用的操作。

## 修改

- 在桌宠设置中增加“快捷键”页，可立即启用或禁用该快捷键。
- 快捷键设置保存到 GUI 原生配置；旧配置或无法读取配置时默认启用。
- 组合键被其他程序占用时保留启用设置并显示未生效状态；重新打开设置页会再次尝试注册。
- 配置保存失败时恢复此前的运行状态，避免配置与实际注册状态不一致。