### PR TITLE
fix(gui): force surface resubmit after resuming a suspended webview

### DIFF
--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1162,6 +1162,16 @@ fn resume_webview<R: Runtime>(ww: &WebviewWindow<R>) {
             if let Err(e) = controller.SetIsVisible(true) {
                 log::warn!("⚠️ SetIsVisible(true) 失败 [{}]: {}", label, e);
             }
+            // 挂起管线恢复后必须强制重新提交 bounds 并通知位置变化，
+            // 否则 DWM 收不到新帧、面板持续黑屏（真机复现于 v0.4.40，
+            // 与 refresh_webview_surface 处理的陈旧合成是同类问题）。
+            let mut bounds = Default::default();
+            if controller.Bounds(&mut bounds).is_ok()
+                && let Err(error) = controller.SetBounds(bounds)
+            {
+                log::debug!("Failed to refresh WebView bounds [{}]: {:?}", label, error);
+            }
+            let _ = controller.NotifyParentWindowPositionChanged();
         }
     });
 }


### PR DESCRIPTION
## Summary
- 修复最小化挂起功能引入的黑屏回归:`ICoreWebView2_3::TrySuspend` 挂起后恢复时,仅 `Resume() + SetIsVisible(true)` 不够——DWM 收不到新帧,面板持续黑屏,且每次最小化/还原循环都会复现
- 在 `resume_webview` 恢复管线后重新提交当前 bounds 并调用 `NotifyParentWindowPositionChanged`,强制 WebView2 重新合成,与 `refresh_webview_surface` 在托盘激活路径的处理一致

## 背景
v0.4.40 真机复现:面板最小化约 12 秒后还原即黑屏,继续最小化/还原无法恢复(渲染进程存活、无崩溃转储、显卡驱动无异常,排除其他因素)。

## Test plan
- [x] `cargo check` 通过
- [x] 真机 A/B 验证:v0.4.40 并行运行修复版,修复版面板连续两轮「最小化 12s → 还原」内容正常,同操作在 v0.4.40 上稳定复现黑屏