### PR TITLE
fix(theme): 修正控制器页深浅主题混搭

### DIFF
--- a/src/renderer/styles/DualSenseSettings.less
+++ b/src/renderer/styles/DualSenseSettings.less
@@ -15,7 +15,12 @@
 
 @ds5-pixel-font: 'FusionPixel', 'PixelMplus12', 'YouYuan', 'Courier New', monospace;
 
-.ds5-page {
+// 主题令牌两块都走 :global()：`:global(x) y` 的写法会丢弃括号外的选择器，
+// 深色块因此只会编译成 `[data-bs-theme='dark']` 挂到 <html> 上，只能靠继承
+// 传给 .ds5-page，于是被直接命中元素的浅色块整体压过 —— 页面就成了
+// 「莫兰迪文字 + Gura 蓝描边 + 近白窗底」的深浅混搭。
+// 这样写让两块权重明确：:global(.ds5-page) 低于 :global([...dark] .ds5-page)。
+:global(.ds5-page) {
   // —— 像素菜单令牌：浅色 = Gura 蓝 ——
   --pix-font: @ds5-pixel-font;
   --ds5-primary: #4a9eff;
@@ -24,14 +29,6 @@
   --ds5-window-fill: rgba(255, 255, 255, .93);
   --ds5-window-shadow: rgba(74, 158, 255, .22);
   --ds5-hover-fill: rgba(74, 158, 255, .1);
-
-  max-width: 860px;
-  margin: 0 auto;
-  padding: 34px 30px 60px;
-  color: var(--el-text-color-primary);
-  font-family: 'Microsoft YaHei UI', 'Noto Sans SC', sans-serif;
-  font-size: 14px;
-  line-height: 1.6;
 
   // —— Element Plus 主色梯度对齐像素令牌 ——
   --el-color-primary: var(--ds5-primary);
@@ -43,7 +40,17 @@
   --el-color-primary-light-9: #e6f2ff;
 }
 
-:global([data-bs-theme='dark']) .ds5-page {
+.ds5-page {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 34px 30px 60px;
+  color: var(--el-text-color-primary);
+  font-family: 'Microsoft YaHei UI', 'Noto Sans SC', sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+:global([data-bs-theme='dark'] .ds5-page) {
   // —— 像素菜单令牌：暗色 = 莫兰迪 ——
   --ds5-primary: #d4a5a5;
   --ds5-primary-deep: #a98383;
@@ -52,6 +59,7 @@
   --ds5-window-shadow: rgba(0, 0, 0, .45);
   --ds5-hover-fill: rgba(212, 165, 165, .12);
 
+  // 只保留本页特有的主色梯度，其余深色 token 由 styles/element-theme.less 统一提供
   --el-color-primary: var(--ds5-primary);
   --el-color-primary-dark-2: var(--ds5-primary-deep);
   --el-color-primary-light-3: rgba(212, 165, 165, .55);
@@ -59,26 +67,6 @@
   --el-color-primary-light-7: rgba(212, 165, 165, .26);
   --el-color-primary-light-8: rgba(212, 165, 165, .18);
   --el-color-primary-light-9: rgba(212, 165, 165, .12);
-
-  --el-bg-color-overlay: rgba(61, 50, 53, .72);
-  --el-fill-color-blank: rgba(255, 255, 255, .055);
-  --el-fill-color-light: rgba(255, 255, 255, .055);
-  --el-fill-color-lighter: rgba(255, 255, 255, .035);
-  --el-fill-color-extra-light: rgba(255, 255, 255, .025);
-  --el-text-color-primary: #f0dfc3;
-  --el-text-color-regular: #d6c3a7;
-  --el-text-color-secondary: #b9aca8;
-  --el-text-color-placeholder: #9d9494;
-  --el-border-color: rgba(230, 213, 184, .22);
-  --el-border-color-lighter: rgba(230, 213, 184, .11);
-  --el-border-color-extra-light: rgba(230, 213, 184, .08);
-  --el-color-success-light-8: rgba(103, 194, 58, .18);
-  --el-color-success-light-9: rgba(103, 194, 58, .11);
-  --el-color-warning-light-8: rgba(230, 162, 60, .2);
-  --el-color-warning-light-9: rgba(230, 162, 60, .12);
-  --el-color-warning-dark-2: #f0bd70;
-  --el-color-danger-light-8: rgba(245, 108, 108, .19);
-  color: var(--el-text-color-primary);
 }
 
 // ============ 页头 ============

--- a/src/renderer/styles/dialog.less
+++ b/src/renderer/styles/dialog.less
@@ -48,21 +48,27 @@ body[data-bs-theme="dark"],
     }
   }
 
-  .el-button {
-    border-radius: 8px !important;
-    padding: 8px 16px !important;
-    font-weight: 500 !important;
+  // 只作用于对话框内部：这些 !important 以前挂在 [data-bs-theme] 下的裸
+  // .el-button 上，会盖掉所有页面自己的按钮样式（控制器页的方括号文本操作
+  // 就被强行渲染成了圆角实心按钮）。
+  .el-dialog,
+  .el-message-box {
+    .el-button {
+      border-radius: 8px !important;
+      padding: 8px 16px !important;
+      font-weight: 500 !important;
 
-    &.el-button--primary {
-      background: #d4a5a5 !important;
-      color: #2d2628 !important;
-      border: none !important;
-    }
+      &.el-button--primary {
+        background: #d4a5a5 !important;
+        color: #2d2628 !important;
+        border: none !important;
+      }
 
-    &.el-button--default {
-      background: rgba(212, 165, 165, 0.2) !important;
-      color: #e6d5b8 !important;
-      border: 1px solid rgba(212, 165, 165, 0.3) !important;
+      &.el-button--default {
+        background: rgba(212, 165, 165, 0.2) !important;
+        color: #e6d5b8 !important;
+        border: 1px solid rgba(212, 165, 165, 0.3) !important;
+      }
     }
   }
 
@@ -144,21 +150,24 @@ body[data-bs-theme="light"],
     }
   }
 
-  .el-button {
-    border-radius: 8px !important;
-    padding: 8px 16px !important;
-    font-weight: 500 !important;
+  .el-dialog,
+  .el-message-box {
+    .el-button {
+      border-radius: 8px !important;
+      padding: 8px 16px !important;
+      font-weight: 500 !important;
 
-    &.el-button--primary {
-      background: #4a9eff !important;
-      color: white !important;
-      border: none !important;
-    }
+      &.el-button--primary {
+        background: #4a9eff !important;
+        color: white !important;
+        border: none !important;
+      }
 
-    &.el-button--default {
-      background: rgba(74, 158, 255, 0.1) !important;
-      color: #3a7ed5 !important;
-      border: 1px solid rgba(74, 158, 255, 0.3) !important;
+      &.el-button--default {
+        background: rgba(74, 158, 255, 0.1) !important;
+        color: #3a7ed5 !important;
+        border: 1px solid rgba(74, 158, 255, 0.3) !important;
+      }
     }
   }
 

--- a/src/renderer/styles/element-theme.less
+++ b/src/renderer/styles/element-theme.less
@@ -1,15 +1,16 @@
 // ========================================
 // Element Plus 主题变量层
 // ========================================
-//
 // Element Plus 的深色调色板挂在 `html.dark` 上（theme-chalk/dark/css-vars.css），
 // 而本应用用 `data-bs-theme` 切换主题，那份变量永远不会生效 —— 深色模式下组件
 // 读到的仍是 Element Plus 的浅色默认值。以前只能靠每个页面各写一份局部覆盖，
 // 漏掉的 token 就会静默回退到浅色，页面于是深浅混搭。
-//
 // 这里集中声明深色模式的整套 token。页面仍可在自己的作用域里继续覆盖
 // （权重更高），但不再需要为了「别变白」而重复声明一遍。
 // 浅色模式直接沿用 Element Plus 默认值，无需覆盖。
+// 未收录 --el-bg-color / --el-bg-color-page：本壳层里前者只被 .el-switch__action
+// （开关滑块，两套主题都应为白色）读取，后者无人读取；弹层与下拉走的是
+// --el-bg-color-overlay，对话框由 dialog.less 硬覆盖。
 
 @import './theme.less';
 

--- a/src/renderer/styles/element-theme.less
+++ b/src/renderer/styles/element-theme.less
@@ -1,0 +1,76 @@
+// ========================================
+// Element Plus 主题变量层
+// ========================================
+//
+// Element Plus 的深色调色板挂在 `html.dark` 上（theme-chalk/dark/css-vars.css），
+// 而本应用用 `data-bs-theme` 切换主题，那份变量永远不会生效 —— 深色模式下组件
+// 读到的仍是 Element Plus 的浅色默认值。以前只能靠每个页面各写一份局部覆盖，
+// 漏掉的 token 就会静默回退到浅色，页面于是深浅混搭。
+//
+// 这里集中声明深色模式的整套 token。页面仍可在自己的作用域里继续覆盖
+// （权重更高），但不再需要为了「别变白」而重复声明一遍。
+// 浅色模式直接沿用 Element Plus 默认值，无需覆盖。
+
+@import './theme.less';
+
+[data-bs-theme='dark'] {
+  // 强调色：深色模式跟随莫兰迪红，与侧边栏、对话框一致
+  --el-color-primary: @morandi-red;
+  --el-color-primary-light-3: rgba(212, 165, 165, 0.55);
+  --el-color-primary-light-5: rgba(212, 165, 165, 0.38);
+  --el-color-primary-light-7: rgba(212, 165, 165, 0.28);
+  --el-color-primary-light-8: rgba(212, 165, 165, 0.2);
+  --el-color-primary-light-9: rgba(212, 165, 165, 0.12);
+  --el-color-primary-dark-2: #e0bcbc;
+
+  // 状态色：基色两套主题一致，只重算深色底上的浅色档与 hover 档
+  --el-color-success-light-3: rgba(103, 194, 58, 0.45);
+  --el-color-success-light-5: rgba(103, 194, 58, 0.34);
+  --el-color-success-light-8: rgba(103, 194, 58, 0.18);
+  --el-color-success-light-9: rgba(103, 194, 58, 0.11);
+  --el-color-success-dark-2: #85ce61;
+  --el-color-warning-light-3: rgba(230, 162, 60, 0.5);
+  --el-color-warning-light-5: rgba(230, 162, 60, 0.38);
+  --el-color-warning-light-8: rgba(230, 162, 60, 0.2);
+  --el-color-warning-light-9: rgba(230, 162, 60, 0.12);
+  --el-color-warning-dark-2: #f0bd70;
+  --el-color-danger-light-3: rgba(245, 108, 108, 0.48);
+  --el-color-danger-light-5: rgba(245, 108, 108, 0.36);
+  --el-color-danger-light-8: rgba(245, 108, 108, 0.19);
+  --el-color-danger-light-9: rgba(245, 108, 108, 0.11);
+  --el-color-danger-dark-2: #f78989;
+  --el-color-error-light-3: rgba(245, 108, 108, 0.48);
+  --el-color-error-light-5: rgba(245, 108, 108, 0.36);
+  --el-color-error-light-8: rgba(245, 108, 108, 0.19);
+  --el-color-error-light-9: rgba(245, 108, 108, 0.11);
+  --el-color-error-dark-2: #f78989;
+  --el-color-info-light-3: rgba(230, 213, 184, 0.3);
+  --el-color-info-light-5: rgba(230, 213, 184, 0.2);
+  --el-color-info-light-8: rgba(230, 213, 184, 0.14);
+  --el-color-info-light-9: rgba(230, 213, 184, 0.08);
+  --el-color-info-dark-2: #cbbfa8;
+
+  // 文字
+  --el-text-color-primary: #f0dfc3;
+  --el-text-color-regular: #d6c3a7;
+  --el-text-color-secondary: #b9aca8;
+  --el-text-color-placeholder: #9d9494;
+  --el-text-color-disabled: #8b8385;
+
+  // 描边
+  --el-border-color: rgba(230, 213, 184, 0.22);
+  --el-border-color-hover: rgba(230, 213, 184, 0.34);
+  --el-border-color-light: rgba(230, 213, 184, 0.16);
+  --el-border-color-lighter: rgba(230, 213, 184, 0.11);
+  --el-border-color-extra-light: rgba(230, 213, 184, 0.08);
+
+  // 填充
+  --el-bg-color-overlay: rgba(61, 50, 53, 0.72);
+  --el-fill-color: rgba(255, 255, 255, 0.075);
+  --el-fill-color-dark: rgba(255, 255, 255, 0.11);
+  --el-fill-color-blank: rgba(255, 255, 255, 0.055);
+  --el-fill-color-light: rgba(255, 255, 255, 0.055);
+  --el-fill-color-lighter: rgba(255, 255, 255, 0.035);
+  --el-fill-color-extra-light: rgba(255, 255, 255, 0.025);
+  --el-mask-color-extra-light: rgba(45, 38, 40, 0.3);
+}

--- a/src/renderer/sunshine-frame.js
+++ b/src/renderer/sunshine-frame.js
@@ -5,6 +5,7 @@ import 'element-plus/theme-chalk/el-message.css'
 import 'element-plus/theme-chalk/el-overlay.css'
 import 'element-plus/theme-chalk/el-message-box.css'
 import 'element-plus/theme-chalk/el-notification.css'
+import './styles/element-theme.less'  // Element Plus 深色 token，需早于各页面覆盖
 import './styles/dialog.less'  // 导入对话框样式
 // 导入 Tauri polyfill
 import './tauri-polyfill.js'


### PR DESCRIPTION
## 问题

控制器页在深色模式下深浅主题混搭：窗体描边、`◈` 像素标签、分区标题与横线仍是浅色主题的 Gura 蓝 `#4a9eff`，窗底是近白的 `rgba(255, 255, 255, .93)`，而文字已经是莫兰迪奶油色 `#f0dfc3`；`[ 安装组件 ]` 这类方括号文本操作被渲染成 8px 圆角的实心莫兰迪按钮。

## 定位

两个独立成因。

### 1. `:global()` 丢掉了后代选择器

`styles/DualSenseSettings.less` 里浅色令牌写在 `.ds5-page`（作用域内，直接命中元素），深色令牌写在 `:global([data-bs-theme='dark']) .ds5-page`。Vue 的 scoped CSS 转换遇到 `:global()` 时**只保留括号内的选择器，括号外的部分被丢弃**，所以深色块实际编译成：

```css
[data-bs-theme=dark] { --ds5-primary: #d4a5a5; ... }   /* 挂到了 <html> 上 */
```

它只能靠继承传给 `.ds5-page`，而直接命中元素的声明永远胜过继承值。于是：

| token | 深色模式实际值 | 期望值 |
|---|---|---|
| `--ds5-primary` | `#4a9eff` | `#d4a5a5` |
| `--ds5-window-line` | `#4a9eff` | `#8b6f5e` |
| `--ds5-window-fill` | `rgba(255,255,255,.93)` | `rgba(45,38,40,.96)` |
| `--el-color-primary` | `#4a9eff` | `#d4a5a5` |
| `--el-text-color-primary` | `#f0dfc3` ✅（只在深色块声明，走继承） | — |

**两块都声明的 token 取浅色值，只有深色块声明的 token 取深色值** —— 这就是混搭的来源。附带影响是整份莫兰迪调色板泄漏到了 `<html>`。

### 2. `dialog.less` 的按钮覆盖没有限定在对话框里

`[data-bs-theme]` 下有一段裸 `.el-button { ... !important }`，会盖掉所有页面自己的按钮样式。控制器页的 `.ds5-action`（透明、方角、像素字、`padding: 3px 2px`）因此被强制成 `background: #d4a5a5; border-radius: 8px; padding: 8px 16px`。

## 修复

- **`styles/DualSenseSettings.less`**：两块主题令牌都放进 `:global()`，权重关系明确（`.ds5-page` < `[data-bs-theme=dark] .ds5-page`）；布局声明留在作用域内的 `.ds5-page`；深色块只保留本页特有的 `--ds5-*` 与主色梯度。
- **新增 `styles/element-theme.less`**：集中声明深色模式下 Element Plus 的整套 token。EP 自带的深色变量挂在 `html.dark` 上（`theme-chalk/dark/css-vars.css`），而本应用用 `data-bs-theme` 切换主题，那份变量永远不生效；此前只能各页面各写一份局部覆盖，漏掉的 token 就静默回退到浅色默认值。现在有了单一来源，页面仍可在自己作用域内继续覆盖。
- **`styles/dialog.less`**：把 `.el-button` 的 `!important` 覆盖收进 `.el-dialog` / `.el-message-box`（文件本身就叫 dialog，这显然是原意）。

## 验证

在渲染进程 dev server 上按计算样式核对（不是靠肉眼看截图）：

- 控制器页逐状态 —— `not_installed` / `repair_required` / `update_available` / `in_use` / `ready`（含调参区的 `el-input-number`、保存按钮、未保存标签）—— 深色模式下**没有任何** Element Plus 浅色默认值残留。
- 基地显示器 / Web 串流 / 米塔页同样清零；修复前 Web 串流有 2 处蓝色主色残留，现已消失。
- 浅色模式逐项比对无变化：`--el-color-primary: #4a9eff`、窗底 `rgba(255,255,255,.93)`、文字 `#303133`。
- 对话框与消息框保持原样：底色 `#3d3235`、莫兰迪描边、主按钮实心 `#d4a5a5` + 8px 圆角。
- `el-select` 下拉弹层（teleport 到 body）深色正常：`rgba(61,50,53,.72)` 底 + 莫兰迪选项文字。
- `vite build` 通过；`node --test` 34/34 通过。

### `dialog.less` 收窄作用域的影响面

只有两个入口 import 它：`sunshine-frame.js`（本 PR 已配套引入 token 层）和 `main.js` / `App.vue`（dashboard 开发桩，从不设置 `data-bs-theme`）。`desktop`、`console`、`toolbar`、`tool-window`、`pin`、`about`、`home` 都没引入过，本来就不受那些 `!important` 影响，也不会因这次改动而变化。

### 顺带做的审计

- 全仓扫了 `:global(x) y` 这个坑：只有被修的那一处。`SunshineFrame.vue` 里 4 处都写成 `:global(html[data-bs-theme='light'] .foo)`，括号内完整，是正确写法。
- `element-theme.less` 里 `@import './theme.less'` 是为了取 `@morandi-red`；`theme.less` 只有变量和带括号的 mixin，不产出任何 CSS，因此和 `dialog.less` 的同名 import 不会重复输出。
- 行尾：`git ls-files --eol` 四个文件索引里都是 `i/lf`，与同目录既有 `.less` 一致。

> 合并后父仓库 Sunshine 需要同步 submodule 指针。
