### PR TITLE
fix(gui): 防止代理和 TUN 拦截本机 WebUI

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,7 +54,50 @@ fn configure_async_runtime() {
     tauri::async_runtime::set(runtime.handle().clone());
 }
 
+#[cfg(target_os = "windows")]
+fn configure_loopback_proxy_bypass() {
+    // This runs before any helper path or async worker can create an HTTP
+    // client, so every GUI-owned loopback request gets the same direct route.
+    unsafe {
+        // WebView2 uses Chromium's bypass syntax. Keep external requests on the
+        // user's configured proxy while forcing every loopback form to direct.
+        std::env::set_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", [
+            // 安全：忽略自签名证书错误（连接本地 Sunshine）
+            "--ignore-certificate-errors",
+            "--proxy-bypass-list=localhost;*.localhost;127.0.0.0/8;[::1]",
+            // 节流：激进的后台/隐藏标签页定时器节流
+            "--enable-features=IntensiveWakeUpThrottling,ThrottleDisplayNoneAndVisibilityHiddenCrossOriginIframes",
+            // GPU 优化：禁用 Edge 特有的 UI 覆盖层（减少不必要的 GPU 合成层）
+            "--disable-features=msWebOOUI",
+            // GPU 优化：禁用 GPU 着色器磁盘缓存，减少 VRAM 占用
+            "--disable-gpu-shader-disk-cache",
+            // GPU 优化：关闭 GPU 光栅化抗锯齿（控制面板 UI 无需 MSAA）
+            "--gpu-rasterization-msaa-sample-count=0",
+            // GPU 优化：限制渲染进程数量，减少 GPU 上下文切换开销
+            "--renderer-process-limit=1",
+        ].join(" "));
+
+        // reqwest follows NO_PROXY/no_proxy. Preserve the user's existing
+        // exclusions and add the same loopback scope used by WebView2.
+        for key in ["NO_PROXY", "no_proxy"] {
+            let mut value = std::env::var(key).unwrap_or_default();
+            for entry in ["localhost", ".localhost", "127.0.0.0/8", "::1"] {
+                if !value.split(',').any(|current| current.trim() == entry) {
+                    if !value.is_empty() {
+                        value.push(',');
+                    }
+                    value.push_str(entry);
+                }
+            }
+            std::env::set_var(key, value);
+        }
+    }
+}
+
 fn main() {
+    #[cfg(target_os = "windows")]
+    configure_loopback_proxy_bypass();
+
     #[cfg(target_os = "windows")]
     utils::wait_for_elevated_restart_handoff();
 
@@ -79,27 +122,9 @@ fn main() {
     }
 
     // The agent mostly waits on local I/O. Bounding the shared runtime avoids
-    // allocating one worker per logical CPU on high-core-count hosts.
+    // allocating one worker per logical CPU on high-core-count hosts. Proxy
+    // environment variables must be finalized before worker threads start.
     configure_async_runtime();
-
-    // 设置 WebView2 浏览器参数以优化 GPU 占用和安全策略
-    #[cfg(target_os = "windows")]
-    unsafe {
-        std::env::set_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", [
-            // 安全：忽略自签名证书错误（连接本地 Sunshine）
-            "--ignore-certificate-errors",
-            // 节流：激进的后台/隐藏标签页定时器节流
-            "--enable-features=IntensiveWakeUpThrottling,ThrottleDisplayNoneAndVisibilityHiddenCrossOriginIframes",
-            // GPU 优化：禁用 Edge 特有的 UI 覆盖层（减少不必要的 GPU 合成层）
-            "--disable-features=msWebOOUI",
-            // GPU 优化：禁用 GPU 着色器磁盘缓存，减少 VRAM 占用
-            "--disable-gpu-shader-disk-cache",
-            // GPU 优化：关闭 GPU 光栅化抗锯齿（控制面板 UI 无需 MSAA）
-            "--gpu-rasterization-msaa-sample-count=0",
-            // GPU 优化：限制渲染进程数量，减少 GPU 上下文切换开销
-            "--renderer-process-limit=1",
-        ].join(" "));
-    }
 
     let builder = tauri::Builder::default()
         .manage(app::AppState {
@@ -184,6 +209,7 @@ fn main() {
             sunshine::restart_sunshine_in_user_mode,
             sunshine::restart_sunshine_service,
             proxy_server::get_proxy_url_command,
+            proxy_server::get_proxy_health_check,
             proxy_server::refresh_sunshine_target,
             proxy_server::wait_for_proxy_ready,
             utils::open_external_url,

--- a/src-tauri/src/proxy_server.rs
+++ b/src-tauri/src/proxy_server.rs
@@ -4,6 +4,7 @@ use axum::{
     extract::Request,
     middleware::Next,
     response::{IntoResponse, Response},
+    routing::get,
 };
 use bytes::Bytes;
 use futures_util::StreamExt;
@@ -39,6 +40,7 @@ static PROXY_REQUEST_PERMITS: Lazy<Arc<Semaphore>> =
     Lazy::new(|| Arc::new(Semaphore::new(MAX_CONCURRENT_PROXY_REQUESTS)));
 static PROXY_PENDING_PERMITS: Lazy<Arc<Semaphore>> =
     Lazy::new(|| Arc::new(Semaphore::new(MAX_PENDING_PROXY_REQUESTS)));
+static PROXY_HEALTH_TOKEN: Lazy<String> = Lazy::new(|| uuid::Uuid::new_v4().to_string());
 
 /// 快速失败冷却时间（秒）- 在此时间内不重试，超过后会重新尝试连接
 const FAST_FAIL_COOLDOWN_SECS: u64 = 3;
@@ -62,6 +64,13 @@ const PROXY_ADMISSION_WAIT_SECS: u64 = 3;
 const PROXY_REQUEST_BODY_TIMEOUT_SECS: u64 = 15;
 const PROXY_STREAM_IDLE_TIMEOUT_SECS: u64 = 60;
 const PROXY_STREAM_CHUNK_BYTES: usize = 64 * 1024;
+const PROXY_HEALTH_PATH: &str = "/__foundation_proxy_health";
+
+#[derive(serde::Serialize)]
+pub struct ProxyHealthCheck {
+    url: String,
+    token: String,
+}
 
 struct UnboundedStreamRule {
     method: &'static str,
@@ -97,6 +106,44 @@ pub fn get_proxy_url() -> String {
 #[tauri::command]
 pub fn get_proxy_url_command() -> String {
     get_proxy_url()
+}
+
+/// Return a per-process challenge used by the WebView to verify loopback routing.
+#[tauri::command]
+pub fn get_proxy_health_check() -> ProxyHealthCheck {
+    ProxyHealthCheck {
+        url: format!(
+            "{}{}?token={}",
+            get_proxy_url(),
+            PROXY_HEALTH_PATH,
+            PROXY_HEALTH_TOKEN.as_str()
+        ),
+        token: PROXY_HEALTH_TOKEN.as_str().to_owned(),
+    }
+}
+
+async fn proxy_health_handler(request: Request) -> Response {
+    let valid_token = request.uri().query().is_some_and(|query| {
+        query
+            .split('&')
+            .any(|pair| pair.strip_prefix("token=") == Some(PROXY_HEALTH_TOKEN.as_str()))
+    });
+
+    if !valid_token {
+        return axum::http::StatusCode::NOT_FOUND.into_response();
+    }
+
+    (
+        [
+            (axum::http::header::CACHE_CONTROL, "no-store"),
+            (
+                axum::http::header::CONTENT_TYPE,
+                "text/plain; charset=utf-8",
+            ),
+        ],
+        PROXY_HEALTH_TOKEN.as_str(),
+    )
+        .into_response()
 }
 
 /// Wait until the local proxy listener is ready before loading the main frame.
@@ -300,6 +347,11 @@ fn hold_proxy_permit_with_timeout(
 }
 
 async fn proxy_concurrency_middleware(req: Request, next: Next) -> Response {
+    // 健康检查不访问 Sunshine，不能因日志下载占满代理槽位而误报为 TUN 拦截。
+    if req.uri().path() == PROXY_HEALTH_PATH {
+        return next.run(req).await;
+    }
+
     let permit = acquire_proxy_permit_with_wait(
         PROXY_REQUEST_PERMITS.clone(),
         PROXY_PENDING_PERMITS.clone(),
@@ -336,6 +388,7 @@ pub async fn start_proxy_server() -> Result<(), Box<dyn std::error::Error + Send
     PROXY_READY.store(false, Ordering::Release);
 
     let app = Router::new()
+        .route(PROXY_HEALTH_PATH, get(proxy_health_handler))
         .fallback(proxy_handler)
         .layer(CorsLayer::permissive())
         .layer(axum::middleware::from_fn(pna_middleware))
@@ -1373,6 +1426,36 @@ mod tests {
         });
 
         format!("http://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn proxy_health_requires_the_current_process_challenge() {
+        let check = get_proxy_health_check();
+        let valid_request = axum::http::Request::builder()
+            .uri(check.url)
+            .body(Body::empty())
+            .unwrap();
+        let valid_response = proxy_health_handler(valid_request).await;
+        assert_eq!(valid_response.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            valid_response.headers()[axum::http::header::CACHE_CONTROL],
+            "no-store"
+        );
+        let valid_body = axum::body::to_bytes(valid_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(valid_body.as_ref(), check.token.as_bytes());
+
+        for uri in [PROXY_HEALTH_PATH, "/__foundation_proxy_health?token=wrong"] {
+            let invalid_request = axum::http::Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            assert_eq!(
+                proxy_health_handler(invalid_request).await.status(),
+                axum::http::StatusCode::NOT_FOUND
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/renderer/components/SunshineFrame.vue
+++ b/src/renderer/components/SunshineFrame.vue
@@ -6,7 +6,13 @@
           <div class="loading-container">
             <img src="../public/gura-pix.png" class="loading-image" alt="Loading" />
             <div class="loading-text">
-              <p>正在准备 {{ currentPath }} ...</p>
+              <template v-if="proxyHealthFailed">
+                <p class="proxy-health-error">{{ t.sunshineFrame.proxyUnavailable }}</p>
+                <button class="proxy-health-retry" type="button" @click="retryProxyHealthCheck">
+                  {{ t.sunshineFrame.retry }}
+                </button>
+              </template>
+              <p v-else>{{ t.sunshineFrame.preparing.replace('{path}', currentPath) }}</p>
             </div>
           </div>
         </div>
@@ -30,9 +36,12 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { invoke } from '@tauri-apps/api/core'
 import { sunshine } from '@/tauri-adapter.js'
+import { checkLocalProxyHealth } from '../utils/proxyHealth.js'
+import { useI18n } from '../desktop/i18n/index.js'
 import SidebarMenu from './SidebarMenu.vue'
 
 invoke('main_panel_loading').catch(() => {})
+const { t } = useI18n()
 
 // Refs
 const loading = ref(true)
@@ -40,6 +49,7 @@ const sunshineUrl = ref('')
 const currentPath = ref('/')
 const sunshineIframe = ref(null)
 const sidebarMenuRef = ref(null)
+const proxyHealthFailed = ref(false)
 
 // State
 let pollTimer = null
@@ -50,6 +60,7 @@ let visibilityHandlerRef = null
 let proxyBase = '' // 代理服务器基础 URL，用于恢复 iframe 到正确页面
 let loadedFrameRevealTimer = null
 let awaitingAppReady = true
+let localProxyVerified = false
 
 // Constants
 const ALLOWED_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']
@@ -120,6 +131,20 @@ const refreshProxyTarget = async () => {
   if (!refreshedTarget) {
     console.warn('[SunshineFrame] refresh proxy target failed')
   }
+}
+
+const verifyLocalProxy = async () => {
+  try {
+    const healthCheck = await invoke('get_proxy_health_check')
+    return checkLocalProxyHealth(healthCheck)
+  } catch (error) {
+    console.warn('[SunshineFrame] local proxy health check failed:', error)
+    return false
+  }
+}
+
+const retryProxyHealthCheck = () => {
+  window.location.reload()
 }
 
 // Navigation handler
@@ -403,6 +428,15 @@ onMounted(async () => {
     await refreshProxyTarget()
     const proxyBaseUrl = await sunshine.getProxyUrl()
     proxyBase = proxyBaseUrl
+
+    if (!await verifyLocalProxy()) {
+      proxyHealthFailed.value = true
+      sunshineUrl.value = 'about:blank'
+      await invoke('main_panel_ready').catch(() => {})
+      return
+    }
+    localProxyVerified = true
+
     const cmdLineUrl = await sunshine.getCommandLineUrl()
 
     messageHandler = createMessageHandler()
@@ -451,6 +485,12 @@ onMounted(async () => {
     await invoke('main_panel_ready')
   } catch (error) {
     console.error('初始化失败:', error)
+    if (!localProxyVerified) {
+      proxyHealthFailed.value = true
+      sunshineUrl.value = 'about:blank'
+      await invoke('main_panel_ready').catch(() => {})
+      return
+    }
     try {
       sunshineUrl.value = (await sunshine.getProxyUrl()) + '/'
     } catch {
@@ -573,6 +613,27 @@ const onLoad = () => {
     margin: 12px 0;
     animation: pulse 2s ease-in-out infinite;
   }
+
+  .proxy-health-error {
+    animation: none;
+    color: #f2c8c8;
+    font-size: 15px;
+    transform: none;
+  }
+}
+
+.proxy-health-retry {
+  margin-top: 12px;
+  padding: 8px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 6px;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.16);
+  }
 }
 
 @keyframes pulse {
@@ -608,6 +669,10 @@ const onLoad = () => {
 :global(html[data-bs-theme='light'] .loading-text) {
   color: @gura-blue;
   text-shadow: 1px 1px 3px rgba(74, 158, 255, 0.2);
+}
+
+:global(html[data-bs-theme='light'] .proxy-health-error) {
+  color: #8f3434;
 }
 </style>
 

--- a/src/renderer/components/SunshineFrame.vue
+++ b/src/renderer/components/SunshineFrame.vue
@@ -425,7 +425,6 @@ onMounted(async () => {
 
   try {
     await invoke('wait_for_proxy_ready')
-    await refreshProxyTarget()
     const proxyBaseUrl = await sunshine.getProxyUrl()
     proxyBase = proxyBaseUrl
 
@@ -436,6 +435,7 @@ onMounted(async () => {
       return
     }
     localProxyVerified = true
+    await refreshProxyTarget()
 
     const cmdLineUrl = await sunshine.getCommandLineUrl()
 

--- a/src/renderer/desktop/i18n/en.js
+++ b/src/renderer/desktop/i18n/en.js
@@ -1,4 +1,10 @@
 export const en = {
+  sunshineFrame: {
+    preparing: 'Preparing {path} ...',
+    proxyUnavailable: 'The local Sunshine WebUI could not be reached. A proxy or TUN service may be intercepting localhost, 127.0.0.0/8, or IPv6 loopback traffic. Exclude loopback traffic from the proxy and try again.',
+    retry: 'Check again',
+  },
+
   // === Navigation ===
   nav: {
     apps: 'Apps',

--- a/src/renderer/desktop/i18n/zh.js
+++ b/src/renderer/desktop/i18n/zh.js
@@ -1,4 +1,10 @@
 export const zh = {
+  sunshineFrame: {
+    preparing: '正在准备 {path} ...',
+    proxyUnavailable: '无法连接本机 Sunshine WebUI。代理或 TUN 软件可能拦截了 localhost、127.0.0.0/8 或 IPv6 环回地址，请将本机环回流量设为直连后重试。',
+    retry: '重新检测',
+  },
+
   // === 导航 ===
   nav: {
     apps: '应用',

--- a/src/renderer/utils/proxyHealth.js
+++ b/src/renderer/utils/proxyHealth.js
@@ -1,0 +1,21 @@
+export async function checkLocalProxyHealth(
+  check,
+  { fetchImpl = globalThis.fetch, timeoutMs = 5000 } = {},
+) {
+  if (!check?.url || !check?.token || typeof fetchImpl !== 'function') return false
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetchImpl(check.url, {
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+    return response.ok && await response.text() === check.token
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/renderer/utils/proxyHealth.test.js
+++ b/src/renderer/utils/proxyHealth.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { checkLocalProxyHealth } from './proxyHealth.js'
+
+const check = {
+  url: 'http://127.0.0.1:48081/__foundation_proxy_health?token=expected',
+  token: 'expected',
+}
+
+test('accepts only the matching loopback health challenge', async () => {
+  const ok = await checkLocalProxyHealth(check, {
+    fetchImpl: async () => ({ ok: true, text: async () => 'expected' }),
+  })
+  const intercepted = await checkLocalProxyHealth(check, {
+    fetchImpl: async () => ({ ok: true, text: async () => '<html>proxy page</html>' }),
+  })
+
+  assert.equal(ok, true)
+  assert.equal(intercepted, false)
+})
+
+test('rejects failed and incomplete health checks', async () => {
+  assert.equal(await checkLocalProxyHealth(check, {
+    fetchImpl: async () => ({ ok: false, text: async () => 'expected' }),
+  }), false)
+  assert.equal(await checkLocalProxyHealth({}, {
+    fetchImpl: async () => ({ ok: true, text: async () => 'expected' }),
+  }), false)
+})
+
+test('stops waiting when the local proxy does not respond', async () => {
+  const result = await checkLocalProxyHealth(check, {
+    timeoutMs: 5,
+    fetchImpl: (_url, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+    }),
+  })
+
+  assert.equal(result, false)
+})


### PR DESCRIPTION
## 说明

控制面板通过本机代理加载 Sunshine WebUI。部分系统代理、PAC 或 TUN 配置会接管环回请求，导致“高级设置”无法打开或持续显示空白页面。

## 修改

- WebView2 和 Rust HTTP 客户端统一将 `localhost`、`*.localhost`、`127.0.0.0/8` 与 `::1` 设为直连，同时保留公网请求原有的代理行为。
- 加载 WebUI 前使用当前进程随机令牌验证本地代理，避免被错误代理页面冒充正常响应。
- 环回连接失败时显示持续提示和重新检测入口；健康检查不访问 Sunshine，也不会被日志下载等长连接占满代理槽位。