### PR TITLE
perf(gui): suspend minimized webviews and add EcoQoS standby mode

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -63,6 +63,7 @@ pub fn setup_application(app: &mut App) -> Result<(), Box<dyn std::error::Error>
     }
 
     tray::create_system_tray(&app_handle)?;
+    crate::power::refresh_ecoqos_state(&app_handle);
     #[cfg(target_os = "windows")]
     if let Err(e) = crate::shell_context_menu::install_file_transfer_menu() {
         warn!("⚠️  安装文件传输右键菜单失败: {}", e);

--- a/src-tauri/src/game_session.rs
+++ b/src-tauri/src/game_session.rs
@@ -127,6 +127,11 @@ fn running_slot() -> &'static Mutex<Option<RunningState>> {
     SLOT.get_or_init(|| Mutex::new(None))
 }
 
+/// 当前是否有活跃的游戏会话（含启动器 shim 的识别窗口期）。
+pub fn is_game_session_active() -> bool {
+    running_slot().lock().is_ok_and(|slot| slot.is_some())
+}
+
 static GENERATION: AtomicU64 = AtomicU64::new(0);
 
 fn now_ms() -> u64 {
@@ -736,6 +741,7 @@ fn monitor_game(mut handle: OwnedHandle, context: MonitorContext) {
             stopped,
         },
     );
+    crate::power::refresh_ecoqos_state(&context.app);
     info!(
         "Game session ended: {} after {}s",
         context.app_name, seconds
@@ -969,6 +975,7 @@ pub async fn launch_game(
             adopted: false,
         },
     );
