### PR TITLE
fix(device-hub): restore DualSense sidecar verification

### DIFF
--- a/src-tauri/src/dualsense/commands.rs
+++ b/src-tauri/src/dualsense/commands.rs
@@ -15,11 +15,10 @@ use super::emit_progress;
 use super::install::{dualsense_install_impl, dualsense_self_test_impl, dualsense_uninstall_impl};
 #[cfg(not(target_os = "windows"))]
 use super::packages::classify_local_component_packages;
-use super::packages::sidecar_path;
 use super::probe::{
     dualsense_get_status_with_config, ensure_no_active_session,
     ensure_no_active_session_for_uninstall, installed_usbip_version, pinned_usbip_installed,
-    run_probe, validate_requested_profile,
+    run_installed_probe, validate_requested_profile,
 };
 use super::{
     COMPONENT_OPERATION, DualSenseStatus, DualSenseTuningResult, MAX_LOCAL_COMPONENT_PACKAGES,
@@ -115,8 +114,7 @@ pub async fn dualsense_set_config(
     })?;
     ensure_no_active_session().await?;
     if enabled {
-        let executable = sidecar_path();
-        let probe = tokio::task::spawn_blocking(move || run_probe(&executable))
+        let probe = tokio::task::spawn_blocking(run_installed_probe)
             .await
             .map_err(|error| format!("DS5-PKG-003: sidecar probe task failed: {error}"))??;
         let usbip_version = installed_usbip_version();

--- a/src-tauri/src/dualsense/mod.rs
+++ b/src-tauri/src/dualsense/mod.rs
@@ -36,7 +36,8 @@ pub(crate) use {
         InstalledComponentManifest, LocalComponentKind, SidecarPackageManifest, UsbipInstallResult,
         classify_local_component_packages, component_matches_current_runtime,
         component_update_available, local_component_kind, purge_stale_handoff_packages,
-        read_sidecar_package_manifest, sha256_file, validate_sidecar_package_manifest,
+        read_sidecar_package_manifest, sha256_file, validate_sidecar_integrity,
+        validate_sidecar_package_manifest,
     },
     probe::{
         component_is_verified, component_state, component_test_failure, local_uninstalled_status,

--- a/src-tauri/src/dualsense/mod.rs
+++ b/src-tauri/src/dualsense/mod.rs
@@ -36,12 +36,11 @@ pub(crate) use {
         InstalledComponentManifest, LocalComponentKind, SidecarPackageManifest, UsbipInstallResult,
         classify_local_component_packages, component_matches_current_runtime,
         component_update_available, local_component_kind, purge_stale_handoff_packages,
-        read_sidecar_package_manifest, sha256_file, validate_component_integrity,
-        validate_sidecar_package_manifest,
+        read_sidecar_package_manifest, sha256_file, validate_sidecar_package_manifest,
     },
     probe::{
-        component_state, component_test_failure, local_uninstalled_status, pinned_usbip_installed,
-        run_with_timeout, validate_requested_profile,
+        component_is_verified, component_state, component_test_failure, local_uninstalled_status,
+        pinned_usbip_installed, run_with_timeout, validate_requested_profile,
     },
 };
 

--- a/src-tauri/src/dualsense/packages.rs
+++ b/src-tauri/src/dualsense/packages.rs
@@ -315,30 +315,6 @@ pub(crate) fn installed_component_manifest() -> Option<InstalledComponentManifes
     serde_json::from_slice(&contents).ok()
 }
 
