### PR TITLE
feat(desktop): 手柄布局识别，双套按键提示

### DIFF
--- a/src/renderer/desktop/components/GamepadLegend.vue
+++ b/src/renderer/desktop/components/GamepadLegend.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="gamepad-legend" aria-hidden="true">
-    <span v-for="hint in hints" :key="hint.button" class="legend-item">
-      <span class="legend-button" :class="'btn-' + hint.tone">{{ hint.button }}</span>
+    <span v-for="hint in hints" :key="hint.id" class="legend-item">
+      <span class="legend-button" :class="'btn-' + hint.tone">{{ hint.glyph }}</span>
       <span class="legend-label">{{ hint.label }}</span>
     </span>
   </span>
@@ -11,6 +11,7 @@
 import { computed } from 'vue'
 import { viewActions } from '../composables/useGamepadActions.js'
 import { bigScreenSettings } from '../composables/useBigScreenSettings.js'
+import { chipFor } from '../composables/useGamepadLayout.js'
 import { useI18n } from '../i18n/index.js'
 
 const { t } = useI18n()
@@ -19,32 +20,37 @@ const props = defineProps({
   cursorMode: { type: Boolean, default: false },
 })
 
-/** 动作 id → [按键文本, 色调]。顺序即显示顺序。 */
-const ACTION_CHIPS = {
-  confirm: ['A', 'a'],
-  back: ['B', 'b'],
-  search: ['Y', 'y'],
-  favorite: ['X', 'x'],
-  menu: ['☰', 'neutral'],
-  scroll: ['LT/RT', 'neutral'],
-  pages: ['LB/RB', 'neutral'],
-  cursor: ['L3', 'neutral'],
+/** 动作 id → 文案。按键符号（A/B/X/Y 还是 ✕○□△）由 useGamepadLayout 按手柄布局给出。 */
+const LABELS = () => {
+  const legend = t.value.gamepadLegend
+  return {
+    click: legend.click,
+    exitCursor: legend.exitCursor,
+    confirm: legend.confirm,
+    back: legend.back,
+    search: legend.search,
+    favorite: legend.favorite,
+    menu: legend.menu,
+    scroll: legend.scroll,
+    pages: legend.switchPage,
+    cursor: legend.cursorOn,
+  }
 }
 
 /**
  * 只显示当前上下文真的会响应的按键：
  * 全局动作（确认/返回/换页/滚动/光标）始终在，视图级动作（搜索/收藏/菜单）
  * 由各视图通过 useGamepadActions 声明——没声明的页面就不显示，不撒谎。
+ * 按键符号跟随当前活跃手柄的布局，换手柄即时切换。
  */
 const hints = computed(() => {
-  const legend = t.value.gamepadLegend
+  const labels = LABELS()
   if (props.cursorMode) {
-    return [
-      { button: 'A', tone: 'a', label: legend.click },
-      { button: '☰', tone: 'neutral', label: legend.menu },
-      { button: 'B', tone: 'b', label: legend.exitCursor },
-      { button: 'LT/RT', tone: 'neutral', label: legend.scroll },
-    ]
+    return ['confirm', 'menu', 'back', 'scroll'].map((id) => {
+      const { glyph, tone } = chipFor(id)
+      const labelId = id === 'confirm' ? 'click' : id === 'back' ? 'exitCursor' : id
+      return { id, glyph, tone, label: labels[labelId] }
+    })
   }
 
   const actions = ['confirm', 'back']
@@ -55,20 +61,9 @@ const hints = computed(() => {
   // 设置里关掉光标模式时 L3 不会响应，提示条不能显示无效按键
   if (bigScreenSettings.value.gamepadCursorEnabled) actions.push('cursor')
 
-  const labels = {
-    confirm: legend.confirm,
-    back: legend.back,
-    search: legend.search,
-    favorite: legend.favorite,
-    menu: legend.menu,
-    scroll: legend.scroll,
-    pages: legend.switchPage,
-    cursor: legend.cursorOn,
-  }
-
   return actions.map((id) => {
-    const [button, tone] = ACTION_CHIPS[id]
-    return { button, tone, label: labels[id] }
+    const { glyph, tone } = chipFor(id)
+    return { id, glyph, tone, label: labels[id] }
   })
 })
 </script>
@@ -106,6 +101,8 @@ const hints = computed(() => {
   background: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.12);
   color: rgba(var(--fd-text-primary-rgb, 255, 255, 255), 0.8);
 
+  // Xbox 与 PS 布局共用四个色位，语义是「按钮家族色」：
+  // 绿=确认系、红=返回系、蓝/黄(粉)=功能键（PS 的 ✕蓝 ○红 △绿 □粉）
   &.btn-a { background: rgba(0, 200, 100, 0.28); color: #7dffb0; }
   &.btn-b { background: rgba(220, 60, 60, 0.28); color: #ff9b9b; }
   &.btn-x { background: rgba(60, 120, 230, 0.28); color: #a3c4ff; }

--- a/src/renderer/desktop/composables/useGamepad.js
+++ b/src/renderer/desktop/composables/useGamepad.js
@@ -87,6 +87,8 @@ export const GAMEPAD_ACTION_EVENT = 'fd-gamepad-action'
  */
 export const gamepadActive = ref(false)
 export const gamepadConnected = ref(false)
+/** 当前活跃手柄的 id 字符串（含厂商标识），布局识别据此推导。 */
+export const gamepadName = ref('')
 /** 长按 B 的进度（0..1），供环形进度指示消费。 */
 export const backHoldProgress = ref(0)
 
@@ -300,6 +302,8 @@ export function useGamepad(options = {}) {
   function switchActivePad(index) {
     if (activeIndex === index) return
     activeIndex = index
+    // 活跃手柄变了，id（布局识别的数据源）跟着换
+    gamepadName.value = connectedPads().find((pad) => pad.index === index)?.id || gamepadName.value
     // 换手柄时旧的按住状态不再有效
     stopAllRepeats()
     clearBackHold()
@@ -405,8 +409,10 @@ export function useGamepad(options = {}) {
     if (wanted !== currentInterval) startPolling(wanted)
   }
 
-  function onGamepadConnected() {
+  function onGamepadConnected(event) {
     gamepadConnected.value = true
+    // 尚无活跃手柄时先用接入者的 id，提示条不用等第一次输入才识别布局
+    if (!gamepadName.value && event?.gamepad?.id) gamepadName.value = event.gamepad.id
     startPolling(POLL_INTERVAL_MS)
   }
 

--- a/src/renderer/desktop/composables/useGamepadLayout.js
+++ b/src/renderer/desktop/composables/useGamepadLayout.js
@@ -1,0 +1,82 @@
+import { computed } from 'vue'
+import { gamepadName } from './useGamepad.js'
+
+/**
+ * 手柄布局识别：同一套「标准映射」按键在不同手柄上印着不同的符号，
+ * 提示条必须跟着用户手里那台走——拿 DualSense 的人看到 "A 确定" 会按错。
+ *
+ * 识别依据是 gamepad.id（浏览器报告的字符串，通常含厂商标识）：
+ *   Sony 054c（DualSense/DualShock，蓝牙下显示为 "Wireless Controller"）
+ *   Microsoft 045e / XInput 系
+ * 串流时主机上看到的是 Sunshine 的虚拟手柄（通常是 XInput 设备），那种
+ * 情况下输入本来就直达游戏、不经过面板；面板里出现的都是本机手柄。
+ *
+ * Switch Pro 故意不单独识别：Nintendo 的 A/B 与 Xbox 物理位置互换，
+ * 正确支持需要连确认/返回语义一起换，超出「两套提示」的范围——先落到
+ * Xbox 布局（与标准映射的按钮索引一致），明确不做静默的半吊子支持。
+ */
+
+/**
+ * PlayStation 识别特征。厂商标识 054c 最可靠；名称兜底覆盖改写 id 的
+ * 第三方驱动（8BitDo 等接收器）。
+ */
+const PS_PATTERNS = [
+  /054c/i, // Sony vendor id
+  /dualsense/i,
+  /dualshock/i,
+  /playstation/i,
+  // Sony 蓝牙默认名就是以 "Wireless Controller" 开头；不能裸匹配该词组，
+  // 否则 "Xbox Elite Wireless Controller" 也会中招
+  /^wireless controller/i,
+  /ps[345] compatible/i,
+]
+
+/**
+ * 从 gamepad.id 判断布局。纯函数，便于用真实设备的 id 字符串做单元测试。
+ * @returns {'xbox' | 'ps'} 无法识别时落到 xbox（标准映射的按钮索引即 Xbox 约定）
+ */
+export function detectLayout(idString) {
+  const id = String(idString || '').trim()
+  if (!id) return 'xbox'
+  return PS_PATTERNS.some((pattern) => pattern.test(id)) ? 'ps' : 'xbox'
+}
+
+/** 当前活跃手柄的布局，随手柄切换实时更新。 */
+export const gamepadLayout = computed(() => detectLayout(gamepadName.value))
+
+/**
+ * 动作 id → 两种布局下的 [按键符号, 色调]。
+ * PS 语义按主机惯例：✕ 确认、○ 返回、△ 搜索/查看、□ 选项，
+ * 色调沿用 PS 手柄的按钮颜色（✕蓝 ○红 △绿 □粉）。
+ */
+const ACTION_CHIPS = {
+  xbox: {
+    confirm: ['A', 'a'],
+    back: ['B', 'b'],
+    search: ['Y', 'y'],
+    favorite: ['X', 'x'],
+    menu: ['☰', 'neutral'],
+    pages: ['LB/RB', 'neutral'],
+    scroll: ['LT/RT', 'neutral'],
+    cursor: ['L3', 'neutral'],
+  },
+  ps: {
+    confirm: ['✕', 'x'],
+    back: ['○', 'b'],
+    search: ['△', 'a'],
+    favorite: ['□', 'y'],
+    menu: ['☰', 'neutral'],
+    pages: ['L1/R1', 'neutral'],
+    scroll: ['L2/R2', 'neutral'],
+    cursor: ['L3', 'neutral'],
+  },
+}
+
+/**
+ * 取某个动作在指定布局下的按键符号与色调。
+ * @returns {{ glyph: string, tone: string }}
+ */
+export function chipFor(actionId, layout = gamepadLayout.value) {
+  const [glyph, tone] = ACTION_CHIPS[layout]?.[actionId] || ACTION_CHIPS.xbox[actionId] || ['', 'neutral']
+  return { glyph, tone }
+}

--- a/src/renderer/desktop/composables/useGamepadLayout.js
+++ b/src/renderer/desktop/composables/useGamepadLayout.js
@@ -21,7 +21,9 @@ import { gamepadName } from './useGamepad.js'
  * 第三方驱动（8BitDo 等接收器）。
  */
 const PS_PATTERNS = [
-  /054c/i, // Sony vendor id
+  // Sony vendor id。必须锚定到 Vendor 字段：标准 id 里同时有 Product，
+  // 非 Sony 手柄的 Product 恰为 054c 时裸匹配会误判
+  /\bvendor:\s*054c\b/i,
   /dualsense/i,
   /dualshock/i,
   /playstation/i,

--- a/src/renderer/desktop/composables/useGamepadLayout.test.js
+++ b/src/renderer/desktop/composables/useGamepadLayout.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { chipFor, detectLayout } from './useGamepadLayout.js'
+
+/** 真实设备在 Windows/Chromium 上报告的 gamepad.id 样本。 */
+const PS_IDS = [
+  'DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)',
+  'Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)', // DualShock 4 蓝牙
+  'DUALSENSE (STANDARD GAMEPAD Vendor: 054c Product: 0df2)',
+  'PLAYSTATION(R)3 Controller (STANDARD GAMEPAD Vendor: 054c Product: 0268)',
+]
+
+const XBOX_IDS = [
+  'Xbox 360 Controller (XInput STANDARD GAMEPAD Vendor: 045e Product: 028e)',
+  'Xbox One Controller (STANDARD GAMEPAD Vendor: 045e Product: 02ea)',
+  'Xbox Elite Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 0b00)',
+  'Generic USB Joystick (STANDARD GAMEPAD Vendor: 0079 Product: 0006)', // 杂牌落到 Xbox 布局
+]
+
+test('Sony 设备（含蓝牙改名）识别为 ps 布局', () => {
+  for (const id of PS_IDS) {
+    assert.equal(detectLayout(id), 'ps', `应识别为 ps: ${id}`)
+  }
+})
+
+test('Xbox 与未知设备落到 xbox 布局（标准映射索引即 Xbox 约定）', () => {
+  for (const id of XBOX_IDS) {
+    assert.equal(detectLayout(id), 'xbox', `应识别为 xbox: ${id}`)
+  }
+})
+
+test('空 id 与无手柄状态落到 xbox 布局', () => {
+  assert.equal(detectLayout(''), 'xbox')
+  assert.equal(detectLayout(null), 'xbox')
+  assert.equal(detectLayout(undefined), 'xbox')
+})
+
+test('大小写与厂商号位置不敏感；"Xbox ... Wireless Controller" 不得误判', () => {
+  assert.equal(detectLayout('vendor: 054C product: 0ce6'), 'ps')
+  assert.equal(detectLayout('dualsense adaptation layer'), 'ps')
+  // 锚定的 ^wireless controller：蓝牙 Sony 开头命中，Xbox 品牌词组不命中
+  assert.equal(detectLayout('Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)'), 'ps')
+  assert.equal(detectLayout('Xbox Elite Wireless Controller (STANDARD GAMEPAD Vendor: 045e)'), 'xbox')
+})
+
+test('两套布局的按键符号语义对应：confirm/back 互为镜像', () => {
+  const xbox = chipFor('confirm', 'xbox')
+  const ps = chipFor('confirm', 'ps')
+  assert.equal(xbox.glyph, 'A')
+  assert.equal(ps.glyph, '✕')
+  assert.equal(chipFor('back', 'xbox').glyph, 'B')
+  assert.equal(chipFor('back', 'ps').glyph, '○')
+  assert.equal(chipFor('search', 'ps').glyph, '△')
+  assert.equal(chipFor('favorite', 'ps').glyph, '□')
+  assert.equal(chipFor('pages', 'ps').glyph, 'L1/R1')
+  assert.equal(chipFor('scroll', 'ps').glyph, 'L2/R2')
+})
+
+test('未知动作 id 不抛异常并返回中性空芯片', () => {
+  const chip = chipFor('nonexistent', 'ps')
+  assert.equal(chip.tone, 'neutral')
+})

--- a/src/renderer/desktop/composables/useGamepadLayout.test.js
+++ b/src/renderer/desktop/composables/useGamepadLayout.test.js
@@ -42,6 +42,9 @@ test('大小写与厂商号位置不敏感；"Xbox ... Wireless Controller" 不�
   // 锚定的 ^wireless controller：蓝牙 Sony 开头命中，Xbox 品牌词组不命中
   assert.equal(detectLayout('Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)'), 'ps')
   assert.equal(detectLayout('Xbox Elite Wireless Controller (STANDARD GAMEPAD Vendor: 045e)'), 'xbox')
+  // vendor 号锚定到 Vendor 字段：非 Sony 手柄的 Product 恰为 054c 不得误判
+  assert.equal(detectLayout('Generic Pad (STANDARD GAMEPAD Vendor: 0079 Product: 054c)'), 'xbox')
+  assert.equal(detectLayout('Xbox One Controller (STANDARD GAMEPAD Vendor: 045e Product: 054c)'), 'xbox')
 })
 
 test('两套布局的按键符号语义对应：confirm/back 互为镜像', () => {


### PR DESCRIPTION
## Summary

- 新增 `useGamepadLayout`：从 `gamepad.id` 识别手柄布局（Sony 054c / DualSense / DualShock / PlayStation / 蓝牙默认名），提示条按键符号跟随当前活跃手柄——拿 DualSense 看到 ✕○△□，拿 Xbox 看到 ABXY
- PS 语义按主机惯例：✕ 确认、○ 返回、△ 搜索、□ 收藏、L1/R1 换页、L2/R2 快速滚动；色调沿用 PS 按钮颜色
- `gamepadName` ref 回归（上上轮曾作为零引用导出被删，现在有正当消费者）：接入时记录、活跃手柄切换时更新，换手柄提示条即时换符号
- Switch Pro 有意不识别为第三套：Nintendo A/B 与 Xbox 物理位置互换，正确支持需要连确认/返回语义一起换，不做半吊子

## Test plan

- [x] 6 项新单测（共 61 过）：真实设备 id 样本（PS 四型 / Xbox 三型 / 杂牌 / 空值 / 大小写 / "Xbox Elite Wireless Controller" 反例——裸匹配 "Wireless Controller" 会误判，已锚定行首）
- [x] 构建、浏览器实测：DualSense 注入 → ✕○△□ 图例；模拟换 Xbox（挑战者切换）→ 即时翻 ABXY；模块 ref 直驱验证 name→layout→图例反应链
- [ ] 真机：实际 DualSense 蓝牙连接下 id 报告格式核对

🤖 Generated with [Claude Code](https://claude.com/claude-code)
