### PR TITLE
fix(ds5): reuse updater mirrors for component downloads

### DIFF
--- a/src-tauri/src/dualsense.rs
+++ b/src-tauri/src/dualsense.rs
@@ -6,7 +6,6 @@
 //! package, or from an explicit development override. This keeps the optional
 //! self-contained .NET runtime out of the main Sunshine package.
 
-use futures_util::StreamExt;
 use log::{info, warn};
 use once_cell::sync::{Lazy, OnceCell};
 use reqwest::header::HeaderValue;
@@ -14,12 +13,15 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::Emitter;
-use tokio::io::{AsyncWriteExt, BufWriter};
+
+use crate::github_download::{
+    self, DEFAULT_IDLE_TIMEOUT, DEFAULT_RESPONSE_TIMEOUT, DownloadAttemptPhase, DownloadRequest,
+};
 
 const COMPONENT_VERSION: &str = "1.2.0";
 const PROTOCOL_VERSION: u32 = 1;
@@ -42,7 +44,6 @@ const SIDECAR_PACKAGE_TARGET: &str = "win-x64-self-contained";
 const SIDECAR_PACKAGE_LICENSE: &str = "GPL-3.0-only";
 const MAX_SIDECAR_PACKAGE_MANIFEST_BYTES: u64 = 64 * 1024;
 const MAX_SIDECAR_PACKAGE_BYTES: u64 = 160 * 1024 * 1024;
-const COMPONENT_DOWNLOAD_BUFFER_BYTES: usize = 1024 * 1024;
 const CONFIG_APPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const CORE_CONFIG_READ_ATTEMPTS: usize = 3;
 const CORE_CONFIG_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(75);