-/// Verifies runtime files against the manifest written during elevated installation.
-pub(crate) fn validate_component_integrity(
-    directory: &Path,
-    manifest: &InstalledComponentManifest,
-) -> Result<(), String> {
-    if manifest.sha256.len() != 64 || manifest.sidecar_sha256.len() != 64 {
-        return Err("DS5-PKG-001: installed component manifest has invalid digests".to_string());
-    }
-    let sidecar_hash = sha256_file(&directory.join(SIDECAR_EXE))?;
-    let hidmaestro_hash = sha256_file(&directory.join("HIDMaestro.Core.dll"))?;
-    if !sidecar_hash.eq_ignore_ascii_case(&manifest.sidecar_sha256)
-        || !hidmaestro_hash.eq_ignore_ascii_case(&manifest.sha256)
-    {
-        return Err("DS5-PKG-001: installed component integrity check failed".to_string());
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_installed_component_integrity(
-    manifest: &InstalledComponentManifest,
-) -> Result<(), String> {
-    validate_component_integrity(&active_dir(), manifest)
-}
-
 pub(crate) fn component_update_available(manifest: Option<&InstalledComponentManifest>) -> bool {
     manifest.is_some_and(|manifest| manifest.component_version != COMPONENT_VERSION)
 }

--- a/src-tauri/src/dualsense/packages.rs
+++ b/src-tauri/src/dualsense/packages.rs
@@ -315,6 +315,27 @@ pub(crate) fn installed_component_manifest() -> Option<InstalledComponentManifes
     serde_json::from_slice(&contents).ok()
 }
 
+/// Verifies only the Sunshine-owned executable before it is launched from the active install.
+/// `sha256` is the HIDMaestro archive digest and must not be compared with an extracted DLL.
+pub(crate) fn validate_sidecar_integrity(
+    executable: &Path,
+    manifest: &InstalledComponentManifest,
+) -> Result<(), String> {
+    let valid_digest = manifest.sidecar_sha256.len() == 64
+        && manifest
+            .sidecar_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit());
+    if manifest.sidecar_file != SIDECAR_EXE || !valid_digest {
+        return Err("DS5-PKG-001: installed sidecar manifest is invalid".to_string());
+    }
+    let actual = sha256_file(executable)?;
+    if !actual.eq_ignore_ascii_case(&manifest.sidecar_sha256) {
+        return Err("DS5-PKG-001: installed sidecar integrity check failed".to_string());
+    }
+    Ok(())
+}
+
 pub(crate) fn component_update_available(manifest: Option<&InstalledComponentManifest>) -> bool {
     manifest.is_some_and(|manifest| manifest.component_version != COMPONENT_VERSION)
 }

