### PR TITLE
fix(ds5): reject stale sidecar runtimes

### DIFF
--- a/src-tauri/src/dualsense.rs
+++ b/src-tauri/src/dualsense.rs
@@ -591,6 +591,12 @@ fn run_probe(executable: &Path) -> Result<ProbeResult, String> {
     if !result.standard || !result.composite {
         return Err("DS5-PKG-003: required DualSense profiles are unavailable".to_string());
     }
+    if !result.genshin_compatibility_identity {
+        return Err(
+            "DS5-PROTO-001: the sidecar runtime does not support Genshin compatibility mode"
+                .to_string(),
+        );
+    }
     Ok(result)
 }
 
@@ -807,6 +813,7 @@ fn sidecar_source_dir() -> Result<PathBuf, String> {
 }
 
 fn copy_runtime_files(source: &Path, destination: &Path) -> Result<(), String> {
+    validate_sidecar_runtime_metadata(source)?;
     for entry in fs::read_dir(source).map_err(|error| error.to_string())? {
         let entry = entry.map_err(|error| error.to_string())?;
         if entry
@@ -824,6 +831,21 @@ fn copy_runtime_files(source: &Path, destination: &Path) -> Result<(), String> {
             fs::copy(entry.path(), destination.join(entry.file_name()))
                 .map_err(|error| format!("DS5-PKG-002: unable to copy sidecar runtime: {error}"))?;
         }
+    }
+    Ok(())
+}
+
+fn validate_sidecar_runtime_metadata(directory: &Path) -> Result<(), String> {
+    let runtime_metadata: SidecarRuntimeMetadata =
+        serde_json::from_slice(&fs::read(directory.join("runtime.json")).map_err(|error| {
+            format!("DS5-PKG-002: sidecar runtime metadata is missing: {error}")
+        })?)
+        .map_err(|error| format!("DS5-PKG-002: invalid sidecar runtime metadata: {error}"))?;
+    if runtime_metadata.component_version != COMPONENT_VERSION
+        || runtime_metadata.protocol != PROTOCOL_VERSION
+        || runtime_metadata.target != SIDECAR_PACKAGE_TARGET
+    {
+        return Err("DS5-PKG-002: sidecar runtime metadata does not match Sunshine".to_string());
     }
     Ok(())
 }
@@ -891,17 +913,7 @@ fn extract_sidecar_package(
     if !staging.join(SIDECAR_EXE).is_file() {
         return Err("DS5-PKG-002: sidecar executable is missing from the package".to_string());
     }
-    let runtime_metadata: SidecarRuntimeMetadata =
-        serde_json::from_slice(&fs::read(staging.join("runtime.json")).map_err(|error| {
-            format!("DS5-PKG-002: sidecar runtime metadata is missing: {error}")
-        })?)
-        .map_err(|error| format!("DS5-PKG-002: invalid sidecar runtime metadata: {error}"))?;
-    if runtime_metadata.component_version != COMPONENT_VERSION
-        || runtime_metadata.protocol != PROTOCOL_VERSION
-        || runtime_metadata.target != SIDECAR_PACKAGE_TARGET
-    {
-        return Err("DS5-PKG-002: sidecar runtime metadata does not match Sunshine".to_string());
-    }
+    validate_sidecar_runtime_metadata(staging)?;
     Ok(())
 }
 