@@ -406,6 +407,53 @@ fn emit_progress(app: &tauri::AppHandle, stage: &str, progress: u32) {
 
 fn report_progress(progress: &ProgressReporter<'_>, stage: &str, value: u32) {
     progress(stage, value.min(100));
+}
+
+struct ComponentDownloadSpec<'a> {
+    url: &'a str,
+    destination: &'a Path,
+    expected_size: Option<u64>,
+    max_size: u64,
+    stage: &'a str,
+    progress_start: u32,
+    progress_span: u32,
+    error_code: &'a str,
+}
+
+async fn download_component_asset(
+    spec: ComponentDownloadSpec<'_>,
+    progress: &ProgressReporter<'_>,
+) -> Result<(), String> {
+    report_progress(progress, spec.stage, spec.progress_start);
+    let mut highest_progress = spec.progress_start;
+    github_download::download_to_file_with_fallbacks(
+        DownloadRequest {
+            url: spec.url,
+            destination: spec.destination,
+            expected_size: spec.expected_size,
+            max_size: Some(spec.max_size),
+            user_agent: "foundation-sunshine-dualsense-component",
+            connect_timeout: std::time::Duration::from_secs(10),
+            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            overall_timeout: Some(std::time::Duration::from_secs(600)),
+        },
+        |event| {
+            if event.phase != DownloadAttemptPhase::Downloading || event.total == 0 {
+                return;
+            }
+            let value = spec.progress_start
+                + (event.downloaded.saturating_mul(spec.progress_span as u64) / event.total)
+                    .min(spec.progress_span as u64) as u32;
+            if value > highest_progress {
+                highest_progress = value;
+                report_progress(progress, spec.stage, value);
+            }
+        },
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("{}: download failed: {error}", spec.error_code))
 }
 
 fn component_root() -> PathBuf {
@@ -1377,7 +1425,6 @@ fn extract_sidecar_package(
 }
 
 async fn acquire_sidecar_package(
-    client: &reqwest::Client,
     manifest: &SidecarPackageManifest,
     local_package: Option<&Path>,
     destination: &Path,
@@ -1413,43 +1460,20 @@ async fn acquire_sidecar_package(
         );
     }
     report_progress(progress, "sidecar_downloading", 12);
-    let response = client
-        .get(&manifest.download_url)
-        .send()
-        .await
-        .map_err(|error| format!("DS5-PKG-001: sidecar download failed: {error}"))?
-        .error_for_status()
-        .map_err(|error| format!("DS5-PKG-001: sidecar download failed: {error}"))?;
-    let total_size = response.content_length();
-    if total_size.is_some_and(|size| size != manifest.size) {
-        return Err("DS5-PKG-001: sidecar download size does not match the manifest".to_string());
-    }
-    let output = tokio::fs::File::create(destination)
-        .await
-        .map_err(|error| error.to_string())?;
-    let mut output = BufWriter::with_capacity(COMPONENT_DOWNLOAD_BUFFER_BYTES, output);
-    let mut downloaded = 0u64;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk =
-            chunk.map_err(|error| format!("DS5-PKG-001: sidecar download failed: {error}"))?;
-        downloaded = downloaded.saturating_add(chunk.len() as u64);
-        if downloaded > manifest.size || downloaded > MAX_SIDECAR_PACKAGE_BYTES {
-            return Err("DS5-PKG-001: sidecar download exceeds the manifest size".to_string());
-        }
-        output
-            .write_all(&chunk)
-            .await
-            .map_err(|error| error.to_string())?;
-        let value = 12 + (downloaded.saturating_mul(24) / manifest.size).min(24) as u32;
-        report_progress(progress, "sidecar_downloading", value);
-    }
-    output.flush().await.map_err(|error| error.to_string())?;
-    drop(output);
-    if downloaded != manifest.size {
-        return Err("DS5-PKG-001: sidecar download ended before the expected size".to_string());
-    }
-    Ok(())
+    download_component_asset(
+        ComponentDownloadSpec {
+            url: &manifest.download_url,
+            destination,
+            expected_size: Some(manifest.size),
+            max_size: MAX_SIDECAR_PACKAGE_BYTES,
+            stage: "sidecar_downloading",
+            progress_start: 12,
+            progress_span: 24,
+            error_code: "DS5-PKG-001",
+        },
+        progress,
+    )
+    .await
 }
 
 fn extract_verified_package(archive_path: &Path, staging: &Path) -> Result<(), String> {
@@ -1514,7 +1538,6 @@ fn extract_verified_package(archive_path: &Path, staging: &Path) -> Result<(), S
 #[cfg(target_os = "windows")]
 async fn ensure_pinned_usbip(
     progress: &ProgressReporter<'_>,
-    client: &reqwest::Client,
     component_root: &Path,
 ) -> Result<UsbipInstallResult, String> {
     if installed_usbip_version().as_deref() == Some(USBIP_VERSION) {
@@ -1524,45 +1547,20 @@ async fn ensure_pinned_usbip(
     report_progress(progress, "transport_downloading", 3);
     let installer_path = component_root.join(format!("USBip-{USBIP_VERSION}-x64.partial.exe"));
     let download_result: Result<UsbipInstallResult, String> = async {
-        let response = client
-            .get(USBIP_URL)
-            .send()
-            .await
-            .map_err(|error| format!("DS5-DRV-001: USB/IP download failed: {error}"))?
-            .error_for_status()
-            .map_err(|error| format!("DS5-DRV-001: USB/IP download failed: {error}"))?;
-        if response
-            .content_length()
-            .is_some_and(|size| size > MAX_USBIP_INSTALLER_BYTES)
-        {
-            return Err("DS5-DRV-001: USB/IP installer exceeds the download limit".to_string());
-        }
-
-        let output = tokio::fs::File::create(&installer_path)
-            .await
-            .map_err(|error| error.to_string())?;
-        let mut output = BufWriter::with_capacity(COMPONENT_DOWNLOAD_BUFFER_BYTES, output);
-        let mut downloaded = 0u64;
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk
-                .map_err(|error| format!("DS5-DRV-001: USB/IP download failed: {error}"))?;
-            downloaded = downloaded.saturating_add(chunk.len() as u64);
-            if downloaded > MAX_USBIP_INSTALLER_BYTES {
-                return Err(
-                    "DS5-DRV-001: USB/IP installer exceeds the download limit".to_string(),
-                );
-            }
-            output
-                .write_all(&chunk)
-                .await
-                .map_err(|error| error.to_string())?;
-        }
-        output
-            .flush()
-            .await
-            .map_err(|error| error.to_string())?;
-        drop(output);
+        download_component_asset(
+            ComponentDownloadSpec {
+                url: USBIP_URL,
+                destination: &installer_path,
+                expected_size: None,
+                max_size: MAX_USBIP_INSTALLER_BYTES,
+                stage: "transport_downloading",
+                progress_start: 3,
+                progress_span: 6,
+                error_code: "DS5-DRV-001",
+            },
+            progress,
+        )
+        .await?;
 
         let actual = sha256_file(&installer_path)?;
         if actual != USBIP_SHA256 {
@@ -1614,7 +1612,6 @@ async fn ensure_pinned_usbip(
 #[cfg(not(target_os = "windows"))]
 async fn ensure_pinned_usbip(
     _progress: &ProgressReporter<'_>,
-    _client: &reqwest::Client,
     _component_root: &Path,
 ) -> Result<UsbipInstallResult, String> {
     Ok(UsbipInstallResult::Ready)
@@ -1695,21 +1692,13 @@ async fn dualsense_install_impl(
     let active = active_dir();
     let backup = root.join("previous");
     let had_previous = active.exists();
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(600))
-        .user_agent("foundation-sunshine-dualsense-component")
-        .build()
-        .map_err(|error| error.to_string())?;
-
     let install_result: Result<UsbipInstallResult, String> = async {
-        let usbip_install_result = ensure_pinned_usbip(progress, &client, &root).await?;
+        let usbip_install_result = ensure_pinned_usbip(progress, &root).await?;
         if let Some(manifest) = package_manifest.as_ref() {
             if using_discovered_package {
                 report_progress(progress, "sidecar_local", 12);
             }
             acquire_sidecar_package(
-                &client,
                 manifest,
                 local_sidecar_package,
                 &sidecar_archive_path,
@@ -1731,44 +1720,20 @@ async fn dualsense_install_impl(
             return Err("DS5-PKG-002: no DualSense sidecar source is available".to_string());
         }
 
-        let response = client
-            .get(HIDMAESTRO_URL)
-            .send()
-            .await
-            .map_err(|error| format!("DS5-PKG-001: download failed: {error}"))?
-            .error_for_status()
-            .map_err(|error| format!("DS5-PKG-001: download failed: {error}"))?;
-        report_progress(progress, "downloading", 38);
-        let total_size = response.content_length();
-        if total_size.is_some_and(|size| size > MAX_ARCHIVE_BYTES) {
-            return Err("DS5-PKG-002: release archive exceeds the download limit".to_string());
-        }
-        let output = tokio::fs::File::create(&archive_path)
-            .await
-            .map_err(|error| error.to_string())?;
-        let mut output = BufWriter::with_capacity(COMPONENT_DOWNLOAD_BUFFER_BYTES, output);
-        let mut downloaded = 0u64;
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|error| format!("DS5-PKG-001: download failed: {error}"))?;
-            downloaded = downloaded.saturating_add(chunk.len() as u64);
-            if downloaded > MAX_ARCHIVE_BYTES {
-                return Err("DS5-PKG-002: release archive exceeds the download limit".to_string());
-            }
-            output
-                .write_all(&chunk)
-                .await
-                .map_err(|error| error.to_string())?;
-            if let Some(total) = total_size.filter(|total| *total != 0) {
-                let download_progress = (downloaded * 34 / total).min(34) as u32;
-                report_progress(progress, "downloading", 38 + download_progress);
-            }
-        }
-        output
-            .flush()
-            .await
-            .map_err(|error| error.to_string())?;
-        drop(output);
+        download_component_asset(
+            ComponentDownloadSpec {
+                url: HIDMAESTRO_URL,
+                destination: &archive_path,
+                expected_size: None,
+                max_size: MAX_ARCHIVE_BYTES,
+                stage: "downloading",
+                progress_start: 38,
+                progress_span: 34,
+                error_code: "DS5-PKG-001",
+            },
+            progress,
+        )
+        .await?;
 
         report_progress(progress, "verifying", 74);
         let archive = archive_path.clone();

--- a/src-tauri/src/github_download.rs
+++ b/src-tauri/src/github_download.rs
@@ -1,0 +1,470 @@
+//! Shared, integrity-friendly downloader for GitHub Release assets.
+//!
+//! Callers remain responsible for cryptographic verification. This module only
+//! provides consistent transport behavior: direct GitHub first, followed by the
+//! configured acceleration mirrors, with bounded redirects, timeouts, size
+//! checks, streaming writes, and retry cleanup.
+
+use futures_util::StreamExt;
+use log::{debug, info, warn};
+use std::fmt;
+use std::path::Path;
+use std::time::Duration;
+use tokio::io::{AsyncWriteExt, BufWriter};
+
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(20);
+
+const GITHUB_RELEASE_HOST: &str = "github.com";
+const DOWNLOAD_BUFFER_BYTES: usize = 1024 * 1024;
+const DOWNLOAD_PROXY_PREFIXES: &[(&str, &str)] = &[
+    ("ghfast.top", "https://ghfast.top/"),
+    ("ghproxy.com", "https://ghproxy.com/"),
+    ("mirror.ghproxy.com", "https://mirror.ghproxy.com/"),
+];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DownloadSource {
+    name: &'static str,
+    url: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DownloadAttemptPhase {
+    Connecting,
+    Downloading,
+    Retrying,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DownloadProgress {
+    pub(crate) phase: DownloadAttemptPhase,
+    pub(crate) source: &'static str,
+    pub(crate) downloaded: u64,
+    pub(crate) total: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DownloadOutcome {
+    pub(crate) source: &'static str,
+    pub(crate) downloaded: u64,
+    pub(crate) total: u64,
+}
+
+pub(crate) struct DownloadRequest<'a> {
+    pub(crate) url: &'a str,
+    pub(crate) destination: &'a Path,
+    pub(crate) expected_size: Option<u64>,
+    pub(crate) max_size: Option<u64>,
+    pub(crate) user_agent: &'a str,
+    pub(crate) connect_timeout: Duration,
+    pub(crate) response_timeout: Duration,
+    pub(crate) idle_timeout: Duration,
+    pub(crate) overall_timeout: Option<Duration>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DownloadErrorKind {
+    Setup,
+    SourcesExhausted,
+}
+
+#[derive(Debug)]
+pub(crate) struct DownloadError {
+    kind: DownloadErrorKind,
+    detail: String,
+}
+
+impl DownloadError {
+    pub(crate) fn is_setup(&self) -> bool {
+        self.kind == DownloadErrorKind::Setup
+    }
+}
+
+impl fmt::Display for DownloadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+fn validate_github_release_url(url: &str) -> Result<(), String> {
+    let parsed =
+        reqwest::Url::parse(url).map_err(|error| format!("invalid download URL: {error}"))?;
+    if parsed.scheme() != "https" {
+        return Err("download URL must use HTTPS".to_string());
+    }
+    if parsed.host_str() != Some(GITHUB_RELEASE_HOST) {
+        return Err(format!("download URL must use {GITHUB_RELEASE_HOST}"));
+    }
+    Ok(())
+}
+
+fn build_download_sources(original_url: &str) -> Result<Vec<DownloadSource>, String> {
+    validate_github_release_url(original_url)?;
+    let mut sources = vec![DownloadSource {
+        name: "GitHub",
+        url: original_url.to_string(),
+    }];
+
+    for (name, prefix) in DOWNLOAD_PROXY_PREFIXES {
+        sources.push(DownloadSource {
+            name,
+            url: format!("{prefix}{original_url}"),
+        });
+    }
+    Ok(sources)
+}
+
+fn create_download_client(request: &DownloadRequest<'_>) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(request.connect_timeout)
+        .read_timeout(request.idle_timeout)
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .no_gzip()
+        .no_deflate();
+    if let Some(timeout) = request.overall_timeout {
+        builder = builder.timeout(timeout);
+    }
+    builder
+        .build()
+        .map_err(|error| format!("could not create download client: {error}"))
+}
+
+fn validate_download_response(
+    response: &reqwest::Response,
+    expected_size: Option<u64>,
+    max_size: Option<u64>,
+) -> Result<(), String> {
+    if !response.status().is_success() {
+        return Err(format!("HTTP status {}", response.status().as_u16()));
+    }
+
+    if let Some(content_type) = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+    {
+        let content_type = content_type.to_ascii_lowercase();
+        if content_type.starts_with("text/")
+            || content_type.contains("application/json")
+            || content_type.contains("application/xml")
+        {
+            return Err(format!("response is not a release asset: {content_type}"));
+        }
+    }
+
+    if response.content_length() == Some(0) {
+        return Err("response is empty".to_string());
+    }
+    if let (Some(expected), Some(actual)) = (expected_size, response.content_length())
+        && expected != actual
+    {
+        return Err(format!(
+            "content length mismatch: expected {expected} bytes, got {actual} bytes"
+        ));
+    }
+    if let (Some(limit), Some(actual)) = (max_size, response.content_length())
+        && actual > limit
+    {
+        return Err(format!(
+            "content length exceeds the {limit}-byte limit: {actual} bytes"
+        ));
+    }
+    Ok(())
+}
+
+async fn request_source(
+    client: &reqwest::Client,
+    source: &DownloadSource,
+    request: &DownloadRequest<'_>,
+) -> Result<reqwest::Response, String> {
+    let pending = client
+        .get(&source.url)
+        .header(reqwest::header::USER_AGENT, request.user_agent)
+        .header(reqwest::header::ACCEPT, "application/octet-stream")
+        .header(reqwest::header::ACCEPT_ENCODING, "identity")
+        .send();
+    let response = match tokio::time::timeout(request.response_timeout, pending).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => return Err(format!("request failed: {error}")),
+        Err(_) => {
+            return Err(format!(
+                "server did not respond within {} seconds",
+                request.response_timeout.as_secs()
+            ));
+        }
+    };
+    validate_download_response(&response, request.expected_size, request.max_size)?;
+    debug!(
+        "GitHub download source ready: {} ({})",
+        source.name,
+        response.url()
+    );
+    Ok(response)
+}
+
+async fn download_source_to_file<F>(
+    client: &reqwest::Client,
+    source: &DownloadSource,
+    request: &DownloadRequest<'_>,
+    on_progress: &mut F,
+) -> Result<DownloadOutcome, String>
+where
+    F: FnMut(DownloadProgress),
+{
+    let response = request_source(client, source, request).await?;
+    let response_size = response.content_length();
+    let total = request.expected_size.or(response_size).unwrap_or(0);
+    on_progress(DownloadProgress {
+        phase: DownloadAttemptPhase::Downloading,
+        source: source.name,
+        downloaded: 0,
+        total,
+    });
+
+    let file = tokio::fs::File::create(request.destination)
+        .await
+        .map_err(|error| format!("could not create partial download: {error}"))?;
+    let mut file = BufWriter::with_capacity(DOWNLOAD_BUFFER_BYTES, file);
+    let mut stream = response.bytes_stream();
+    let mut downloaded = 0u64;
+    while let Some(item) = stream.next().await {
+        let chunk = item.map_err(|error| format!("download stream failed: {error}"))?;
+        let next_size = downloaded
+            .checked_add(chunk.len() as u64)
+            .ok_or_else(|| "download size overflow".to_string())?;
+        if let Some(limit) = request.max_size
+            && next_size > limit
+        {
+            return Err(format!("download exceeds the {limit}-byte limit"));
+        }
+        if let Some(expected) = request.expected_size
+            && next_size > expected
+        {
+            return Err(format!("download exceeds the expected {expected} bytes"));
+        }
+        file.write_all(&chunk)
+            .await
+            .map_err(|error| format!("could not write partial download: {error}"))?;
+        downloaded = next_size;
+        on_progress(DownloadProgress {
+            phase: DownloadAttemptPhase::Downloading,
+            source: source.name,
+            downloaded,
+            total,
+        });
+    }
+    file.flush()
+        .await
+        .map_err(|error| format!("could not flush partial download: {error}"))?;
+    drop(file);
+
+    if downloaded == 0 {
+        return Err("download is empty".to_string());
+    }
+    if let Some(required) = request.expected_size.or(response_size)
+        && downloaded != required
+    {
+        return Err(format!(
+            "download size mismatch: expected {required} bytes, got {downloaded} bytes"
+        ));
+    }
+    Ok(DownloadOutcome {
+        source: source.name,
+        downloaded,
+        total,
+    })
+}
+
+pub(crate) async fn download_to_file_with_fallbacks<F>(
+    request: DownloadRequest<'_>,
+    on_progress: F,
+) -> Result<DownloadOutcome, DownloadError>
+where
+    F: FnMut(DownloadProgress),
+{
+    if request.expected_size == Some(0) || request.max_size == Some(0) {
+        return Err(DownloadError {
+            kind: DownloadErrorKind::Setup,
+            detail: "download size constraints must be greater than zero".to_string(),
+        });
+    }
+    if let (Some(expected), Some(limit)) = (request.expected_size, request.max_size)
+        && expected > limit
+    {
+        return Err(DownloadError {
+            kind: DownloadErrorKind::Setup,
+            detail: format!("expected size {expected} exceeds the {limit}-byte limit"),
+        });
+    }
+
+    let sources = build_download_sources(request.url).map_err(|detail| DownloadError {
+        kind: DownloadErrorKind::Setup,
+        detail,
+    })?;
+    download_from_sources(request, &sources, on_progress).await
+}
+
+async fn download_from_sources<F>(
+    request: DownloadRequest<'_>,
+    sources: &[DownloadSource],
+    mut on_progress: F,
+) -> Result<DownloadOutcome, DownloadError>
+where
+    F: FnMut(DownloadProgress),
+{
+    let client = create_download_client(&request).map_err(|detail| DownloadError {
+        kind: DownloadErrorKind::Setup,
+        detail,
+    })?;
+    let mut errors = Vec::new();
+
+    for (index, source) in sources.iter().enumerate() {
+        on_progress(DownloadProgress {
+            phase: if index == 0 {
+                DownloadAttemptPhase::Connecting
+            } else {
+                DownloadAttemptPhase::Retrying
+            },
+            source: source.name,
+            downloaded: 0,
+            total: request.expected_size.unwrap_or(0),
+        });
+        info!("Trying GitHub download source: {}", source.name);
+        match download_source_to_file(&client, source, &request, &mut on_progress).await {
+            Ok(outcome) => return Ok(outcome),
+            Err(error) => {
+                warn!("GitHub download source {} failed: {}", source.name, error);
+                errors.push(format!("{}: {error}", source.name));
+                let _ = tokio::fs::remove_file(request.destination).await;
+            }
+        }
+    }
+
+    Err(DownloadError {
+        kind: DownloadErrorKind::SourcesExhausted,
+        detail: format!("all download sources failed: {}", errors.join("; ")),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, http::StatusCode, response::Html, routing::get};
+
+    #[test]
+    fn sources_are_direct_first_then_follow_mirror_order() {
+        let original = "https://github.com/example/project/releases/download/v1/asset.zip";
+        let sources = build_download_sources(original).unwrap();
+        assert_eq!(sources.len(), 1 + DOWNLOAD_PROXY_PREFIXES.len());
+        assert_eq!(sources[0].name, "GitHub");
+        assert_eq!(sources[0].url, original);
+        for (source, (name, prefix)) in sources.iter().skip(1).zip(DOWNLOAD_PROXY_PREFIXES) {
+            assert_eq!(source.name, *name);
+            assert_eq!(source.url, format!("{prefix}{original}"));
+        }
+    }
+
+    #[test]
+    fn only_https_github_urls_can_be_mirrored() {
+        for invalid in [
+            "http://github.com/example/project/releases/download/v1/a.zip",
+            "https://github.com.example.invalid/a.zip",
+            "https://example.invalid/a.zip",
+            "not a url",
+        ] {
+            assert!(
+                build_download_sources(invalid).is_err(),
+                "accepted {invalid}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn html_response_is_rejected_before_streaming() {
+        let app = Router::new().route("/html", get(|| async { Html("proxy error") }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let request = DownloadRequest {
+            url: "https://github.com/example/project/releases/download/v1/a.zip",
+            destination: Path::new("unused"),
+            expected_size: None,
+            max_size: None,
+            user_agent: "test",
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            overall_timeout: None,
+        };
+        let source = DownloadSource {
+            name: "html",
+            url: format!("http://{address}/html"),
+        };
+        let client = create_download_client(&request).unwrap();
+        let error = request_source(&client, &source, &request)
+            .await
+            .unwrap_err();
+        assert!(error.contains("response is not a release asset"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_source_is_cleaned_up_before_fallback_succeeds() {
+        let app = Router::new()
+            .route("/fail", get(|| async { StatusCode::BAD_GATEWAY }))
+            .route(
+                "/asset",
+                get(|| async { ([("content-type", "application/octet-stream")], "asset") }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let destination = std::env::temp_dir().join(format!(
+            "sunshine-github-download-test-{}-{}.partial",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let request = DownloadRequest {
+            url: "https://github.com/example/project/releases/download/v1/a.zip",
+            destination: &destination,
+            expected_size: Some(5),
+            max_size: Some(5),
+            user_agent: "test",
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            overall_timeout: None,
+        };
+        let sources = [
+            DownloadSource {
+                name: "broken",
+                url: format!("http://{address}/fail"),
+            },
+            DownloadSource {
+                name: "fallback",
+                url: format!("http://{address}/asset"),
+            },
+        ];
+        let mut phases = Vec::new();
+        let outcome = download_from_sources(request, &sources, |progress| {
+            phases.push((progress.phase, progress.source));
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.source, "fallback");
+        assert_eq!(tokio::fs::read(&destination).await.unwrap(), b"asset");
+        assert!(phases.contains(&(DownloadAttemptPhase::Retrying, "fallback")));
+        let _ = tokio::fs::remove_file(&destination).await;
+        server.abort();
+    }
+}

--- a/src-tauri/src/github_download.rs
+++ b/src-tauri/src/github_download.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::path::Path;
 use std::time::Duration;
 use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::time::Instant;
 
 pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -28,6 +29,13 @@ const DOWNLOAD_PROXY_PREFIXES: &[(&str, &str)] = &[
 struct DownloadSource {
     name: &'static str,
     url: String,
+}
+
+#[derive(Clone, Copy)]
+enum DownloadClientPolicy {
+    HttpsOnly,
+    #[cfg(test)]
+    AllowHttpForTests,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -116,16 +124,21 @@ fn build_download_sources(original_url: &str) -> Result<Vec<DownloadSource>, Str
     Ok(sources)
 }
 
-fn create_download_client(request: &DownloadRequest<'_>) -> Result<reqwest::Client, String> {
-    let mut builder = reqwest::Client::builder()
+fn create_download_client(
+    request: &DownloadRequest<'_>,
+    policy: DownloadClientPolicy,
+) -> Result<reqwest::Client, String> {
+    let builder = reqwest::Client::builder()
         .connect_timeout(request.connect_timeout)
         .read_timeout(request.idle_timeout)
         .redirect(reqwest::redirect::Policy::limited(10))
         .no_gzip()
         .no_deflate();
-    if let Some(timeout) = request.overall_timeout {
-        builder = builder.timeout(timeout);
-    }
+    let builder = match policy {
+        DownloadClientPolicy::HttpsOnly => builder.https_only(true),
+        #[cfg(test)]
+        DownloadClientPolicy::AllowHttpForTests => builder,
+    };
     builder
         .build()
         .map_err(|error| format!("could not create download client: {error}"))
@@ -178,20 +191,29 @@ async fn request_source(
     client: &reqwest::Client,
     source: &DownloadSource,
     request: &DownloadRequest<'_>,
+    remaining_budget: Option<Duration>,
 ) -> Result<reqwest::Response, String> {
     let pending = client
         .get(&source.url)
         .header(reqwest::header::USER_AGENT, request.user_agent)
         .header(reqwest::header::ACCEPT, "application/octet-stream")
-        .header(reqwest::header::ACCEPT_ENCODING, "identity")
-        .send();
-    let response = match tokio::time::timeout(request.response_timeout, pending).await {
+        .header(reqwest::header::ACCEPT_ENCODING, "identity");
+    let pending = if let Some(timeout) = remaining_budget {
+        pending.timeout(timeout)
+    } else {
+        pending
+    }
+    .send();
+    let response_timeout = remaining_budget
+        .map(|remaining| request.response_timeout.min(remaining))
+        .unwrap_or(request.response_timeout);
+    let response = match tokio::time::timeout(response_timeout, pending).await {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => return Err(format!("request failed: {error}")),
         Err(_) => {
             return Err(format!(
                 "server did not respond within {} seconds",
-                request.response_timeout.as_secs()
+                response_timeout.as_secs_f64()
             ));
         }
     };
@@ -208,12 +230,13 @@ async fn download_source_to_file<F>(
     client: &reqwest::Client,
     source: &DownloadSource,
     request: &DownloadRequest<'_>,
+    remaining_budget: Option<Duration>,
     on_progress: &mut F,
 ) -> Result<DownloadOutcome, String>
 where
     F: FnMut(DownloadProgress),
 {
-    let response = request_source(client, source, request).await?;
+    let response = request_source(client, source, request, remaining_budget).await?;
     let response_size = response.content_length();
     let total = request.expected_size.or(response_size).unwrap_or(0);
     on_progress(DownloadProgress {
@@ -303,24 +326,46 @@ where
         kind: DownloadErrorKind::Setup,
         detail,
     })?;
-    download_from_sources(request, &sources, on_progress).await
+    download_from_sources(
+        request,
+        &sources,
+        DownloadClientPolicy::HttpsOnly,
+        on_progress,
+    )
+    .await
 }
 
 async fn download_from_sources<F>(
     request: DownloadRequest<'_>,
     sources: &[DownloadSource],
+    client_policy: DownloadClientPolicy,
     mut on_progress: F,
 ) -> Result<DownloadOutcome, DownloadError>
 where
     F: FnMut(DownloadProgress),
 {
-    let client = create_download_client(&request).map_err(|detail| DownloadError {
-        kind: DownloadErrorKind::Setup,
-        detail,
-    })?;
+    let client =
+        create_download_client(&request, client_policy).map_err(|detail| DownloadError {
+            kind: DownloadErrorKind::Setup,
+            detail,
+        })?;
+    let overall_deadline = request
+        .overall_timeout
+        .map(|timeout| Instant::now() + timeout);
     let mut errors = Vec::new();
 
     for (index, source) in sources.iter().enumerate() {
+        let remaining_budget = match overall_deadline {
+            Some(deadline) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    errors.push("shared overall timeout expired".to_string());
+                    break;
+                }
+                Some(remaining)
+            }
+            None => None,
+        };
         on_progress(DownloadProgress {
             phase: if index == 0 {
                 DownloadAttemptPhase::Connecting
@@ -332,12 +377,29 @@ where
             total: request.expected_size.unwrap_or(0),
         });
         info!("Trying GitHub download source: {}", source.name);
-        match download_source_to_file(&client, source, &request, &mut on_progress).await {
+        let attempt = download_source_to_file(
+            &client,
+            source,
+            &request,
+            remaining_budget,
+            &mut on_progress,
+        );
+        let result = match remaining_budget {
+            Some(remaining) => match tokio::time::timeout(remaining, attempt).await {
+                Ok(result) => result,
+                Err(_) => Err("shared overall timeout expired during this source".to_string()),
+            },
+            None => attempt.await,
+        };
+        match result {
             Ok(outcome) => return Ok(outcome),
             Err(error) => {
                 warn!("GitHub download source {} failed: {}", source.name, error);
                 errors.push(format!("{}: {error}", source.name));
                 let _ = tokio::fs::remove_file(request.destination).await;
+                if overall_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                    break;
+                }
             }
         }
     }
@@ -404,8 +466,9 @@ mod tests {
             name: "html",
             url: format!("http://{address}/html"),
         };
-        let client = create_download_client(&request).unwrap();
-        let error = request_source(&client, &source, &request)
+        let client =
+            create_download_client(&request, DownloadClientPolicy::AllowHttpForTests).unwrap();
+        let error = request_source(&client, &source, &request, None)
             .await
             .unwrap_err();
         assert!(error.contains("response is not a release asset"));
@@ -455,15 +518,115 @@ mod tests {
             },
         ];
         let mut phases = Vec::new();
-        let outcome = download_from_sources(request, &sources, |progress| {
-            phases.push((progress.phase, progress.source));
-        })
+        let outcome = download_from_sources(
+            request,
+            &sources,
+            DownloadClientPolicy::AllowHttpForTests,
+            |progress| {
+                phases.push((progress.phase, progress.source));
+            },
+        )
         .await
         .unwrap();
 
         assert_eq!(outcome.source, "fallback");
         assert_eq!(tokio::fs::read(&destination).await.unwrap(), b"asset");
         assert!(phases.contains(&(DownloadAttemptPhase::Retrying, "fallback")));
+        let _ = tokio::fs::remove_file(&destination).await;
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn production_client_rejects_http_sources() {
+        let request = DownloadRequest {
+            url: "https://github.com/example/project/releases/download/v1/a.zip",
+            destination: Path::new("unused"),
+            expected_size: None,
+            max_size: None,
+            user_agent: "test",
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            overall_timeout: None,
+        };
+        let source = DownloadSource {
+            name: "insecure",
+            url: "http://127.0.0.1/asset".to_string(),
+        };
+        let client = create_download_client(&request, DownloadClientPolicy::HttpsOnly).unwrap();
+
+        assert!(
+            request_source(&client, &source, &request, None)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn overall_timeout_is_shared_across_source_attempts() {
+        let app = Router::new()
+            .route(
+                "/slow-fail",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(400)).await;
+                    StatusCode::BAD_GATEWAY
+                }),
+            )
+            .route(
+                "/slow-asset",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(400)).await;
+                    ([("content-type", "application/octet-stream")], "asset")
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let destination = std::env::temp_dir().join(format!(
+            "sunshine-github-download-deadline-test-{}-{}.partial",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let request = DownloadRequest {
+            url: "https://github.com/example/project/releases/download/v1/a.zip",
+            destination: &destination,
+            expected_size: Some(5),
+            max_size: Some(5),
+            user_agent: "test",
+            connect_timeout: Duration::from_secs(1),
+            response_timeout: Duration::from_secs(1),
+            idle_timeout: Duration::from_secs(1),
+            overall_timeout: Some(Duration::from_millis(500)),
+        };
+        let sources = [
+            DownloadSource {
+                name: "slow-broken",
+                url: format!("http://{address}/slow-fail"),
+            },
+            DownloadSource {
+                name: "slow-fallback",
+                url: format!("http://{address}/slow-asset"),
+            },
+        ];
+        let started = Instant::now();
+        let mut phases = Vec::new();
+        let error = download_from_sources(
+            request,
+            &sources,
+            DownloadClientPolicy::AllowHttpForTests,
+            |progress| phases.push((progress.phase, progress.source)),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("all download sources failed"));
+        assert!(phases.contains(&(DownloadAttemptPhase::Retrying, "slow-fallback")));
+        assert!(started.elapsed() < Duration::from_millis(650));
         let _ = tokio::fs::remove_file(&destination).await;
         server.abort();
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ mod dualsense;
 mod file_mapping;
 mod file_transfer;
 mod fs_utils;
+mod github_download;
 mod hwinfo;
 mod logger;
 mod moonlight_web;

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -6,6 +6,11 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
+use crate::github_download::{
+    self, DEFAULT_CONNECT_TIMEOUT, DEFAULT_IDLE_TIMEOUT, DEFAULT_RESPONSE_TIMEOUT,
+    DownloadAttemptPhase, DownloadRequest,
+};
+
 mod channel;
 mod preferences;
 
@@ -20,21 +25,11 @@ const GITHUB_API_URL_LATEST: &str =
     "https://api.github.com/repos/qiin2333/sunshine/releases/latest";
 const UPDATE_CHECK_INTERVAL: u64 = 4 * 60 * 60; // 4小时（秒）
 const HTTP_TIMEOUT_SECS: u64 = 3;
-const DOWNLOAD_CONNECT_TIMEOUT_SECS: u64 = 5;
-const DOWNLOAD_RESPONSE_TIMEOUT_SECS: u64 = 10;
-const DOWNLOAD_IDLE_TIMEOUT_SECS: u64 = 20;
 const GITHUB_RELEASE_HOST: &str = "github.com";
 const MAX_RELEASES_TO_CHECK: usize = 10; // 最多检查的发布数量
 
 // GitHub API 加速代理列表（按优先级排序）
 const API_PROXY_PREFIXES: &[&str] = &["https://ghapi.hackhub.cn/", "https://mirror.ghproxy.com/"];
-
-// GitHub 下载加速代理列表
-const DOWNLOAD_PROXY_PREFIXES: &[(&str, &str)] = &[
-    ("ghfast.top", "https://ghfast.top/"),
-    ("ghproxy.com", "https://ghproxy.com/"),
-    ("mirror.ghproxy.com", "https://mirror.ghproxy.com/"),
-];
 
 // ========== 数据结构定义 ==========
 
@@ -73,12 +68,6 @@ struct GitHubAsset {
     browser_download_url: String,
     #[serde(default)]
     size: u64,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct DownloadSource {
-    name: &'static str,
-    url: String,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -1665,114 +1654,6 @@ fn validate_download_filename(filename: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// 创建安装包下载客户端。下载使用独立请求头和更细粒度的超时策略。
-fn create_download_http_client() -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(DOWNLOAD_CONNECT_TIMEOUT_SECS))
-        .read_timeout(Duration::from_secs(DOWNLOAD_IDLE_TIMEOUT_SECS))
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .no_gzip()
-        .no_deflate()
-        .build()
-        .map_err(|e| format!("创建下载客户端失败: {}", e))
-}
-
-/// 构建安装包候选源：GitHub 直连优先，其后按配置顺序尝试代理。
-fn build_download_sources(original_url: &str) -> Vec<DownloadSource> {
-    let mut sources = vec![DownloadSource {
-        name: "GitHub",
-        url: original_url.to_string(),
-    }];
-
-    for (name, prefix) in DOWNLOAD_PROXY_PREFIXES {
-        sources.push(DownloadSource {
-            name,
-            url: format!("{}{}", prefix, original_url),
-        });
-    }
-
-    sources
-}
-
-fn validate_download_response(
-    response: &reqwest::Response,
-    expected_size: Option<u64>,
-) -> Result<(), String> {
-    if !response.status().is_success() {
-        return Err(format!("HTTP状态码 {}", response.status().as_u16()));
-    }
-
-    if let Some(content_type) = response
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-    {
-        let content_type = content_type.to_ascii_lowercase();
-        if content_type.starts_with("text/")
-            || content_type.contains("application/json")
-            || content_type.contains("application/xml")
-        {
-            return Err(format!("返回了非安装包内容: {}", content_type));
-        }
-    }
-
-    if response.content_length() == Some(0) {
-        return Err("返回了空文件".to_string());
-    }
-
-    if let (Some(expected), Some(actual)) = (
-        expected_size.filter(|size| *size > 0),
-        response.content_length(),
-    ) && actual != expected
-    {
-        return Err(format!(
-            "文件大小不匹配，预期 {} bytes，响应为 {} bytes",
-            expected, actual
-        ));
-    }
-
-    Ok(())
-}
-
-async fn request_download_source(
-    client: &reqwest::Client,
-    source: &DownloadSource,
-    expected_size: Option<u64>,
-) -> Result<reqwest::Response, String> {
-    let request = client
-        .get(&source.url)
-        .header(
-            reqwest::header::USER_AGENT,
-            "Sunshine-Control-Panel updater",
-        )
-        .header(reqwest::header::ACCEPT, "application/octet-stream")
-        .header(reqwest::header::ACCEPT_ENCODING, "identity");
-
-    let response = match tokio::time::timeout(
-        Duration::from_secs(DOWNLOAD_RESPONSE_TIMEOUT_SECS),
-        request.send(),
-    )
-    .await
-    {
-        Ok(Ok(response)) => response,
-        Ok(Err(error)) => {
-            return Err(format!("{} 请求失败: {}", source.name, error));
-        }
-        Err(_) => {
-            return Err(format!(
-                "{} 在 {} 秒内未返回响应",
-                source.name, DOWNLOAD_RESPONSE_TIMEOUT_SECS
-            ));
-        }
-    };
-
-    validate_download_response(&response, expected_size)
-        .map_err(|error| format!("{} 响应无效: {}", source.name, error))?;
-
-    debug!("✅ 下载源已就绪: {} ({})", source.name, response.url());
-    Ok(response)
-}
-
 /// 发送下载进度事件到前端
 fn emit_download_progress(
     window: &tauri::WebviewWindow,
@@ -1810,124 +1691,6 @@ fn emit_install_progress(
     );
 }
 
-/// 处理下载流
-async fn download_stream(
-    mut stream: impl futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Unpin,
-    file: &mut tokio::fs::File,
-    total_size: u64,
-    source_name: &str,
-    window: Option<&tauri::WebviewWindow>,
-) -> Result<u64, String> {
-    use futures_util::StreamExt;
-    use tokio::io::AsyncWriteExt;
-
-    let mut downloaded: u64 = 0;
-    let mut last_progress_percent: u32 = 0;
-
-    while let Some(item) = stream.next().await {
-        let chunk = item.map_err(|e| format!("读取数据块失败: {}", e))?;
-        file.write_all(&chunk)
-            .await
-            .map_err(|e| format!("写入文件失败: {}", e))?;
-        downloaded += chunk.len() as u64;
-
-        // 更新进度
-        if total_size > 0 {
-            // 完整性校验通过之前最多显示 99%，避免残缺文件被表现为下载成功。
-            let progress_percent = (downloaded.saturating_mul(100) / total_size).min(99) as u32;
-
-            if progress_percent > last_progress_percent || downloaded == total_size {
-                last_progress_percent = progress_percent;
-
-                if let Some(win) = window {
-                    emit_download_progress(
-                        win,
-                        progress_percent,
-                        total_size,
-                        downloaded,
-                        DownloadPhase::Downloading,
-                        Some(source_name),
-                    );
-                }
-
-                debug!(
-                    "📊 下载进度: {}% ({}/{})",
-                    progress_percent, downloaded, total_size
-                );
-            }
-        } else if let Some(win) = window {
-            emit_download_progress(
-                win,
-                0,
-                0,
-                downloaded,
-                DownloadPhase::Downloading,
-                Some(source_name),
-            );
-        }
-    }
-
-    file.flush()
-        .await
-        .map_err(|e| format!("刷新下载文件失败: {}", e))?;
-
-    Ok(downloaded)
-}
-
-async fn download_source_to_file(
-    client: &reqwest::Client,
-    source: &DownloadSource,
-    partial_path: &Path,
-    expected_size: Option<u64>,
-    window: Option<&tauri::WebviewWindow>,
-) -> Result<(u64, u64), String> {
-    let response = request_download_source(client, source, expected_size).await?;
-    let response_size = response.content_length();
-    let total_size = expected_size
-        .filter(|size| *size > 0)
-        .or(response_size)
-        .unwrap_or(0);
-
-    if let Some(win) = window {
-        emit_download_progress(
-            win,
-            0,
-            total_size,
-            0,
-            DownloadPhase::Downloading,
-            Some(source.name),
-        );
-    }
-
-    let mut file = tokio::fs::File::create(partial_path)
-        .await
-        .map_err(|e| format!("创建临时下载文件失败: {}", e))?;
-    let downloaded = download_stream(
-        response.bytes_stream(),
-        &mut file,
-        total_size,
-        source.name,
-        window,
-    )
-    .await?;
-    drop(file);
-
-    if downloaded == 0 {
-        return Err("下载结果为空文件".to_string());
-    }
-
-    if let Some(required_size) = expected_size.filter(|size| *size > 0).or(response_size)
-        && downloaded != required_size
-    {
-        return Err(format!(
-            "下载文件大小不匹配，预期 {} bytes，实际 {} bytes",
-            required_size, downloaded
-        ));
-    }
-
-    Ok((downloaded, total_size))
-}
-
 fn remove_file_if_exists(
     path: &Path,
     error_code: DownloadErrorCode,
@@ -1962,15 +1725,6 @@ async fn finalize_download_file(
         })
 }
 
-fn sources_exhausted_error(errors: &[String]) -> DownloadCommandError {
-    let detail = if errors.is_empty() {
-        "所有下载源都失败了".to_string()
-    } else {
-        format!("所有下载源都失败了：{}", errors.join("；"))
-    };
-    DownloadCommandError::new(DownloadErrorCode::SourcesExhausted, detail)
-}
-
 /// 下载更新文件（带真实进度报告）
 #[tauri::command]
 pub async fn download_update(
@@ -1994,10 +1748,6 @@ pub async fn download_update(
     let file_path = download_dir.join(&filename);
     let partial_path = download_dir.join(format!("{}.part", filename));
     let window = app_handle.get_webview_window("main");
-    let client = create_download_http_client()
-        .map_err(|detail| DownloadCommandError::new(DownloadErrorCode::SetupFailed, detail))?;
-    let sources = build_download_sources(&url);
-    let mut errors = Vec::new();
 
     remove_file_if_exists(
         &partial_path,
@@ -2005,77 +1755,103 @@ pub async fn download_update(
         "清理旧的临时下载文件",
     )?;
 
-    for (index, source) in sources.iter().enumerate() {
-        if let Some(ref win) = window {
-            let phase = if index == 0 {
-                DownloadPhase::Connecting
-            } else {
-                DownloadPhase::Retrying
+    let mut last_progress_percent = 0;
+    let outcome = github_download::download_to_file_with_fallbacks(
+        DownloadRequest {
+            url: &url,
+            destination: &partial_path,
+            expected_size: expected_size.filter(|size| *size > 0),
+            max_size: expected_size.filter(|size| *size > 0),
+            user_agent: "Sunshine-Control-Panel updater",
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            overall_timeout: None,
+        },
+        |event| {
+            let Some(win) = window.as_ref() else {
+                return;
             };
-            emit_download_progress(win, 0, 0, 0, phase, None);
-        }
-
-        info!("📡 尝试下载源: {}", source.name);
-        match download_source_to_file(
-            &client,
-            source,
-            &partial_path,
-            expected_size,
-            window.as_ref(),
-        )
-        .await
-        {
-            Ok((downloaded, total_size)) => {
-                if let Some(ref win) = window {
-                    emit_download_progress(
-                        win,
-                        99,
-                        total_size,
-                        downloaded,
-                        DownloadPhase::Verifying,
-                        Some(source.name),
-                    );
+            match event.phase {
+                DownloadAttemptPhase::Connecting => {
+                    last_progress_percent = 0;
+                    emit_download_progress(win, 0, event.total, 0, DownloadPhase::Connecting, None);
                 }
-                let finalization = finalize_download_file(&partial_path, &file_path).await;
-                if let Err(error) = finalization {
-                    let _ = tokio::fs::remove_file(&partial_path).await;
-                    return Err(error);
+                DownloadAttemptPhase::Retrying => {
+                    last_progress_percent = 0;
+                    emit_download_progress(win, 0, event.total, 0, DownloadPhase::Retrying, None);
                 }
-
-                info!("✅ 下载完成: {} bytes，来源: {}", downloaded, source.name);
-                if let Some(win) = window {
-                    emit_download_progress(
-                        &win,
-                        100,
-                        total_size,
-                        downloaded,
-                        DownloadPhase::Complete,
-                        Some(source.name),
-                    );
+                DownloadAttemptPhase::Downloading => {
+                    let progress = if event.total == 0 {
+                        0
+                    } else {
+                        (event.downloaded.saturating_mul(100) / event.total).min(99) as u32
+                    };
+                    if event.total == 0 || progress > last_progress_percent || event.downloaded == 0
+                    {
+                        last_progress_percent = progress;
+                        emit_download_progress(
+                            win,
+                            progress,
+                            event.total,
+                            event.downloaded,
+                            DownloadPhase::Downloading,
+                            Some(event.source),
+                        );
+                    }
                 }
-
-                return Ok(serde_json::json!({
-                    "success": true,
-                    "file_path": file_path.to_string_lossy().to_string(),
-                    "source": source.name
-                }));
             }
-            Err(error) => {
-                warn!("⚠️ {}", error);
-                errors.push(error);
-                let _ = tokio::fs::remove_file(&partial_path).await;
-            }
-        }
+        },
+    )
+    .await
+    .map_err(|error| {
+        let code = if error.is_setup() {
+            DownloadErrorCode::SetupFailed
+        } else {
+            DownloadErrorCode::SourcesExhausted
+        };
+        DownloadCommandError::new(code, error.to_string())
+    })?;
+
+    if let Some(ref win) = window {
+        emit_download_progress(
+            win,
+            99,
+            outcome.total,
+            outcome.downloaded,
+            DownloadPhase::Verifying,
+            Some(outcome.source),
+        );
+    }
+    if let Err(error) = finalize_download_file(&partial_path, &file_path).await {
+        let _ = tokio::fs::remove_file(&partial_path).await;
+        return Err(error);
     }
 
-    let _ = tokio::fs::remove_file(&partial_path).await;
-    Err(sources_exhausted_error(&errors))
+    info!(
+        "✅ 下载完成: {} bytes，来源: {}",
+        outcome.downloaded, outcome.source
+    );
+    if let Some(win) = window {
+        emit_download_progress(
+            &win,
+            100,
+            outcome.total,
+            outcome.downloaded,
+            DownloadPhase::Complete,
+            Some(outcome.source),
+        );
+    }
+    Ok(serde_json::json!({
+        "success": true,
+        "file_path": file_path.to_string_lossy().to_string(),
+        "source": outcome.source
+    }))
 }
 
 #[cfg(test)]
 mod download_source_tests {
     use super::*;
-    use axum::{Router, response::Html, routing::get};
 
     #[test]
     fn download_url_requires_https_and_the_github_release_host() {
@@ -2126,24 +1902,6 @@ mod download_source_tests {
     }
 
     #[test]
-    fn download_sources_are_direct_first_then_follow_proxy_order() {
-        let original_url = "https://github.com/qiin2333/sunshine/releases/download/v1/setup.exe";
-        let sources = build_download_sources(original_url);
-
-        assert_eq!(sources.len(), 1 + DOWNLOAD_PROXY_PREFIXES.len());
-        assert_eq!(sources[0].name, "GitHub");
-        assert_eq!(sources[0].url, original_url);
-
-        for (source, (expected_name, expected_prefix)) in
-            sources.iter().skip(1).zip(DOWNLOAD_PROXY_PREFIXES)
-        {
-            assert_eq!(source.name, *expected_name);
-            assert_eq!(source.url, format!("{}{}", expected_prefix, original_url));
-            assert!(!source.url.contains("cdn.jsdelivr.net"));
-        }
-    }
-
-    #[test]
     fn download_errors_expose_stable_language_neutral_codes() {
         let error = DownloadCommandError::new(
             DownloadErrorCode::SourcesExhausted,
@@ -2156,28 +1914,6 @@ mod download_source_tests {
             serialized["detail"],
             "diagnostic details stay out of the localized UI"
         );
-    }
-
-    #[tokio::test]
-    async fn html_response_is_rejected_before_writing_a_download_file() {
-        let app = Router::new().route("/html", get(|| async { Html("proxy error") }));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let address = listener.local_addr().unwrap();
-        let server = tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let source = DownloadSource {
-            name: "html",
-            url: format!("http://{}/html", address),
-        };
-        let client = create_download_http_client().unwrap();
-        let error = request_download_source(&client, &source, None)
-            .await
-            .unwrap_err();
-
-        assert!(error.contains("返回了非安装包内容"));
-        server.abort();
     }
 }
 


### PR DESCRIPTION
## 改了啥呀

- 把 GitHub Release 下载能力抽成公共模块，统一处理直连、镜像回退、超时、响应校验、大小限制、异步缓冲写入和失败清理
- 更新器与 DualSense Sidecar、USB/IP、HIDMaestro 共用同一条下载链路
- 下载顺序保持为 GitHub → ghfast.top → ghproxy.com → mirror.ghproxy.com
- 保留组件 manifest 大小约束、固定 SHA-256、解包限制和 10 分钟总超时，镜像只负责搬运文件，不参与信任判断

## 为啥要改

提权后的组件安装以前只会硬冲 GitHub，撞墙以后就原地躺平啦。更新器明明已经会切镜像，这条杂鱼下载链路却没复用上；现在统一以后，组件安装和应用更新的网络行为终于一致了。

## 验证

- `cargo check --tests`
- `cargo test github_download -- --nocapture`（4 passed）
- `cargo test download_source_tests -- --nocapture`（3 passed）
- `cargo test dualsense::tests -- --nocapture`（28 passed）
- `rustfmt --edition 2024 --check src/github_download.rs src/dualsense.rs src/update.rs`
- `git diff --check origin/main...HEAD`
- `cargo clippy --tests -- -D warnings`：主线现有 Clippy 告警导致未通过；整理后新下载器及组件下载辅助区域没有 Clippy 诊断