--- a/src-tauri/src/dualsense/probe.rs
+++ b/src-tauri/src/dualsense/probe.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use super::config::{CoreDualSenseResponse, get_core_ds5_settings, resolve_core_config};
 use super::packages::{
     active_dir, component_matches_current_runtime, component_update_available,
-    installed_component_manifest, sidecar_path,
+    installed_component_manifest, sidecar_path, validate_sidecar_integrity,
 };
 use super::{
     COMPONENT_VERSION, DualSenseStatus, PROTOCOL_VERSION, USBIP_VERSION, observe_config_revision,
@@ -247,6 +247,14 @@ pub(crate) fn run_probe(executable: &Path) -> Result<ProbeResult, String> {
     Ok(result)
 }
 
+pub(crate) fn run_installed_probe() -> Result<ProbeResult, String> {
+    let executable = sidecar_path();
+    let manifest = installed_component_manifest()
+        .ok_or_else(|| "DS5-PKG-001: installed component manifest is missing".to_string())?;
+    validate_sidecar_integrity(&executable, &manifest)?;
+    run_probe(&executable)
+}
+
 pub(crate) fn component_test_failure(output: &std::process::Output, result_path: &Path) -> String {
     if let Ok(contents) = fs::read_to_string(result_path)
         && let Ok(result) = serde_json::from_str::<serde_json::Value>(&contents)
@@ -406,9 +414,8 @@ pub(crate) async fn dualsense_get_status_with_config(
     let installed = executable.is_file();
     let in_use = has_active_session().await;
     let probe = if installed {
-        let probe_executable = executable.clone();
         Some(
-            tokio::task::spawn_blocking(move || run_probe(&probe_executable))
+            tokio::task::spawn_blocking(run_installed_probe)
                 .await
                 .map_err(|error| format!("DS5-PKG-003: sidecar probe task failed: {error}"))
                 .and_then(|result| result),

--- a/src-tauri/src/dualsense/probe.rs
+++ b/src-tauri/src/dualsense/probe.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use super::config::{CoreDualSenseResponse, get_core_ds5_settings, resolve_core_config};
 use super::packages::{
     active_dir, component_matches_current_runtime, component_update_available,
-    installed_component_manifest, sidecar_path, validate_installed_component_integrity,
+    installed_component_manifest, sidecar_path,
 };
 use super::{
     COMPONENT_VERSION, DualSenseStatus, PROTOCOL_VERSION, USBIP_VERSION, observe_config_revision,
@@ -299,15 +299,23 @@ pub(crate) fn component_state(
         "in_use"
     } else if !installed {
         "not_installed"
-    } else if update_available {
-        "update_available"
     } else if !verified {
         "repair_required"
+    } else if update_available {
+        "update_available"
     } else if !transport_available {
         "transport_missing"
     } else {
         "ready"
     }
+}
+
+pub(crate) fn component_is_verified(
+    probe_succeeded: bool,
+    update_available: bool,
+    matches_current_runtime: bool,
+) -> bool {
+    probe_succeeded && (update_available || matches_current_runtime)
 }
 
 pub(crate) async fn ensure_no_active_session_for_uninstall() -> Result<(), String> {
@@ -397,28 +405,14 @@ pub(crate) async fn dualsense_get_status_with_config(
     let executable = sidecar_path();
     let installed = executable.is_file();
     let in_use = has_active_session().await;
-    let manifest = installed.then(installed_component_manifest).flatten();
-    let integrity_error = if installed {
-        manifest
-            .as_ref()
-            .ok_or_else(|| "DS5-PKG-001: installed component manifest is missing".to_string())
-            .and_then(validate_installed_component_integrity)
-            .err()
-    } else {
-        None
-    };
     let probe = if installed {
-        if let Some(error) = integrity_error {
-            Some(Err(error))
-        } else {
-            let probe_executable = executable.clone();
-            Some(
-                tokio::task::spawn_blocking(move || run_probe(&probe_executable))
-                    .await
-                    .map_err(|error| format!("DS5-PKG-003: sidecar probe task failed: {error}"))
-                    .and_then(|result| result),
-            )
-        }
+        let probe_executable = executable.clone();
+        Some(
+            tokio::task::spawn_blocking(move || run_probe(&probe_executable))
+                .await
+                .map_err(|error| format!("DS5-PKG-003: sidecar probe task failed: {error}"))
+                .and_then(|result| result),
+        )
     } else {
         None
     };
@@ -445,14 +439,16 @@ pub(crate) async fn dualsense_get_status_with_config(
     let usbip_version = installed_usbip_version().unwrap_or_default();
     let usbip_version_valid = pinned_usbip_installed(Some(usbip_version.as_str()));
     let usbip_available = result.usbip_available && usbip_version_valid;
+    let manifest = installed.then(installed_component_manifest).flatten();
     let update_available = installed && component_update_available(manifest.as_ref());
     let matches_current_runtime = component_matches_current_runtime(
         manifest.as_ref(),
         result.genshin_compatibility_identity,
         result.audio_policy_violation,
     );
-    let verified = probe_succeeded && matches_current_runtime;
-    if probe_succeeded && !matches_current_runtime {
+    let verified =
+        component_is_verified(probe_succeeded, update_available, matches_current_runtime);
+    if probe_succeeded && !update_available && !matches_current_runtime {
         error_code = "DS5-PROTO-001".to_string();
         detail = "DS5-PROTO-001: the installed component metadata or capabilities do not match this Control Panel build".to_string();
     }

--- a/src-tauri/src/dualsense/tests.rs
+++ b/src-tauri/src/dualsense/tests.rs
@@ -7,7 +7,8 @@ use super::{
     read_sidecar_package_manifest, recover_interrupted_activation, require_entity_tag,
     resolve_core_config, rollback_activated_component, run_with_timeout, sha256_file,
     update_config_fields, update_tuning_fields, validate_core_ds5_response,
-    validate_requested_profile, validate_sidecar_package_manifest, validate_strong_entity_tag,
+    validate_requested_profile, validate_sidecar_integrity, validate_sidecar_package_manifest,
+    validate_strong_entity_tag,
 };
 #[cfg(target_os = "windows")]
 use super::{
@@ -101,6 +102,20 @@ fn component_state_prioritizes_stream_ownership_and_recovery() {
         "transport_missing"
     );
     assert_eq!(component_state(true, true, true, false, false), "ready");
+}
+
+#[test]
+fn installed_sidecar_integrity_rejects_a_replaced_executable() {
+    let root = std::env::temp_dir().join(format!("sunshine-ds5-test-{}", uuid::Uuid::new_v4()));
+    write_valid_component(&root, b"trusted");
+    let manifest: InstalledComponentManifest =
+        serde_json::from_slice(&std::fs::read(root.join("component.json")).unwrap()).unwrap();
+    let executable = root.join(super::SIDECAR_EXE);
+
+    assert!(validate_sidecar_integrity(&executable, &manifest).is_ok());
+    std::fs::write(&executable, b"replaced").unwrap();
+    assert!(validate_sidecar_integrity(&executable, &manifest).is_err());
+    std::fs::remove_dir_all(root).unwrap();
 }
 
 #[test]

--- a/src-tauri/src/dualsense/tests.rs
+++ b/src-tauri/src/dualsense/tests.rs
@@ -1,12 +1,12 @@
 use super::{
     CoreDualSenseResponse, CoreDualSenseSettings, InstalledComponentManifest,
     SidecarPackageManifest, UsbipInstallResult, clamp_tuning, classify_usbip_installer_exit_code,
-    component_matches_current_runtime, component_state, component_test_failure,
-    component_update_available, copy_runtime_files, core_ds5_http_error, extract_sidecar_package,
-    local_uninstalled_status, pinned_usbip_installed, read_sidecar_package_manifest,
-    recover_interrupted_activation, require_entity_tag, resolve_core_config,
-    rollback_activated_component, run_with_timeout, sha256_file, update_config_fields,
-    update_tuning_fields, validate_component_integrity, validate_core_ds5_response,
+    component_is_verified, component_matches_current_runtime, component_state,
+    component_test_failure, component_update_available, copy_runtime_files, core_ds5_http_error,
+    extract_sidecar_package, local_uninstalled_status, pinned_usbip_installed,
+    read_sidecar_package_manifest, recover_interrupted_activation, require_entity_tag,
+    resolve_core_config, rollback_activated_component, run_with_timeout, sha256_file,
+    update_config_fields, update_tuning_fields, validate_core_ds5_response,
     validate_requested_profile, validate_sidecar_package_manifest, validate_strong_entity_tag,
 };
 #[cfg(target_os = "windows")]
@@ -90,7 +90,7 @@ fn component_state_prioritizes_stream_ownership_and_recovery() {
     );
     assert_eq!(
         component_state(true, false, true, false, true),
-        "update_available"
+        "repair_required"
     );
     assert_eq!(
         component_state(true, true, true, false, true),
@@ -101,19 +101,6 @@ fn component_state_prioritizes_stream_ownership_and_recovery() {
         "transport_missing"
     );
     assert_eq!(component_state(true, true, true, false, false), "ready");
-}
-
-#[test]
-fn installed_component_integrity_rejects_modified_runtime_files() {
-    let root = std::env::temp_dir().join(format!("sunshine-ds5-test-{}", uuid::Uuid::new_v4()));
-    write_valid_component(&root, b"trusted");
-    let manifest: InstalledComponentManifest =
-        serde_json::from_slice(&std::fs::read(root.join("component.json")).unwrap()).unwrap();
-
-    assert!(validate_component_integrity(&root, &manifest).is_ok());
-    std::fs::write(root.join(super::SIDECAR_EXE), b"modified").unwrap();
-    assert!(validate_component_integrity(&root, &manifest).is_err());
-    std::fs::remove_dir_all(root).unwrap();
 }
 
 #[test]
@@ -169,6 +156,9 @@ fn component_status_separates_updates_from_same_version_repairs() {
         true,
         true
     ));
+    assert!(component_is_verified(true, true, false));
+    assert!(!component_is_verified(false, true, false));
+    assert!(component_is_verified(true, false, true));
 }
 
 #[test]

--- a/src/renderer/components/DualSenseSettings.vue
+++ b/src/renderer/components/DualSenseSettings.vue
@@ -20,7 +20,7 @@
         </div>
         <div class="ds5-hud-actions">
           <el-button
-            v-if="statusKnown && !status.installed"
+            v-if="statusKnown && componentAction === 'install'"
             text
             type="primary"
             class="ds5-action"
@@ -29,7 +29,7 @@
             @click="install()"
           >{{ t.dualSense.install }}</el-button>
           <el-button
-            v-else-if="statusKnown && !status.verified"
+            v-else-if="statusKnown && componentAction === 'repair'"
             text
             type="warning"
             class="ds5-action"
@@ -38,7 +38,7 @@
             @click="install()"
           >{{ t.dualSense.repair }}</el-button>
           <el-button
-            v-else-if="statusKnown && status.update_available"
+            v-else-if="statusKnown && componentAction === 'update'"
             text
             type="warning"
             class="ds5-action"
@@ -75,7 +75,7 @@
         <el-checkbox
           v-model="enabled"
           class="ds5-enable-control"
-          :disabled="!status.verified || status.in_use || componentControlsBusy"
+          :disabled="!componentOperational || status.in_use || componentControlsBusy"
           @change="saveSettings"
         >{{ t.dualSense.enableShort }}</el-checkbox>
       </div>
@@ -100,7 +100,7 @@
       @close="operationError = ''"
     />
 
-    <section v-if="status.verified" class="ds5-section" :aria-label="t.dualSense.profileTitle">
+    <section v-if="componentOperational" class="ds5-section" :aria-label="t.dualSense.profileTitle">
       <div class="ds5-section-head">
         <span class="ds5-section-label">◈ {{ t.dualSense.profileTitle }}</span>
         <span class="ds5-section-rule"></span>
@@ -133,7 +133,7 @@
       </div>
     </section>
 
-    <section v-if="status.verified" class="ds5-section" :aria-label="t.dualSense.tuningTitle">
+    <section v-if="componentOperational" class="ds5-section" :aria-label="t.dualSense.tuningTitle">
       <div class="ds5-section-head">
         <span class="ds5-section-label">◈ {{ t.dualSense.tuningTitle }}</span>
         <span class="ds5-section-rule"></span>
@@ -184,7 +184,7 @@
       </div>
     </section>
 
-    <section v-if="status.verified" class="ds5-section" :aria-label="t.dualSense.gameCompatibility">
+    <section v-if="componentOperational" class="ds5-section" :aria-label="t.dualSense.gameCompatibility">
       <div class="ds5-section-head">
         <span class="ds5-section-label">◈ {{ t.dualSense.gameCompatibility }}</span>
         <span class="ds5-section-rule"></span>
@@ -207,7 +207,7 @@
       </p>
     </section>
 
-    <section v-if="status.verified" class="ds5-section">
+    <section v-if="componentOperational" class="ds5-section">
       <div class="ds5-section-head">
         <span class="ds5-section-label">◈ {{ t.dualSense.validateMode }}</span>
         <span class="ds5-section-rule"></span>
@@ -280,7 +280,7 @@ const {
   enabled, audioHaptics, genshinCompatibility,
   legacyStrength, legacyCurve, legacyNoiseGate,
   tuningSaving, tuningDirty, testCompleted, expandedSections,
-  controlsBusy, componentControlsBusy,
+  controlsBusy, componentControlsBusy, componentAction, componentOperational,
   stateLabel, nextAction, overallVersion, canTestAudioHaptics,
   showNotice, healthRows, safeStatusDetail,
   install, installFromPackage, refresh,

--- a/src/renderer/composables/deviceHubStatus.js
+++ b/src/renderer/composables/deviceHubStatus.js
@@ -2,6 +2,17 @@ export function deviceRuntimeReady(dualsenseStatus = {}, microphoneStatus = {}) 
   return Boolean(dualsenseStatus.verified || microphoneStatus.component_available)
 }
 
+export function dualSenseComponentAction(status = {}) {
+  if (!status.installed) return 'install'
+  if (!status.verified) return 'repair'
+  if (status.update_available) return 'update'
+  return ''
+}
+
+export function dualSenseComponentOperational(status = {}) {
+  return Boolean(status.verified)
+}
+
 export function microphoneStatusTone(status = {}) {
   if (status.error_code || status.state === 'faulted') return 'state-error'
   if (status.device_created || status.online) return 'state-ready'

--- a/src/renderer/composables/deviceHubStatus.test.js
+++ b/src/renderer/composables/deviceHubStatus.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import {
   canTestMicrophone,
   deviceRuntimeReady,
+  dualSenseComponentAction,
+  dualSenseComponentOperational,
   microphoneOverviewState,
   microphoneStatusTone,
 } from './deviceHubStatus.js'
@@ -11,6 +13,18 @@ test('device runtime is ready when either shared host probe succeeds', () => {
   assert.equal(deviceRuntimeReady({ verified: true }, {}), true)
   assert.equal(deviceRuntimeReady({}, { component_available: true }), true)
   assert.equal(deviceRuntimeReady({}, {}), false)
+})
+
+test('DualSense actions distinguish repair from a compatible update', () => {
+  assert.equal(dualSenseComponentAction({ installed: false }), 'install')
+  assert.equal(dualSenseComponentAction({ installed: true, verified: false, update_available: true }), 'repair')
+  assert.equal(dualSenseComponentAction({ installed: true, verified: true, update_available: true }), 'update')
+  assert.equal(dualSenseComponentAction({ installed: true, verified: true }), '')
+})
+
+test('DualSense settings remain available for verified components with an update', () => {
+  assert.equal(dualSenseComponentOperational({ verified: true, update_available: true }), true)
+  assert.equal(dualSenseComponentOperational({ verified: false, update_available: true }), false)
 })
 
 test('microphone status prioritizes faults over an old online flag', () => {

--- a/src/renderer/composables/useDualSenseSettings.js
+++ b/src/renderer/composables/useDualSenseSettings.js
@@ -17,6 +17,7 @@ import {
   mergeDualSenseStatus,
 } from './dualsenseConfigSync.js'
 import { installSelectedDualSensePackages } from './dualsenseInstallFlow.js'
+import { dualSenseComponentAction, dualSenseComponentOperational } from './deviceHubStatus.js'
 import { useI18n } from '../desktop/i18n/index.js'
 
 const STATUS_REFRESH_WAIT_TIMEOUT_MS = 5000
@@ -66,6 +67,8 @@ export function useDualSenseSettings() {
 
   const controlsBusy = computed(() => saving.value || tuningSaving.value || Boolean(operation.value))
   const componentControlsBusy = computed(() => Boolean(operation.value))
+  const componentAction = computed(() => dualSenseComponentAction(status.value))
+  const componentOperational = computed(() => dualSenseComponentOperational(status.value))
   const tuningDirty = computed(() =>
     legacyStrength.value !== status.value.legacy_strength
     || legacyCurve.value !== status.value.legacy_curve
@@ -91,7 +94,7 @@ export function useDualSenseSettings() {
   })
 
   const overallVersion = computed(() => {
-    if (status.value.update_available) {
+    if (status.value.verified && status.value.update_available) {
       const installedVersion = status.value.component_version || t.value.dualSense.unknownVersion
       return `${installedVersion} → ${status.value.available_component_version}`
     }
@@ -108,13 +111,13 @@ export function useDualSenseSettings() {
   const healthRows = computed(() => [
     {
       label: t.value.dualSense.component,
-      state: status.value.update_available
+      state: status.value.verified && status.value.update_available
         ? t.value.dualSense.updateAvailable
         : status.value.verified ? t.value.dualSense.available : t.value.dualSense.unavailable,
-      detail: status.value.update_available
+      detail: status.value.verified && status.value.update_available
         ? `${status.value.component_version || t.value.dualSense.unknownVersion} → ${status.value.available_component_version}`
         : status.value.component_version || status.value.error_code,
-      tone: status.value.update_available ? 'warn' : status.value.verified ? 'ok' : status.value.installed ? 'bad' : '',
+      tone: status.value.verified && status.value.update_available ? 'warn' : status.value.verified ? 'ok' : status.value.installed ? 'bad' : '',
     },
     {
       label: t.value.dualSense.runtime,
@@ -606,7 +609,7 @@ export function useDualSenseSettings() {
     enabled, audioHaptics, genshinCompatibility,
     legacyStrength, legacyCurve, legacyNoiseGate,
     tuningSaving, tuningDirty, testCompleted, expandedSections,
-    controlsBusy, componentControlsBusy,
+    controlsBusy, componentControlsBusy, componentAction, componentOperational,
     stateLabel, nextAction, overallVersion, canTestAudioHaptics,
     showNotice, healthRows, safeStatusDetail,
     install, installFromPackage, refresh,

--- a/src/renderer/composables/useDualSenseSettings.js
+++ b/src/renderer/composables/useDualSenseSettings.js
@@ -225,7 +225,7 @@ export function useDualSenseSettings() {
       ? packagePaths.filter((path) => typeof path === 'string' && path)
       : []
     const componentWasInstalled = status.value.installed
-    const upgrading = Boolean(status.value.installed && status.value.update_available)
+    const upgrading = componentAction.value === 'update'
     const localPackage = packagePaths.length > 0
     operation.value = 'confirm-install'
     try {


### PR DESCRIPTION
## 改了啥呀

- 恢复 v0.4.36 的 DualSense sidecar 状态语义：真实 probe 成功的旧组件继续可用，只提示更新
- 撤掉 PR #104 把 HIDMaestro 压缩包 SHA-256 当作解压后 DLL 摘要的错误校验
- 在所有 active sidecar 执行入口前，使用安装清单的 `sidecar_sha256` 单独核验 Sunshine.Ds5Sidecar.exe；文件被替换时拒绝执行
- 让真正未验证的组件优先进入“需要修复”，避免被“有可用更新”这个杂鱼状态盖住
- 安装、修复、更新的确认与成功文案统一复用 `componentAction`，修复流程不会再冒充更新
- 把组件操作与配置区可用性收敛成可测试状态，确保更新提示不会再藏掉振动调节

## 为啥要改

PR #104 的生命周期加固改变了 sidecar 验证路径。合法安装会在 probe 前因摘要类型不一致被拒绝；组件版本不同又不再视为可用，最终让整个 DualSense 配置区（包括振动强度、曲线和噪声门）消失。

这次恢复成熟行为的同时保留独立 sidecar 完整性检查，只校验即将执行的 Sunshine-owned 文件，不再混淆 HIDMaestro 包摘要。当前 Device Hub 模块结构、USB/IP 能力和有界进程树清理都保留。

## 验证

- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features`：156 passed
- `npm run test:renderer`：67 passed
- `npm run build:renderer`：通过
- `npm run build`：最新提交 Windows release 构建通过并已替换本机
- 本机安装清单的 `sidecar_sha256` 与 Sunshine.Ds5Sidecar.exe 实际摘要一致
- 本机 sidecar 执行 `--probe`：exit 0；standard、composite、Genshin identity、audio policy、driver、USB/IP 均为 true
- probe 退出后无 Sunshine.Ds5Sidecar / dotnet 残留进程