+    crate::power::refresh_ecoqos_state(&app_handle);
 
     if options.auto_yield {
         yield_desktop_window(&app_handle);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,6 +18,7 @@ mod github_download;
 mod hwinfo;
 mod logger;
 mod moonlight_web;
+mod power;
 mod proxy_server;
 mod rtss;
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/power.rs
+++ b/src-tauri/src/power.rs
@@ -6,21 +6,25 @@
 //! 可见面板/工具窗，就不能节流宿主进程。
 
 use log::info;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use tauri::{AppHandle, Manager, Runtime};
 
 /// 初值 true：`--hidden` 代理模式启动即处于 EcoQoS ON，无需打日志。
-static ECOQOS_ENABLED: AtomicBool = AtomicBool::new(true);
+/// 锁覆盖「求值 → 记录 → 应用」整个流程：并发回调按加锁顺序串行化，
+/// 避免较早回调的求值结果覆盖较新回调已应用的状态。
+static ECOQOS_ENABLED: Mutex<bool> = Mutex::new(true);
 
 /// 按当前应用状态重新评估并应用 EcoQoS。幂等、线程无关、可任意频率调用。
 pub fn refresh_ecoqos_state<R: Runtime>(app: &AppHandle<R>) {
     #[cfg(target_os = "windows")]
     {
+        let mut enabled = ECOQOS_ENABLED.lock().unwrap_or_else(|e| e.into_inner());
         let enable = app.webview_windows().is_empty()
             && !crate::game_session::is_game_session_active()
             && !crate::tray::is_tray_session_active();
 
-        if ECOQOS_ENABLED.swap(enable, Ordering::Relaxed) != enable {
+        if *enabled != enable {
+            *enabled = enable;
             info!(
                 "⚡ 效率模式（EcoQoS）→ {}",
                 if enable {

--- a/src-tauri/src/power.rs
+++ b/src-tauri/src/power.rs
@@ -1,0 +1,75 @@
+//! Windows 效率模式（EcoQoS）状态开关。
+//!
+//! 仅在「完全托盘常驻」时启用：所有 WebView 窗口已关闭、无游戏会话、
+//! Sunshine 核心未处于推流/暂停状态。任何窗口打开或会话活跃都会立即退出
+//! 效率模式。WebView2 子进程会继承宿主进程的节流状态，因此只要还有一个
+//! 可见面板/工具窗，就不能节流宿主进程。
+
+use log::info;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::{AppHandle, Manager, Runtime};
+
+/// 初值 true：`--hidden` 代理模式启动即处于 EcoQoS ON，无需打日志。
+static ECOQOS_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// 按当前应用状态重新评估并应用 EcoQoS。幂等、线程无关、可任意频率调用。
+pub fn refresh_ecoqos_state<R: Runtime>(app: &AppHandle<R>) {
+    #[cfg(target_os = "windows")]
+    {
+        let enable = app.webview_windows().is_empty()
+            && !crate::game_session::is_game_session_active()
+            && !crate::tray::is_tray_session_active();
+
+        if ECOQOS_ENABLED.swap(enable, Ordering::Relaxed) != enable {
+            info!(
+                "⚡ 效率模式（EcoQoS）→ {}",
+                if enable {
+                    "ON（托盘常驻，面板已全部关闭）"
+                } else {
+                    "OFF（面板或会话活动）"
+                }
+            );
+        }
+        apply_ecoqos(enable);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = app;
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn apply_ecoqos(enable: bool) {
+    use windows::Win32::System::Threading::{
+        GetCurrentProcess, PROCESS_POWER_THROTTLING_CURRENT_VERSION,
+        PROCESS_POWER_THROTTLING_EXECUTION_SPEED, PROCESS_POWER_THROTTLING_STATE,
+        ProcessPowerThrottling, SetProcessInformation,
+    };
+
+    let state = PROCESS_POWER_THROTTLING_STATE {
+        // Version 必须为 CURRENT_VERSION(1),传 0 会让 SetProcessInformation 静默失败。
+        Version: PROCESS_POWER_THROTTLING_CURRENT_VERSION,
+        ControlMask: PROCESS_POWER_THROTTLING_EXECUTION_SPEED,
+        StateMask: if enable {
+            PROCESS_POWER_THROTTLING_EXECUTION_SPEED
+        } else {
+            0
+        },
+    };
+
+    // GetCurrentProcess 返回伪句柄，绝不能 CloseHandle。
+    let result = unsafe {
+        SetProcessInformation(
+            GetCurrentProcess(),
+            ProcessPowerThrottling,
+            &state as *const PROCESS_POWER_THROTTLING_STATE as *const core::ffi::c_void,
+            size_of_val(&state) as u32,
+        )
+    };
+    if let Err(e) = result {
+        log::warn!(
+            "⚠️ SetProcessInformation(ProcessPowerThrottling) 失败: {}",
+            e
+        );
+    }
+}

--- a/src-tauri/src/toolbar.rs
+++ b/src-tauri/src/toolbar.rs
@@ -310,6 +310,7 @@ pub fn create_tool_window_internal<R: Runtime>(app: &AppHandle<R>, tool_type: &s
             #[cfg(target_os = "windows")]
             windows::configure_webview_security(&window);
 
+            crate::power::refresh_ecoqos_state(app);
             // 开发模式下自动打开 DevTools
             #[cfg(debug_assertions)]
             {
@@ -449,6 +450,7 @@ pub fn create_toolbar_window_internal<R: Runtime>(app: &AppHandle<R>) -> Result<
         Ok(win) => {
             // 在生产环境禁用右键菜单
             windows::disable_context_menu(&win);
+            crate::power::refresh_ecoqos_state(app);
 
             // 延迟 500ms 检查窗口尺寸（WebView2 初始化可能意外扩大窗口）
             let win_check = win.clone();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -193,6 +193,20 @@ static TRAY_RUNTIME_STATE: Mutex<TrayRuntimeState> = Mutex::new(TrayRuntimeState
     },
 });
 
+/// Sunshine 核心是否处于活跃会话（推流中或暂停）。paused 会话仍持有资源，
+/// 恢复瞬间不能处于效率模式节流之下。
+pub(crate) fn is_tray_session_active() -> bool {
+    TRAY_RUNTIME_STATE
+        .lock()
+        .map(|runtime| {
+            runtime
+                .tray_state
+                .as_ref()
+                .is_some_and(|state| matches!(state.status.as_str(), "streaming" | "paused"))
+        })
+        .unwrap_or(false)
+}
+
 static MAIN_PANEL_BRIDGE: main_panel::Bridge = main_panel::Bridge::new();
 
 pub(crate) fn emit_message<R: Runtime>(app: &AppHandle<R>, msg_type: &str, message: &str) {
@@ -1013,6 +1027,7 @@ fn apply_tray_state<R: Runtime + 'static>(
         let mut runtime = TRAY_RUNTIME_STATE.lock().unwrap();
         runtime.apply_connected_state(state, monitored_state_receipt)
     };
+    crate::power::refresh_ecoqos_state(app);
     let Some((previous_state, should_rebuild_menu)) = applied else {
         debug!("Ignored non-monitor tray state while Core is unavailable");
         return;
@@ -1053,6 +1068,7 @@ fn apply_tray_state<R: Runtime + 'static>(
 
 fn apply_core_disconnected<R: Runtime + 'static>(app: &AppHandle<R>) {
     let should_rebuild_menu = TRAY_RUNTIME_STATE.lock().unwrap().mark_disconnected();
+    crate::power::refresh_ecoqos_state(app);
 
     if let Err(e) = build_owned_system_tray(app) {
         error!(

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1,7 +1,7 @@
 use crate::proxy_server;
 use log::{debug, error, info, warn};
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use tauri::{
     AppHandle, Manager, PhysicalPosition, PhysicalSize, Runtime, WebviewWindow,
@@ -27,6 +27,11 @@ impl HeartbeatState {
 /// recovery monitor reload that window while its first page is still loading.
 static HEARTBEAT_MAP: Lazy<Mutex<HashMap<String, HeartbeatState>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Labels whose WebView2 render pipeline is suspended via ICoreWebView2_3::TrySuspend.
+/// A suspended webview's JS timers are frozen, so the heartbeat monitor must not
+/// treat it as crashed while it sits in this set.
+static SUSPENDED_WEBVIEWS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 #[derive(Default)]
 struct ToolWindowMoveSave {
@@ -290,6 +295,9 @@ pub fn webview_heartbeat(webview: tauri::Webview) {
 }
 
 fn begin_webview_heartbeat(window_id: &str) {
+    // A window recreated under the same label must never inherit a suspended
+    // state from its destroyed predecessor.
+    SUSPENDED_WEBVIEWS.lock().unwrap().remove(window_id);
     HEARTBEAT_MAP
         .lock()
         .unwrap()
@@ -439,6 +447,11 @@ pub fn start_heartbeat_monitor(app: AppHandle) {
 
             // 只检查可见的主要窗口（main / desktop）
             for label in &[MAIN_WINDOW_ID, DESKTOP_WINDOW_ID] {
+                // 挂起中的 WebView JS 定时器被冻结，心跳缺失是预期行为，
+                // 不能按崩溃恢复（否则会在挂起期间强制重载页面）。
+                if SUSPENDED_WEBVIEWS.lock().unwrap().contains(*label) {
+                    continue;
+                }
                 if let Some(win) = app.get_webview_window(label) {
                     let is_visible = win.is_visible().unwrap_or(false);
                     let is_minimized = win.is_minimized().unwrap_or(true);
@@ -461,6 +474,7 @@ pub fn show_and_activate_window<R: Runtime>(window: &WebviewWindow<R>) {
     let _ = window.set_focus();
 
     // 恢复 WebView 活跃状态（引擎级 + JS 级）
+    resume_webview(window);
     set_webview_window_visibility(window, true);
 
     // 重置代理快速失败状态，确保恢复后首次请求不被拦截
@@ -586,10 +600,13 @@ where
         let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
+        crate::power::refresh_ecoqos_state(app);
         return Ok(window);
     }
 
-    builder_fn(app).map_err(|e| format!("创建窗口失败: {}", e))
+    let window = builder_fn(app).map_err(|e| format!("创建窗口失败: {}", e))?;
+    crate::power::refresh_ecoqos_state(app);
+    Ok(window)
 }
 
 /// 打开关于窗口（单例模式）
@@ -651,6 +668,7 @@ pub fn open_pin_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std
         let _ = window.show();
         let _ = window.set_focus();
         debug!("✅ PIN 窗口已激活");
+        crate::power::refresh_ecoqos_state(app);
         return Ok(());
     }
 
@@ -681,6 +699,7 @@ pub fn open_pin_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std
     });
 
     debug!("✅ PIN 配对窗口创建成功");
+    crate::power::refresh_ecoqos_state(app);
     Ok(())
 }
 
@@ -782,6 +801,7 @@ fn create_main_window_internal<R: Runtime>(
 
     disable_context_menu(&window);
     info!("✅ {}主窗口创建成功", visibility_desc);
+    crate::power::refresh_ecoqos_state(app);
     Ok(())
 }
 
@@ -837,6 +857,7 @@ fn create_desktop_window_internal<R: Runtime>(
 
     disable_context_menu(&window);
     info!("✅ 桌面 UI 窗口创建成功");
+    crate::power::refresh_ecoqos_state(app);
     Ok(())
 }
 
@@ -847,6 +868,7 @@ pub fn open_desktop_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String>
         let _ = window.show();
         let _ = window.set_focus();
         debug!("✅ 桌面 UI 窗口已激活");
+        crate::power::refresh_ecoqos_state(app);
     } else {
         create_desktop_window(app).map_err(|e| e.to_string())?;
     }
@@ -896,7 +918,9 @@ pub fn activate_main_window(app: &tauri::AppHandle, target_url: Option<String>) 
     let _ = window.set_focus();
 
     // 恢复 WebView 活跃状态（引擎级 + JS 级）
+    resume_webview(&window);
     set_webview_window_visibility(&window, true);
+    crate::power::refresh_ecoqos_state(app);
 
     // 重置代理快速失败状态
     proxy_server::reset_fast_fail();
@@ -1028,6 +1052,113 @@ fn refresh_webview_surface<R: Runtime>(window: &WebviewWindow<R>) {
     });
 }
 
+/// 挂起 WebView2 渲染管线（窗口最小化/隐藏时调用）。
+///
+/// TrySuspend 要求 controller 不可见，而 wry 最小化时不会自动隐藏 controller，
+/// 因此先 SetIsVisible(false) 再挂起；恢复时由 resume_webview 按相反顺序还原。
+#[cfg(target_os = "windows")]
+fn suspend_webview<R: Runtime>(ww: &WebviewWindow<R>) {
+    use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2_3;
+    use webview2_com::TrySuspendCompletedHandler;
+    use wv2_windows_core::Interface;
+
+    let is_visible = ww.is_visible().unwrap_or(true);
+    let is_minimized = ww.is_minimized().unwrap_or(false);
+    if is_visible && !is_minimized {
+        // 200ms 延迟期内窗口已经恢复，不挂起。
+        return;
+    }
+
+    let label = ww.label().to_string();
+    if !SUSPENDED_WEBVIEWS.lock().unwrap().insert(label.clone()) {
+        return;
+    }
+
+    let _ = ww.with_webview(move |webview| {
+        let controller = webview.controller();
+        unsafe {
+            let mut started = true;
+            if let Err(e) = controller.SetIsVisible(false) {
+                log::warn!("⚠️ SetIsVisible(false) 失败 [{}]: {}", label, e);
+                started = false;
+            }
+
+            let webview3 = started
+                .then(|| controller.CoreWebView2())
+                .and_then(|core| core.ok())
+                .map(|core| core.cast::<ICoreWebView2_3>());
+
+            match webview3 {
+                Some(Ok(webview3)) => {
+                    let cb_label = label.clone();
+                    let handler =
+                        TrySuspendCompletedHandler::create(Box::new(move |result, suspended| {
+                            if result.is_ok() && suspended {
+                                debug!("💤 WebView2 渲染已挂起 [{}]", cb_label);
+                            } else {
+                                debug!("⚠️ WebView2 挂起未生效 [{}]: {:?}", cb_label, result.err());
+                                SUSPENDED_WEBVIEWS.lock().unwrap().remove(&cb_label);
+                            }
+                            Ok(())
+                        }));
+                    if let Err(e) = webview3.TrySuspend(&handler) {
+                        log::warn!("⚠️ TrySuspend 调用失败 [{}]: {}", label, e);
+                        started = false;
+                    }
+                }
+                Some(Err(e)) => {
+                    log::warn!("⚠️ 无法获取 ICoreWebView2_3 [{}]: {}", label, e);
+                    started = false;
+                }
+                None => {}
+            }
+
+            if !started {
+                // 还原 controller 可见性，避免留下"隐形但仍活着"的 WebView。
+                SUSPENDED_WEBVIEWS.lock().unwrap().remove(&label);
+                if let Err(e) = controller.SetIsVisible(true) {
+                    log::warn!("⚠️ 挂起失败后恢复可见性失败 [{}]: {}", label, e);
+                }
+            }
+        }
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+fn suspend_webview<R: Runtime>(_ww: &WebviewWindow<R>) {}
+
+/// 恢复挂起的 WebView2（窗口重新可见/获得焦点时调用）。幂等：未挂起时为 no-op。
+#[cfg(target_os = "windows")]
+fn resume_webview<R: Runtime>(ww: &WebviewWindow<R>) {
+    use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2_3;
+    use wv2_windows_core::Interface;
+
+    let label = ww.label().to_string();
+    if !SUSPENDED_WEBVIEWS.lock().unwrap().remove(&label) {
+        return;
+    }
+
+    debug!("☀️ 恢复 WebView2 渲染 [{}]", label);
+    let _ = ww.with_webview(move |webview| {
+        let controller = webview.controller();
+        unsafe {
+            // SetIsVisible(true) 本身会隐式恢复，但显式 Resume 语义更明确。
+            if let Ok(core) = controller.CoreWebView2()
+                && let Ok(webview3) = core.cast::<ICoreWebView2_3>()
+                && let Err(e) = webview3.Resume()
+            {
+                log::warn!("⚠️ Resume 失败 [{}]: {}", label, e);
+            }
+            if let Err(e) = controller.SetIsVisible(true) {
+                log::warn!("⚠️ SetIsVisible(true) 失败 [{}]: {}", label, e);
+            }
+        }
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+fn resume_webview<R: Runtime>(_ww: &WebviewWindow<R>) {}
+
 /// Notify the page so it can pause animations and suspend expensive content.
 /// The native window already controls WebView2 composition. Toggling the
 /// controller's IsVisible property separately can leave transparent WebViews
@@ -1053,6 +1184,8 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
         }
         tauri::WindowEvent::CloseRequested { .. } => {
             end_webview_heartbeat(window.label());
+            // 窗口正在销毁：清掉挂起标记即可，无需 Resume。
+            SUSPENDED_WEBVIEWS.lock().unwrap().remove(window.label());
             match window.label() {
                 "main" => {
                     // Let the WebView close so the user agent returns to its
@@ -1092,6 +1225,9 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
             if *focused {
                 // 窗口获得焦点时恢复 WebView 活跃状态
                 set_webview_visibility(window, true);
+                if let Some(ww) = window.app_handle().get_webview_window(label) {
+                    resume_webview(&ww);
+                }
                 // 重置代理快速失败状态
                 proxy_server::reset_fast_fail();
             } else {
@@ -1105,6 +1241,7 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
                         let is_visible = ww.is_visible().unwrap_or(true);
                         if is_minimized || !is_visible {
                             set_webview_window_visibility(&ww, false);
+                            suspend_webview(&ww);
                             debug!(
                                 "💤 WebView 进入休眠 [{}]: minimized={}, visible={}",
                                 label, is_minimized, is_visible
@@ -1113,6 +1250,14 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
                     }
                 });
             }
+        }
+        tauri::WindowEvent::Destroyed => {
+            // 延迟重估，等窗口从 Tauri 注册表移除后再判断是否回到托盘常驻态。
+            let app_handle = window.app_handle().clone();
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                crate::power::refresh_ecoqos_state(&app_handle);
+            });
         }
         _ => {}
     }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1091,6 +1091,7 @@ fn suspend_webview<R: Runtime>(ww: &WebviewWindow<R>) {
             match webview3 {
                 Some(Ok(webview3)) => {
                     let cb_label = label.clone();
+                    let cb_controller = controller.clone();
                     let handler =
                         TrySuspendCompletedHandler::create(Box::new(move |result, suspended| {
                             if result.is_ok() && suspended {
@@ -1098,6 +1099,15 @@ fn suspend_webview<R: Runtime>(ww: &WebviewWindow<R>) {
                             } else {
                                 debug!("⚠️ WebView2 挂起未生效 [{}]: {:?}", cb_label, result.err());
                                 SUSPENDED_WEBVIEWS.lock().unwrap().remove(&cb_label);
+                                // 异步失败时外层闭包已返回，必须在此自行还原
+                                // controller 可见性，否则面板会停留在隐形状态。
+                                if let Err(e) = cb_controller.SetIsVisible(true) {
+                                    log::warn!(
+                                        "⚠️ 挂起失败后恢复可见性失败 [{}]: {}",
+                                        cb_label,
+                                        e
+                                    );
+                                }
                             }
                             Ok(())
                         }));


### PR DESCRIPTION
## Summary
- **最小化挂起渲染管线**:main/desktop 面板最小化或隐藏 200ms 确认后,调用 `ICoreWebView2_3::TrySuspend` 冻结 WebView2 渲染/合成(挂起前 `SetIsVisible(false)`,wry 最小化不会自动隐藏 controller);恢复焦点/激活时幂等 `Resume`。`SUSPENDED_WEBVIEWS` 集合同步给心跳监控——挂起中 JS 定时器冻结、心跳缺失属预期,不得按渲染进程崩溃强制重载;CloseRequested/窗口重建时清理标记,避免跨窗口生命周期继承。
- **EcoQoS 效率模式开关**(新 `power.rs`):所有 WebView 窗口关闭(纯托盘常驻)+ 无活跃游戏会话 + 核心非 streaming/paused 时,通过 `SetProcessInformation(ProcessPowerThrottling)` 启用效率模式;任一窗口打开或会话活跃立即退出。窗口创建/销毁、游戏启动/退出、托盘状态变化均触发重估,跳变打 info 日志。WebView2 子进程继承宿主节流状态,因此条件要求全部窗口关闭。
- 注意:`PROCESS_POWER_THROTTLING_STATE.Version` 必须传 `PROCESS_POWER_THROTTLING_CURRENT_VERSION`(=1),传 0 会让 `SetProcessInformation` 静默失败。

## Test plan
- [x] `cargo clippy` 无新增警告;改动文件 `cargo fmt --check` 干净
- [x] 面板打开时查询进程节流状态为显式 OFF(ControlMask=1, StateMask=0)
- [x] 最小化面板放置 >110s:渲染子进程 CPU 归零,无「WebView 心跳超时」强制重载;还原后渲染与交互正常
- [x] 关闭全部窗口 → 进程节流状态读取为 ON(ControlMask=1, StateMask=1);重新打开面板立即回到 OFF
- [x] 与 #106(dualsense/renderer)无文件交集,不冲突