### PR TITLE
fix(dualsense): 优化快速配置保存与错误展示

### DIFF
--- a/src-tauri/src/dualsense.rs
+++ b/src-tauri/src/dualsense.rs
@@ -259,6 +259,18 @@ struct CoreDualSenseSnapshot {
     entity_tag: Option<HeaderValue>,
 }
 
+#[derive(Debug)]
+enum CoreDualSenseResponseError {
+    Transfer(reqwest::Error),
+    Message(String),
+}
+
+impl From<String> for CoreDualSenseResponseError {
+    fn from(message: String) -> Self {
+        Self::Message(message)
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct DualSenseTuningResult {
     legacy_strength: f64,
@@ -530,7 +542,7 @@ fn component_matches_current_runtime(
 
 async fn read_core_ds5_response(
     mut response: reqwest::Response,
-) -> Result<CoreDualSenseSnapshot, String> {
+) -> Result<CoreDualSenseSnapshot, CoreDualSenseResponseError> {
     const MAX_RESPONSE_BYTES: usize = 64 * 1024;
     let status = response.status();
     let entity_tag = response.headers().get(reqwest::header::ETAG).cloned();
@@ -538,7 +550,9 @@ async fn read_core_ds5_response(
         .content_length()
         .is_some_and(|size| size > MAX_RESPONSE_BYTES as u64)
     {
-        return Err("DS5-CFG-001: DualSense configuration response is too large".to_string());
+        return Err("DS5-CFG-001: DualSense configuration response is too large"
+            .to_string()
+            .into());
     }
     let mut bytes = Vec::with_capacity(
         response
@@ -549,16 +563,12 @@ async fn read_core_ds5_response(
     while let Some(chunk) = response
         .chunk()
         .await
-        .map_err(|error| {
-            warn!(
-                "Unable to read the DualSense configuration response: {}",
-                error.without_url()
-            );
-            "DS5-CFG-001: unable to read DualSense configuration".to_string()
-        })?
+        .map_err(CoreDualSenseResponseError::Transfer)?
     {
         if bytes.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
-            return Err("DS5-CFG-001: DualSense configuration response is too large".to_string());
+            return Err("DS5-CFG-001: DualSense configuration response is too large"
+                .to_string()
+                .into());
         }
         bytes.extend_from_slice(&chunk);
     }
@@ -566,10 +576,12 @@ async fn read_core_ds5_response(
         let error_code = serde_json::from_slice::<serde_json::Value>(&bytes)
             .ok()
             .and_then(|body| body.get("error_code")?.as_str().map(str::to_owned));
-        return Err(core_ds5_http_error(error_code.as_deref(), status));
+        return Err(core_ds5_http_error(error_code.as_deref(), status).into());
     }
     let result: CoreDualSenseResponse = serde_json::from_slice(&bytes).map_err(|error| {
-        format!("DS5-CFG-001: invalid DualSense configuration response: {error}")
+        CoreDualSenseResponseError::Message(format!(
+            "DS5-CFG-001: invalid DualSense configuration response: {error}"
+        ))
     })?;
     let result = validate_core_ds5_response(result)?;
     let entity_tag = entity_tag.map(validate_strong_entity_tag).transpose()?;
@@ -584,15 +596,16 @@ async fn get_core_ds5_settings() -> Result<CoreDualSenseSnapshot, String> {
         warn!("Unable to resolve the Sunshine address for DualSense configuration");
         "DS5-CFG-001: unable to read DualSense configuration".to_string()
     })?;
-    let endpoint = format!(
-        "{}/api/dualsense/config",
-        base_url.trim_end_matches('/')
-    );
+    let endpoint = format!("{}/api/dualsense/config", base_url.trim_end_matches('/'));
     let client = crate::sunshine::create_https_client()?;
     for attempt in 1..=CORE_CONFIG_READ_ATTEMPTS {
-        match client.get(&endpoint).send().await {
-            Ok(response) => return read_core_ds5_response(response).await,
-            Err(error) => {
+        let response = match client.get(&endpoint).send().await {
+            Ok(response) => read_core_ds5_response(response).await,
+            Err(error) => Err(CoreDualSenseResponseError::Transfer(error)),
+        };
+        match response {
+            Ok(snapshot) => return Ok(snapshot),
+            Err(CoreDualSenseResponseError::Transfer(error)) => {
                 let timed_out = error.is_timeout();
                 warn!(
                     "Unable to query DualSense configuration (attempt {attempt}/{CORE_CONFIG_READ_ATTEMPTS}): {}",
@@ -604,6 +617,7 @@ async fn get_core_ds5_settings() -> Result<CoreDualSenseSnapshot, String> {
                     break;
                 }
             }
+            Err(CoreDualSenseResponseError::Message(message)) => return Err(message),
         }
     }
     Err("DS5-CFG-001: unable to read DualSense configuration".to_string())
@@ -633,9 +647,19 @@ async fn save_core_ds5_settings(
             );
             "DS5-CFG-003: unable to save DualSense configuration".to_string()
         })?;
-    read_core_ds5_response(response)
-        .await
-        .map_err(|error| error.replacen("DS5-CFG-001:", "DS5-CFG-003:", 1))
+    read_core_ds5_response(response).await.map_err(|error| {
+        let message = match error {
+            CoreDualSenseResponseError::Transfer(error) => {
+                warn!(
+                    "Unable to read the saved DualSense configuration response: {}",
+                    error.without_url()
+                );
+                "DS5-CFG-001: unable to read DualSense configuration".to_string()
+            }
+            CoreDualSenseResponseError::Message(message) => message,
+        };
+        message.replacen("DS5-CFG-001:", "DS5-CFG-003:", 1)
+    })
 }
 
 fn sha256_file(path: &Path) -> Result<String, String> {

--- a/src-tauri/src/dualsense.rs
+++ b/src-tauri/src/dualsense.rs
@@ -41,6 +41,8 @@ const SIDECAR_PACKAGE_TARGET: &str = "win-x64-self-contained";
 const SIDECAR_PACKAGE_LICENSE: &str = "GPL-3.0-only";
 const MAX_SIDECAR_PACKAGE_BYTES: u64 = 160 * 1024 * 1024;
 const CONFIG_APPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const CORE_CONFIG_READ_ATTEMPTS: usize = 3;
+const CORE_CONFIG_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(75);
 #[cfg(target_os = "windows")]
 const ELEVATED_DS5_ARG: &str = "--elevated-dualsense";
 #[cfg(target_os = "windows")]
@@ -547,7 +549,13 @@ async fn read_core_ds5_response(
     while let Some(chunk) = response
         .chunk()
         .await
-        .map_err(|error| format!("DS5-CFG-001: unable to read DualSense configuration: {error}"))?
+        .map_err(|error| {
+            warn!(
+                "Unable to read the DualSense configuration response: {}",
+                error.without_url()
+            );
+            "DS5-CFG-001: unable to read DualSense configuration".to_string()
+        })?
     {
         if bytes.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
             return Err("DS5-CFG-001: DualSense configuration response is too large".to_string());
@@ -572,23 +580,43 @@ async fn read_core_ds5_response(
 }
 
 async fn get_core_ds5_settings() -> Result<CoreDualSenseSnapshot, String> {
-    let base_url = crate::sunshine::get_sunshine_url().await?;
-    let response = crate::sunshine::create_https_client()?
-        .get(format!(
-            "{}/api/dualsense/config",
-            base_url.trim_end_matches('/')
-        ))
-        .send()
-        .await
-        .map_err(|error| format!("DS5-CFG-001: unable to read DualSense configuration: {error}"))?;
-    read_core_ds5_response(response).await
+    let base_url = crate::sunshine::get_sunshine_url().await.map_err(|_| {
+        warn!("Unable to resolve the Sunshine address for DualSense configuration");
+        "DS5-CFG-001: unable to read DualSense configuration".to_string()
+    })?;
+    let endpoint = format!(
+        "{}/api/dualsense/config",
+        base_url.trim_end_matches('/')
+    );
+    let client = crate::sunshine::create_https_client()?;
+    for attempt in 1..=CORE_CONFIG_READ_ATTEMPTS {
+        match client.get(&endpoint).send().await {
+            Ok(response) => return read_core_ds5_response(response).await,
+            Err(error) => {
+                let timed_out = error.is_timeout();
+                warn!(
+                    "Unable to query DualSense configuration (attempt {attempt}/{CORE_CONFIG_READ_ATTEMPTS}): {}",
+                    error.without_url()
+                );
+                if attempt < CORE_CONFIG_READ_ATTEMPTS && !timed_out {
+                    tokio::time::sleep(CORE_CONFIG_RETRY_DELAY * attempt as u32).await;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Err("DS5-CFG-001: unable to read DualSense configuration".to_string())
 }
 
 async fn save_core_ds5_settings(
     settings: CoreDualSenseSettings,
     entity_tag: HeaderValue,
 ) -> Result<CoreDualSenseSnapshot, String> {
-    let base_url = crate::sunshine::get_sunshine_url().await?;
+    let base_url = crate::sunshine::get_sunshine_url().await.map_err(|_| {
+        warn!("Unable to resolve the Sunshine address for DualSense configuration");
+        "DS5-CFG-003: unable to save DualSense configuration".to_string()
+    })?;
     let response = crate::sunshine::create_https_client()?
         .post(format!(
             "{}/api/dualsense/config",
@@ -598,7 +626,13 @@ async fn save_core_ds5_settings(
         .json(&settings)
         .send()
         .await
-        .map_err(|error| format!("DS5-CFG-003: unable to save DualSense configuration: {error}"))?;
+        .map_err(|error| {
+            warn!(
+                "Unable to save DualSense configuration: {}",
+                error.without_url()
+            );
+            "DS5-CFG-003: unable to save DualSense configuration".to_string()
+        })?;
     read_core_ds5_response(response)
         .await
         .map_err(|error| error.replacen("DS5-CFG-001:", "DS5-CFG-003:", 1))

--- a/src/renderer/components/DualSenseSettings.vue
+++ b/src/renderer/components/DualSenseSettings.vue
@@ -286,6 +286,8 @@ import {
 } from '../composables/dualsenseErrors.js'
 import {
   createLatestIntentQueue,
+  dualSenseConfigAfterInstall,
+  dualSenseConfigAfterUninstall,
   dualSenseConfigMatches,
   dualSenseConfigReadable,
   dualSenseConfigUiState,
@@ -488,6 +490,7 @@ const refresh = async (quiet = false, allowBusy = false) => {
 const install = async (packagePath = null) => {
   if (controlsBusy.value) return
   packagePath = typeof packagePath === 'string' ? packagePath : null
+  const componentWasInstalled = status.value.installed
   const upgrading = Boolean(status.value.installed && status.value.update_available)
   const localPackage = Boolean(packagePath)
   operation.value = 'confirm-install'
@@ -520,6 +523,7 @@ const install = async (packagePath = null) => {
     return showError(result.message, 'install')
   }
   operation.value = ''
+  rebootRecommended.value = result.data.reboot_recommended
   const configReadable = dualSenseConfigReadable(result.data)
   status.value = mergeDualSenseStatus(status.value, result.data)
   statusKnown.value = true
@@ -531,7 +535,15 @@ const install = async (packagePath = null) => {
     legacyCurve.value = result.data.legacy_curve
     legacyNoiseGate.value = result.data.legacy_noise_gate
   }
-  rebootRecommended.value = result.data.reboot_recommended
+  const installedConfig = dualSenseConfigAfterInstall(result.data, componentWasInstalled)
+  if (installedConfig && !(await applyComponentConfig(installedConfig))) {
+    if (rebootRecommended.value) {
+      ElMessage.warning(result.data.usbip_available
+        ? t.value.dualSense.restartSuggestedAvailable
+        : t.value.dualSense.restartSuggestedUnavailable)
+    }
+    return
+  }
   operationError.value = ''
   ElMessage.success(upgrading ? t.value.dualSense.updateSuccess : t.value.dualSense.installSuccess)
   if (result.data.reboot_recommended) {
@@ -564,6 +576,24 @@ const applyConfigControls = (requested) => {
   enabled.value = requested.enabled
   audioHaptics.value = requested.audioHaptics
   genshinCompatibility.value = requested.genshinCompatibility
+}
+
+const restoreConfirmedConfigControls = () => {
+  enabled.value = status.value.enabled
+  audioHaptics.value = status.value.audio_haptics
+  genshinCompatibility.value = status.value.genshin_compatibility ?? false
+}
+
+const synchronizeConfirmedConfig = (preserveTuning) => {
+  const uiState = dualSenseConfigUiState(status.value, preserveTuning || tuningDirty.value)
+  enabled.value = uiState.enabled
+  audioHaptics.value = uiState.audioHaptics
+  genshinCompatibility.value = uiState.genshinCompatibility
+  if (uiState.tuning) {
+    legacyStrength.value = uiState.tuning.strength
+    legacyCurve.value = uiState.tuning.curve
+    legacyNoiseGate.value = uiState.tuning.noiseGate
+  }
 }
 
 const persistConfigIntent = async (requestedConfig, queue) => {
@@ -621,6 +651,30 @@ const persistConfigIntent = async (requestedConfig, queue) => {
   return { success: true, preserveTuning }
 }
 
+const applyComponentConfig = async (requestedConfig) => {
+  const queue = {
+    hasPending: () => false,
+    peekPending: () => undefined,
+  }
+  invalidateStatusRefresh()
+  saving.value = true
+  applyConfigControls(requestedConfig)
+  let outcome
+  try {
+    outcome = await persistConfigIntent(requestedConfig, queue)
+  } catch (error) {
+    outcome = { success: false, preserveTuning: tuningDirty.value, message: error }
+  }
+  saving.value = false
+  if (!outcome.success) {
+    restoreConfirmedConfigControls()
+    showError(outcome.message, 'config')
+    return false
+  }
+  synchronizeConfirmedConfig(outcome.preserveTuning)
+  return true
+}
+
 const configSaveQueue = createLatestIntentQueue(async (requestedConfig, queue) => {
   saving.value = true
   applyConfigControls(requestedConfig)
@@ -638,22 +692,11 @@ const configSaveQueue = createLatestIntentQueue(async (requestedConfig, queue) =
 
   saving.value = false
   if (!outcome.success) {
-    enabled.value = status.value.enabled
-    audioHaptics.value = status.value.audio_haptics
-    genshinCompatibility.value = status.value.genshin_compatibility ?? false
+    restoreConfirmedConfigControls()
     showError(outcome.message, 'config')
     return
   }
-
-  const uiState = dualSenseConfigUiState(status.value, outcome.preserveTuning || tuningDirty.value)
-  enabled.value = uiState.enabled
-  audioHaptics.value = uiState.audioHaptics
-  genshinCompatibility.value = uiState.genshinCompatibility
-  if (uiState.tuning) {
-    legacyStrength.value = uiState.tuning.strength
-    legacyCurve.value = uiState.tuning.curve
-    legacyNoiseGate.value = uiState.tuning.noiseGate
-  }
+  synchronizeConfirmedConfig(outcome.preserveTuning)
   ElMessage.success(t.value.dualSense.configSuccess)
 }, { debounceMs: CONFIG_SAVE_DEBOUNCE_MS })
 
@@ -778,8 +821,10 @@ const uninstall = async () => {
   operation.value = ''
   if (!result.success) return showError(result.message, 'uninstall')
   rebootRecommended.value = false
+  status.value = mergeDualSenseStatus(status.value, result.data)
+  statusKnown.value = true
+  if (!(await applyComponentConfig(dualSenseConfigAfterUninstall()))) return
   ElMessage.success(t.value.dualSense.uninstallSuccess)
-  await refresh()
 }
 
 onMounted(async () => {

--- a/src/renderer/components/DualSenseSettings.vue
+++ b/src/renderer/components/DualSenseSettings.vue
@@ -22,7 +22,7 @@
           class="enable-control"
           :disabled="!status.verified || status.in_use || componentControlsBusy"
           @change="saveSettings"
-        >{{ saving ? t.dualSense.saving : t.dualSense.enableShort }}</el-checkbox>
+        >{{ t.dualSense.enableShort }}</el-checkbox>
       </section>
 
       <section class="status-row" aria-live="polite">
@@ -140,7 +140,7 @@
               <strong>{{ t.dualSense.nativeModeShort }}</strong>
               <small>{{ status.usbip_available ? t.dualSense.nativeModeTip : t.dualSense.nativeUnavailable }}</small>
             </span>
-            <kbd>{{ saving ? t.dualSense.saving : (audioHaptics ? t.dualSense.enabledLabel : t.dualSense.disabledLabel) }}</kbd>
+            <kbd>{{ audioHaptics ? t.dualSense.enabledLabel : t.dualSense.disabledLabel }}</kbd>
           </button>
         </div>
       </section>
@@ -254,9 +254,9 @@
             </div>
           </div>
           <footer class="panel-footer">
-            <details v-if="status.detail">
+            <details v-if="safeStatusDetail">
               <summary>{{ status.error_code || t.dualSense.technicalDetails }}</summary>
-              <pre>{{ status.detail }}</pre>
+              <pre>{{ safeStatusDetail }}</pre>
             </details>
             <el-button
               v-if="status.installed"
@@ -279,7 +279,11 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { Refresh } from '@element-plus/icons-vue'
 import { open } from '@tauri-apps/plugin-dialog'
 import { dualsense } from '../tauri-adapter.js'
-import { dualSenseErrorCode, friendlyDualSenseError } from '../composables/dualsenseErrors.js'
+import {
+  dualSenseErrorCode,
+  friendlyDualSenseError,
+  safeDualSenseTechnicalError,
+} from '../composables/dualsenseErrors.js'
 import {
   createLatestIntentQueue,
   dualSenseConfigMatches,
@@ -327,6 +331,7 @@ let statusRefreshGeneration = 0
 let statusRefreshPromise = null
 let tuningSavePromise = null
 const STATUS_REFRESH_WAIT_TIMEOUT_MS = 5000
+const CONFIG_SAVE_DEBOUNCE_MS = 300
 
 const controlsBusy = computed(() => saving.value || tuningSaving.value || Boolean(operation.value))
 const componentControlsBusy = computed(() => Boolean(operation.value))
@@ -335,6 +340,9 @@ const tuningDirty = computed(() =>
   || legacyCurve.value !== status.value.legacy_curve
   || legacyNoiseGate.value !== status.value.legacy_noise_gate)
 const stateLabel = computed(() => t.value.dualSense.states[status.value.state] || status.value.state)
+const safeStatusDetail = computed(() => status.value.detail
+  ? safeDualSenseTechnicalError(status.value.detail)
+  : '')
 const operationStage = computed(() => t.value.dualSense.stages[operationStageKey.value] || operationStageKey.value)
 const nextAction = computed(() => {
   if (rebootRecommended.value) {
@@ -404,7 +412,7 @@ const healthRows = computed(() => [
 ])
 
 const showError = (message, context = 'generic') => {
-  operationError.value = String(message || '')
+  operationError.value = safeDualSenseTechnicalError(message)
   ElMessage.error(friendlyDualSenseError(message, t.value.dualSense.errors, context))
 }
 
@@ -559,7 +567,6 @@ const applyConfigControls = (requested) => {
 }
 
 const persistConfigIntent = async (requestedConfig, queue) => {
-  invalidateStatusRefresh()
   const requestedEnabled = requestedConfig.enabled
   const requestedAudioHaptics = requestedConfig.audioHaptics
   const requestedGenshinCompatibility = requestedConfig.genshinCompatibility
@@ -648,7 +655,7 @@ const configSaveQueue = createLatestIntentQueue(async (requestedConfig, queue) =
     legacyNoiseGate.value = uiState.tuning.noiseGate
   }
   ElMessage.success(t.value.dualSense.configSuccess)
-})
+}, { debounceMs: CONFIG_SAVE_DEBOUNCE_MS })
 
 const saveSettings = async () => {
   if (operation.value) {
@@ -665,6 +672,9 @@ const saveSettings = async () => {
     audioHaptics: requestedAudioHaptics,
     genshinCompatibility: requestedGenshinCompatibility,
   }
+  invalidateStatusRefresh()
+  operationError.value = ''
+  saving.value = true
   applyConfigControls(requestedConfig)
   await configSaveQueue.submit(requestedConfig)
 }

--- a/src/renderer/composables/dualsenseConfigSync.js
+++ b/src/renderer/composables/dualsenseConfigSync.js
@@ -19,6 +19,20 @@ export const dualSenseConfigMatches = (data, requested) =>
   && data.audio_haptics === requested.audioHaptics
   && (data.genshin_compatibility ?? false) === requested.genshinCompatibility
 
+export const dualSenseConfigAfterInstall = (status, wasInstalled = false) => wasInstalled
+  ? null
+  : {
+      enabled: true,
+      audioHaptics: Boolean(status?.usbip_available && status?.composite_profile),
+      genshinCompatibility: false,
+    }
+
+export const dualSenseConfigAfterUninstall = () => ({
+  enabled: false,
+  audioHaptics: true,
+  genshinCompatibility: false,
+})
+
 export const createLatestIntentQueue = (run, { debounceMs = 0 } = {}) => {
   let active = null
   let pending

--- a/src/renderer/composables/dualsenseConfigSync.js
+++ b/src/renderer/composables/dualsenseConfigSync.js
@@ -19,19 +19,31 @@ export const dualSenseConfigMatches = (data, requested) =>
   && data.audio_haptics === requested.audioHaptics
   && (data.genshin_compatibility ?? false) === requested.genshinCompatibility
 
-export const createLatestIntentQueue = (run) => {
+export const createLatestIntentQueue = (run, { debounceMs = 0 } = {}) => {
   let active = null
   let pending
+  let intentVersion = 0
   const state = {
     hasPending: () => pending !== undefined,
     peekPending: () => pending,
   }
 
+  const waitForSettledIntent = async () => {
+    if (debounceMs <= 0) return
+    let observedVersion
+    do {
+      observedVersion = intentVersion
+      await new Promise((resolve) => setTimeout(resolve, debounceMs))
+    } while (observedVersion !== intentVersion)
+  }
+
   const submit = (intent) => {
     pending = intent
+    intentVersion += 1
     if (!active) {
       active = (async () => {
         while (pending !== undefined) {
+          if (debounceMs > 0) await waitForSettledIntent()
           const current = pending
           pending = undefined
           await run(current, state)

--- a/src/renderer/composables/dualsenseConfigSync.test.js
+++ b/src/renderer/composables/dualsenseConfigSync.test.js
@@ -82,6 +82,20 @@ test('serializes config saves and keeps only the latest pending intent', async (
   assert.equal(queue.hasPending(), false)
 })
 
+test('debounces rapid config changes before sending the latest intent', async () => {
+  const observed = []
+  const queue = createLatestIntentQueue(async (intent) => {
+    observed.push(intent)
+  }, { debounceMs: 5 })
+
+  const saving = queue.submit('enable')
+  queue.submit('disable')
+  queue.submit('enable-latest')
+
+  await saving
+  assert.deepEqual(observed, ['enable-latest'])
+})
+
 test('preserves confirmed config when a status refresh cannot read Core settings', () => {
   const current = {
     ...response,

--- a/src/renderer/composables/dualsenseConfigSync.test.js
+++ b/src/renderer/composables/dualsenseConfigSync.test.js
@@ -3,6 +3,8 @@ import test from 'node:test'
 
 import {
   createLatestIntentQueue,
+  dualSenseConfigAfterInstall,
+  dualSenseConfigAfterUninstall,
   dualSenseConfigMatches,
   dualSenseConfigReadable,
   dualSenseConfigUiState,
@@ -57,6 +59,37 @@ test('recognizes a requested switch state after an ambiguous save response', () 
     audioHaptics: false,
     genshinCompatibility: false,
   }), false)
+})
+
+test('enables the available DualSense capabilities after a fresh install', () => {
+  assert.deepEqual(dualSenseConfigAfterInstall({
+    usbip_available: true,
+    composite_profile: true,
+  }), {
+    enabled: true,
+    audioHaptics: true,
+    genshinCompatibility: false,
+  })
+  assert.deepEqual(dualSenseConfigAfterInstall({
+    usbip_available: false,
+    composite_profile: true,
+  }), {
+    enabled: true,
+    audioHaptics: false,
+    genshinCompatibility: false,
+  })
+  assert.equal(dualSenseConfigAfterInstall({
+    usbip_available: true,
+    composite_profile: true,
+  }, true), null)
+})
+
+test('disables DualSense after component removal while restoring audio defaults', () => {
+  assert.deepEqual(dualSenseConfigAfterUninstall(), {
+    enabled: false,
+    audioHaptics: true,
+    genshinCompatibility: false,
+  })
 })
 
 test('serializes config saves and keeps only the latest pending intent', async () => {

--- a/src/renderer/composables/dualsenseErrors.js
+++ b/src/renderer/composables/dualsenseErrors.js
@@ -1,6 +1,11 @@
 const CODE_PATTERN = /^(DS5-[A-Z]+-\d{3}):\s*/
+const TECHNICAL_MESSAGE_PATTERN = /^(DS5-[A-Z]+-\d{3}:\s*[^:\r\n]+)/
 
 export const dualSenseErrorCode = (message) => String(message || '').match(CODE_PATTERN)?.[1] || ''
+
+export const safeDualSenseTechnicalError = (message) =>
+  String(message || '').match(TECHNICAL_MESSAGE_PATTERN)?.[1]
+  || 'DualSense operation failed'
 
 export const friendlyDualSenseError = (message, messages, context = 'generic') => {
   const code = dualSenseErrorCode(message)

--- a/src/renderer/composables/dualsenseErrors.test.js
+++ b/src/renderer/composables/dualsenseErrors.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { dualSenseErrorCode, friendlyDualSenseError } from './dualsenseErrors.js'
+import {
+  dualSenseErrorCode,
+  friendlyDualSenseError,
+  safeDualSenseTechnicalError,
+} from './dualsenseErrors.js'
 
 const messages = {
   unknown: 'Please try again.',
@@ -37,6 +41,19 @@ describe('DualSense user-facing errors', () => {
     assert.equal(
       friendlyDualSenseError('DS5-CFG-003: unable to save Sunshine configuration: connection reset', messages, 'config'),
       'Make sure Sunshine is running.',
+    )
+  })
+
+  it('removes request URLs and transport details from technical errors', () => {
+    assert.equal(
+      safeDualSenseTechnicalError(
+        'DS5-CFG-001: unable to read DualSense configuration: error sending request for url (https://example.invalid/api/dualsense/config)',
+      ),
+      'DS5-CFG-001: unable to read DualSense configuration',
+    )
+    assert.equal(
+      safeDualSenseTechnicalError('request failed for https://example.invalid/private'),
+      'DualSense operation failed',
     )
   })
 


### PR DESCRIPTION
## 说明

快速连续切换 DualSense 配置时，前端仍可能在相邻请求之间重复执行 GET/POST，并将本地传输错误的 URL 和内部信息显示在页面中。保存期间把配置标签替换为“保存中”也会混淆用户选择与请求状态。

## 修改

- 配置保存增加 300 ms 防抖，并与 latest-intent 队列配合，只提交连续操作后的最终状态。
- 用户操作后立即废弃旧状态刷新；安全的配置 GET 使用有界重试，POST 保持不自动重发。
- 技术信息和组件详情只显示稳定错误摘要，不再展示请求 URL 或底层传输错误。
- 启用及 HD Haptics 标签始终表示当前选择，不再替换为“保存中”。
- 补充防抖队列和错误脱敏回归测试。