@@ -1214,13 +1226,18 @@ async fn dualsense_install_impl(
     let using_discovered_package = discovered_package.is_some();
     let using_selected_package = local_sidecar_package.is_some();
     let local_sidecar_package = local_sidecar_package.or(discovered_package.as_deref());
-    let bundled_source = if local_sidecar_package.is_none() {
-        sidecar_source_dir().ok()
+    let manifest_available = sidecar_package_manifest_path()
+        .try_exists()
+        .map_err(|error| {
+            format!("DS5-PKG-002: unable to inspect the DualSense package manifest: {error}")
+        })?;
+    let package_manifest = if local_sidecar_package.is_some() || manifest_available {
+        Some(sidecar_package_manifest()?)
     } else {
         None
     };
-    let package_manifest = if bundled_source.is_none() {
-        Some(sidecar_package_manifest()?)
+    let bundled_source = if package_manifest.is_none() {
+        Some(sidecar_source_dir()?)
     } else {
         None
     };
@@ -1406,6 +1423,14 @@ async fn dualsense_install_impl(
     }
     report_progress(progress, "complete", 100);
     let mut status = dualsense_get_status().await?;
+    if !status.verified {
+        return Err(if status.detail.is_empty() {
+            "DS5-PKG-003: the installed component did not pass the final capability check"
+                .to_string()
+        } else {
+            status.detail
+        });
+    }
     status.reboot_recommended = reboot_recommended;
     Ok(status)
 }
@@ -2035,8 +2060,9 @@ mod tests {
         InstalledComponentManifest, SidecarPackageManifest, UsbipInstallResult,
         apply_gamepad_selection, classify_usbip_installer_exit_code,
         component_matches_current_runtime, component_state, component_test_failure,
-        component_update_available, extract_sidecar_package, pinned_usbip_installed, sha256_file,
-        validate_requested_profile, validate_sidecar_package_manifest,
+        component_update_available, copy_runtime_files, extract_sidecar_package,
+        pinned_usbip_installed, sha256_file, validate_requested_profile,
+        validate_sidecar_package_manifest,
     };
     use std::io::Write as _;
     use std::process::Command;
@@ -2190,6 +2216,32 @@ mod tests {
         extract_sidecar_package(&archive_path, &staging, &manifest).unwrap();
         assert!(staging.join(super::SIDECAR_EXE).is_file());
         assert!(staging.join("runtime.json").is_file());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn bundled_runtime_rejects_stale_component_metadata() {
+        let root = std::env::temp_dir().join(format!("sunshine-ds5-test-{}", uuid::Uuid::new_v4()));
+        let source = root.join("source");
+        let destination = root.join("destination");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::write(source.join(super::SIDECAR_EXE), b"MZ-test").unwrap();
+        std::fs::write(
+            source.join("runtime.json"),
+            serde_json::json!({
+                "component_version": "1.0.0-build-runtime",
+                "protocol": super::PROTOCOL_VERSION,
+                "target": super::SIDECAR_PACKAGE_TARGET,
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let error = copy_runtime_files(&source, &destination).unwrap_err();
+
+        assert!(error.contains("runtime metadata does not match Sunshine"));
+        assert!(!destination.join(super::SIDECAR_EXE).exists());
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/src-tauri/src/dualsense.rs
+++ b/src-tauri/src/dualsense.rs
@@ -204,6 +204,7 @@ struct InstalledComponentManifest {
     sha256: String,
     protocol: u32,
     sidecar_file: String,
+    sidecar_sha256: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -850,6 +851,41 @@ fn validate_sidecar_runtime_metadata(directory: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_component_backup(directory: &Path) -> Result<(), String> {
+    let manifest: InstalledComponentManifest = serde_json::from_slice(
+        &fs::read(directory.join("component.json"))
+            .map_err(|error| format!("backup component manifest is missing: {error}"))?,
+    )
+    .map_err(|error| format!("backup component manifest is invalid: {error}"))?;
+    if manifest.protocol != PROTOCOL_VERSION || manifest.sidecar_file != SIDECAR_EXE {
+        return Err("backup component protocol or sidecar does not match Sunshine".to_string());
+    }
+
+    let runtime_metadata: SidecarRuntimeMetadata = serde_json::from_slice(
+        &fs::read(directory.join("runtime.json"))
+            .map_err(|error| format!("backup runtime metadata is missing: {error}"))?,
+    )
+    .map_err(|error| format!("backup runtime metadata is invalid: {error}"))?;
+    if runtime_metadata.component_version != manifest.component_version
+        || runtime_metadata.protocol != PROTOCOL_VERSION
+        || runtime_metadata.target != SIDECAR_PACKAGE_TARGET
+    {
+        return Err("backup runtime metadata does not match its component manifest".to_string());
+    }
+
+    let sidecar_hash = sha256_file(&directory.join(SIDECAR_EXE))?;
+    if manifest.sidecar_sha256.len() != 64
+        || !sidecar_hash.eq_ignore_ascii_case(&manifest.sidecar_sha256)
+    {
+        return Err("backup sidecar integrity check failed".to_string());
+    }
+    let hidmaestro_hash = sha256_file(&directory.join("HIDMaestro.Core.dll"))?;
+    if manifest.sha256.len() != 64 || !hidmaestro_hash.eq_ignore_ascii_case(&manifest.sha256) {
+        return Err("backup HIDMaestro integrity check failed".to_string());
+    }
+    Ok(())
+}
+
 fn extract_sidecar_package(
     archive_path: &Path,
     staging: &Path,
@@ -1224,10 +1260,25 @@ fn rollback_activated_component(
         if !backup.exists() {
             return Err("previous component backup is missing".to_string());
         }
+        validate_component_backup(backup)?;
         fs::rename(backup, active)
             .map_err(|error| format!("unable to restore previous component: {error}"))?;
     }
     Ok(())
+}
+
+fn install_error_after_rollback(
+    error: String,
+    active: &Path,
+    backup: &Path,
+    had_previous: bool,
+) -> String {
+    match rollback_activated_component(active, backup, had_previous) {
+        Ok(()) => format!("{error}; activated component was rolled back"),
+        Err(rollback_error) => {
+            format!("{error}; component rollback also failed: {rollback_error}")
+        }
+    }
 }
 
 async fn dualsense_install_impl(
@@ -1416,18 +1467,25 @@ async fn dualsense_install_impl(
         if config_error.starts_with("DS5-CFG-002:") {
             return Err(config_error);
         }
-        let rollback_result = rollback_activated_component(&active, &backup, had_previous);
-        return match rollback_result {
-            Ok(()) => Err(format!(
-                "{config_error}; activated component was rolled back"
-            )),
-            Err(rollback_error) => Err(format!(
-                "{config_error}; component rollback also failed: {rollback_error}"
-            )),
-        };
+        return Err(install_error_after_rollback(
+            config_error,
+            &active,
+            &backup,
+            had_previous,
+        ));
     }
     report_progress(progress, "complete", 100);
-    let mut status = dualsense_get_status().await?;
+    let mut status = match dualsense_get_status().await {
+        Ok(status) => status,
+        Err(status_error) => {
+            return Err(install_error_after_rollback(
+                status_error,
+                &active,
+                &backup,
+                had_previous,
+            ));
+        }
+    };
     if !status.verified {
         let verification_error = if status.detail.is_empty() {
             "DS5-PKG-003: the installed component did not pass the final capability check"
@@ -1435,14 +1493,12 @@ async fn dualsense_install_impl(
         } else {
             status.detail
         };
-        return match rollback_activated_component(&active, &backup, had_previous) {
-            Ok(()) => Err(format!(
-                "{verification_error}; activated component was rolled back"
-            )),
-            Err(rollback_error) => Err(format!(
-                "{verification_error}; component rollback also failed: {rollback_error}"
-            )),
-        };
+        return Err(install_error_after_rollback(
+            verification_error,
+            &active,
+            &backup,
+            had_previous,
+        ));
     }
     status.reboot_recommended = reboot_recommended;
     Ok(status)
@@ -2080,6 +2136,35 @@ mod tests {
     use std::io::Write as _;
     use std::process::Command;
 
+    fn write_valid_component(directory: &std::path::Path, marker: &[u8]) {
+        std::fs::create_dir_all(directory).unwrap();
+        std::fs::write(directory.join(super::SIDECAR_EXE), marker).unwrap();
+        std::fs::write(directory.join("HIDMaestro.Core.dll"), marker).unwrap();
+        std::fs::write(
+            directory.join("runtime.json"),
+            serde_json::json!({
+                "component_version": "1.0.0",
+                "protocol": super::PROTOCOL_VERSION,
+                "target": super::SIDECAR_PACKAGE_TARGET,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        std::fs::write(
+            directory.join("component.json"),
+            serde_json::json!({
+                "component_version": "1.0.0",
+                "hidmaestro_version": "1.6.1",
+                "sha256": sha256_file(&directory.join("HIDMaestro.Core.dll")).unwrap(),
+                "protocol": super::PROTOCOL_VERSION,
+                "sidecar_file": super::SIDECAR_EXE,
+                "sidecar_sha256": sha256_file(&directory.join(super::SIDECAR_EXE)).unwrap(),
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn composite_profile_requires_usbip() {
         let error = validate_requested_profile(true, true, false, false).unwrap_err();
@@ -2144,6 +2229,7 @@ mod tests {
             sha256: super::HIDMAESTRO_SHA256.to_uppercase(),
             protocol: super::PROTOCOL_VERSION,
             sidecar_file: super::SIDECAR_EXE.to_string(),
+            sidecar_sha256: "a".repeat(64),
         };
         assert!(!component_update_available(Some(&current)));
         assert!(component_matches_current_runtime(Some(&current), true));
@@ -2264,14 +2350,13 @@ mod tests {
         let active = root.join("active");
         let backup = root.join("previous");
         std::fs::create_dir_all(&active).unwrap();
-        std::fs::create_dir_all(&backup).unwrap();
         std::fs::write(active.join("runtime.txt"), b"failed").unwrap();
-        std::fs::write(backup.join("runtime.txt"), b"previous").unwrap();
+        write_valid_component(&backup, b"previous");
 
         rollback_activated_component(&active, &backup, true).unwrap();
 
         assert_eq!(
-            std::fs::read(active.join("runtime.txt")).unwrap(),
+            std::fs::read(active.join(super::SIDECAR_EXE)).unwrap(),
             b"previous"
         );
         assert!(!backup.exists());
@@ -2289,6 +2374,23 @@ mod tests {
         rollback_activated_component(&active, &backup, false).unwrap();
 
         assert!(!active.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn final_verification_rollback_rejects_a_corrupt_backup() {
+        let root = std::env::temp_dir().join(format!("sunshine-ds5-test-{}", uuid::Uuid::new_v4()));
+        let active = root.join("active");
+        let backup = root.join("previous");
+        std::fs::create_dir_all(&active).unwrap();
+        write_valid_component(&backup, b"previous");
+        std::fs::write(backup.join(super::SIDECAR_EXE), b"tampered").unwrap();
+
+        let error = rollback_activated_component(&active, &backup, true).unwrap_err();
+
+        assert!(error.contains("backup sidecar integrity check failed"));
+        assert!(!active.exists());
+        assert!(backup.exists());
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/src-tauri/src/dualsense.rs
+++ b/src-tauri/src/dualsense.rs
@@ -1211,6 +1211,25 @@ async fn apply_config(
     Ok(())
 }
 
+fn rollback_activated_component(
+    active: &Path,
+    backup: &Path,
+    had_previous: bool,
+) -> Result<(), String> {
+    if active.exists() {
+        fs::remove_dir_all(active)
+            .map_err(|error| format!("unable to remove failed active component: {error}"))?;
+    }
+    if had_previous {
+        if !backup.exists() {
+            return Err("previous component backup is missing".to_string());
+        }
+        fs::rename(backup, active)
+            .map_err(|error| format!("unable to restore previous component: {error}"))?;
+    }
+    Ok(())
+}
+
 async fn dualsense_install_impl(
     progress: &ProgressReporter<'_>,
     local_sidecar_package: Option<&Path>,
@@ -1397,21 +1416,7 @@ async fn dualsense_install_impl(
         if config_error.starts_with("DS5-CFG-002:") {
             return Err(config_error);
         }
-        let rollback_result = (|| -> Result<(), String> {
-            if active.exists() {
-                fs::remove_dir_all(&active).map_err(|error| {
-                    format!("unable to remove failed active component: {error}")
-                })?;
-            }
-            if had_previous {
-                if !backup.exists() {
-                    return Err("previous component backup is missing".to_string());
-                }
-                fs::rename(&backup, &active)
-                    .map_err(|error| format!("unable to restore previous component: {error}"))?;
-            }
-            Ok(())
-        })();
+        let rollback_result = rollback_activated_component(&active, &backup, had_previous);
         return match rollback_result {
             Ok(()) => Err(format!(
                 "{config_error}; activated component was rolled back"
@@ -1424,12 +1429,20 @@ async fn dualsense_install_impl(
     report_progress(progress, "complete", 100);
     let mut status = dualsense_get_status().await?;
     if !status.verified {
-        return Err(if status.detail.is_empty() {
+        let verification_error = if status.detail.is_empty() {
             "DS5-PKG-003: the installed component did not pass the final capability check"
                 .to_string()
         } else {
             status.detail
-        });
+        };
+        return match rollback_activated_component(&active, &backup, had_previous) {
+            Ok(()) => Err(format!(
+                "{verification_error}; activated component was rolled back"
+            )),
+            Err(rollback_error) => Err(format!(
+                "{verification_error}; component rollback also failed: {rollback_error}"
+            )),
+        };
     }
     status.reboot_recommended = reboot_recommended;
     Ok(status)
@@ -2061,8 +2074,8 @@ mod tests {
         apply_gamepad_selection, classify_usbip_installer_exit_code,
         component_matches_current_runtime, component_state, component_test_failure,
         component_update_available, copy_runtime_files, extract_sidecar_package,
-        pinned_usbip_installed, sha256_file, validate_requested_profile,
-        validate_sidecar_package_manifest,
+        pinned_usbip_installed, rollback_activated_component, sha256_file,
+        validate_requested_profile, validate_sidecar_package_manifest,
     };
     use std::io::Write as _;
     use std::process::Command;
@@ -2242,6 +2255,40 @@ mod tests {
 
         assert!(error.contains("runtime metadata does not match Sunshine"));
         assert!(!destination.join(super::SIDECAR_EXE).exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn final_verification_rollback_restores_the_previous_component() {
+        let root = std::env::temp_dir().join(format!("sunshine-ds5-test-{}", uuid::Uuid::new_v4()));
+        let active = root.join("active");
+        let backup = root.join("previous");
+        std::fs::create_dir_all(&active).unwrap();
+        std::fs::create_dir_all(&backup).unwrap();
+        std::fs::write(active.join("runtime.txt"), b"failed").unwrap();
+        std::fs::write(backup.join("runtime.txt"), b"previous").unwrap();
+
+        rollback_activated_component(&active, &backup, true).unwrap();
+
+        assert_eq!(
+            std::fs::read(active.join("runtime.txt")).unwrap(),
+            b"previous"
+        );
+        assert!(!backup.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn final_verification_rollback_removes_a_failed_first_install() {
+        let root = std::env::temp_dir().join(format!("sunshine-ds5-test-{}", uuid::Uuid::new_v4()));
+        let active = root.join("active");
+        let backup = root.join("previous");
+        std::fs::create_dir_all(&active).unwrap();
+        std::fs::write(active.join("runtime.txt"), b"failed").unwrap();
+
+        rollback_activated_component(&active, &backup, false).unwrap();
+
+        assert!(!active.exists());
         std::fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
## 改了啥呀

- 有发布 manifest 时优先安装当前 Sidecar 包，不再误用升级后遗留的旧内置 runtime，杂鱼安装器别再假装升级成功啦
- 复用 runtime.json 校验，fallback runtime 也必须匹配当前组件版本、协议与目标
- 激活前要求当前原神兼容能力，激活后再确认组件 verified
- 最终能力校验失败时恢复旧组件；首次安装失败则移除未验证组件
- 增加陈旧 runtime 与两类回滚路径的回归测试

## 为啥要改

旧安装目录可能保留 tools/sunshine-ds5-sidecar。修复组件原先会优先复制它，再写入 1.1.0 的 component.json，导致界面版本看似正确但 Sidecar 仍以 DS5-PROTO-001 不可用。

## 验证

- cargo test --manifest-path src-tauri/Cargo.toml（129 passed）
- npm run test:renderer（22 passed）
- npm run build:renderer
- git diff --check
