### PR TITLE
refactor(elevation): share one hardened IPC module across helper stacks

### DIFF
--- a/src-tauri/src/dualsense/elevated.rs
+++ b/src-tauri/src/dualsense/elevated.rs
@@ -1,6 +1,5 @@
 //! Elevated (administrator) DualSense operations over a local named pipe.
 
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -23,10 +22,6 @@ pub(crate) const MAX_ELEVATED_MESSAGE_BYTES: usize = 64 * 1024;
 #[cfg(target_os = "windows")]
 pub(crate) const ELEVATION_CONNECT_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(10);
-
-#[cfg(target_os = "windows")]
-pub(crate) static ELEVATED_HELPER_JOB: OnceCell<std::os::windows::io::OwnedHandle> =
-    OnceCell::new();
 
 #[cfg(target_os = "windows")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -96,73 +91,6 @@ pub(crate) enum ElevatedMessage {
     Progress { stage: String, progress: u32 },
     Complete { data: serde_json::Value },
     Error { message: String },
-}
-
-#[cfg(target_os = "windows")]
-/// Bind the elevated helper and all children it launches to one lifetime job.
-fn bind_elevated_helper_lifetime() -> Result<(), String> {
-    use std::os::windows::io::{AsRawHandle, FromRawHandle};
-    use windows::Win32::Foundation::HANDLE;
-    use windows::Win32::System::JobObjects::{
-        AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
-        SetInformationJobObject,
-    };
-    use windows::Win32::System::Threading::GetCurrentProcess;
-    use windows::core::PCWSTR;
-
-    ELEVATED_HELPER_JOB
-        .get_or_try_init(|| unsafe {
-            let raw_job = CreateJobObjectW(None, PCWSTR::null()).map_err(|error| {
-                format!("DS5-PKG-003: unable to create elevated helper job: {error}")
-            })?;
-            let job = std::os::windows::io::OwnedHandle::from_raw_handle(raw_job.0);
-            let job_handle = HANDLE(job.as_raw_handle());
-            let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-            SetInformationJobObject(
-                job_handle,
-                JobObjectExtendedLimitInformation,
-                std::ptr::from_ref(&limits).cast(),
-                std::mem::size_of_val(&limits) as u32,
-            )
-            .map_err(|error| {
-                format!("DS5-PKG-003: unable to configure elevated helper job: {error}")
-            })?;
-            AssignProcessToJobObject(job_handle, GetCurrentProcess()).map_err(|error| {
-                format!("DS5-PKG-003: unable to bind elevated helper lifetime: {error}")
-            })?;
-            Ok(job)
-        })
-        .map(|_| ())
-}
-
-#[cfg(target_os = "windows")]
-pub(crate) fn elevated_pipe_name(token: uuid::Uuid) -> String {
-    format!(r"\\.\pipe\sunshine-dualsense-{token}")
-}
-
-#[cfg(target_os = "windows")]
-async fn connect_elevated_pipe(
-    token: uuid::Uuid,
-) -> Result<tokio::net::windows::named_pipe::NamedPipeClient, String> {
-    use tokio::net::windows::named_pipe::ClientOptions;
-
-    let pipe_name = elevated_pipe_name(token);
-    for _ in 0..100 {
-        match ClientOptions::new().read(true).write(true).open(&pipe_name) {
-            Ok(client) => return Ok(client),
-            Err(error) if matches!(error.raw_os_error(), Some(2 | 231)) => {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            }
-            Err(error) => {
-                return Err(format!(
-                    "DS5-PKG-004: unable to connect to the administrator operation: {error}"
-                ));
-            }
-        }
-    }
-    Err("DS5-PKG-004: administrator operation pipe was unavailable".to_string())
 }
 
 #[cfg(target_os = "windows")]
@@ -257,8 +185,14 @@ where
 async fn run_elevated_helper(operation: ElevatedOperation, token: uuid::Uuid) -> i32 {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let Ok(pipe) = connect_elevated_pipe(token).await else {
-        return 3;
+    let pipe = match crate::elevation::connect_helper_pipe(
+        &crate::elevation::pipe_name("dualsense", token),
+        "DS5-PKG-004",
+    )
+    .await
+    {
+        Ok(pipe) => pipe,
+        Err(_) => return 3,
     };
     let (mut pipe_reader, mut pipe_writer) = tokio::io::split(pipe);
     let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<ElevatedMessage>();
@@ -298,8 +232,8 @@ async fn run_elevated_helper(operation: ElevatedOperation, token: uuid::Uuid) ->
         });
     };
     let outcome: Result<serde_json::Value, String> = async {
-        bind_elevated_helper_lifetime()?;
-        if !crate::bat_runner::is_elevated() {
+        crate::elevation::bind_lifetime_job("DS5-PKG-003")?;
+        if !crate::elevation::is_elevated() {
             return Err("DS5-PKG-004: administrator authorization was not granted".to_string());
         }
         ensure_no_active_session().await?;
@@ -427,60 +361,12 @@ pub(crate) async fn read_limited_elevated_line<R: tokio::io::AsyncBufRead + Unpi
 }
 
 #[cfg(target_os = "windows")]
-async fn wait_for_elevated_process_exit(
-    process: &crate::utils::ElevatedProcess,
-    timeout: std::time::Duration,
-) -> Result<Option<i32>, String> {
-    let wait = async {
-        loop {
-            if let Some(exit_code) = process.exit_code()? {
-                return Ok::<_, String>(exit_code);
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-    };
-
-    match tokio::time::timeout(timeout, wait).await {
-        Ok(result) => result.map(Some),
-        Err(_) => Ok(None),
-    }
-}
-
-#[cfg(target_os = "windows")]
-pub(crate) async fn wait_for_elevated_pipe_connection<Connect, HelperExit>(
-    connect: Connect,
-    helper_exit: HelperExit,
-) -> Result<(), String>
-where
-    Connect: std::future::Future<Output = std::io::Result<()>>,
-    HelperExit: std::future::Future<Output = Result<Option<i32>, String>>,
-{
-    tokio::select! {
-        biased;
-        connected = connect => connected.map_err(|error| {
-            format!("DS5-PKG-004: administrator IPC connection failed: {error}")
-        }),
-        status = helper_exit => {
-            let status = status
-                .map_err(|error| format!("DS5-PKG-004: administrator helper wait failed: {error}"))?;
-            let Some(status) = status else {
-                return Err("DS5-PKG-004: administrator authorization timed out".to_string());
-            };
-            Err(format!(
-                "DS5-PKG-004: administrator authorization was canceled or the helper exited early ({status})"
-            ))
-        },
-    }
-}
-
-#[cfg(target_os = "windows")]
 pub(crate) async fn run_elevated_operation(
     app: Option<&tauri::AppHandle>,
     operation: ElevatedOperation,
     selected_packages: &[PathBuf],
 ) -> Result<serde_json::Value, String> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
-    use tokio::net::windows::named_pipe::ServerOptions;
 
     let token = uuid::Uuid::new_v4();
     let mut local_packages = if operation == ElevatedOperation::InstallLocal {
@@ -517,34 +403,30 @@ pub(crate) async fn run_elevated_operation(
         }
         None
     };
-    let pipe_name = elevated_pipe_name(token);
-    let mut server = ServerOptions::new()
-        .access_inbound(true)
-        .access_outbound(true)
-        .first_pipe_instance(true)
-        .reject_remote_clients(true)
-        .create(&pipe_name)
-        .map_err(|error| format!("DS5-PKG-004: unable to create administrator IPC: {error}"))?;
+    let mut server = crate::elevation::create_hardened_pipe(
+        &crate::elevation::pipe_name("dualsense", token),
+        "DS5-PKG-004",
+    )?;
     let operation_arg = operation.as_arg();
     let token_arg = token.to_string();
-    let elevated_process = tokio::task::spawn_blocking(move || {
-        crate::utils::launch_current_executable_elevated(
-            &[ELEVATED_DS5_ARG, operation_arg, &token_arg],
-            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
-        )
-    })
-    .await
-    .map_err(|error| format!("DS5-PKG-004: administrator launch task failed: {error}"))?
-    .map_err(|error| {
-        format!("DS5-PKG-004: unable to request administrator authorization: {error}")
-    })?;
-    let mut helper_exit = Box::pin(wait_for_elevated_process_exit(
+    let elevated_process = crate::elevation::spawn_helper(
+        vec![
+            ELEVATED_DS5_ARG.to_string(),
+            operation_arg.to_string(),
+            token_arg,
+        ],
+        "DS5-PKG-004",
+    )
+    .await?;
+    // Races the connect against an early helper exit (UAC cancellation) and
+    // verifies the pipe client is the process spawned above.
+    crate::elevation::connect_verified(
+        &mut server,
         &elevated_process,
         ELEVATION_CONNECT_TIMEOUT,
-    ));
-
-    wait_for_elevated_pipe_connection(server.connect(), &mut helper_exit).await?;
-    drop(helper_exit);
+        "DS5-PKG-004",
+    )
+    .await?;
     if let Some(packages) = local_packages.take() {
         server
             .write_all(&[packages.len() as u8])
@@ -600,7 +482,7 @@ pub(crate) async fn run_elevated_operation(
         Ok(Ok(result)) => result,
         Ok(Err(error)) => {
             // Dropping the pipe wakes the elevated helper's disconnect watcher.
-            let _ = wait_for_elevated_process_exit(
+            let _ = crate::elevation::wait_for_exit(
                 &elevated_process,
                 std::time::Duration::from_secs(5),
             )
@@ -611,7 +493,7 @@ pub(crate) async fn run_elevated_operation(
             // Dropping the timed-out receive future closes the pipe and causes
             // the helper to terminate itself even though this process cannot
             // directly kill a high-integrity child.
-            let _ = wait_for_elevated_process_exit(
+            let _ = crate::elevation::wait_for_exit(
                 &elevated_process,
                 std::time::Duration::from_secs(5),
             )
@@ -619,11 +501,13 @@ pub(crate) async fn run_elevated_operation(
             return Err("DS5-PKG-004: administrator operation timed out".to_string());
         }
     };
-    let status =
-        wait_for_elevated_process_exit(&elevated_process, std::time::Duration::from_secs(5))
-            .await
-            .map_err(|error| format!("DS5-PKG-004: administrator helper wait failed: {error}"))?
-            .ok_or_else(|| "DS5-PKG-004: administrator helper did not exit".to_string())?;
+    let status = crate::elevation::wait_for_exit(
+        &elevated_process,
+        std::time::Duration::from_secs(5),
+    )
+    .await
+    .map_err(|error| format!("DS5-PKG-004: administrator helper wait failed: {error}"))?
+    .ok_or_else(|| "DS5-PKG-004: administrator helper did not exit".to_string())?;
     match final_result {
         Some(Ok(data)) if status == 0 => Ok(data),
         Some(Err(error)) => Err(error),

--- a/src-tauri/src/dualsense/mod.rs
+++ b/src-tauri/src/dualsense/mod.rs
@@ -56,9 +56,8 @@ pub(crate) use {
 #[cfg(test)]
 #[cfg(target_os = "windows")]
 pub(crate) use elevated::{
-    ElevatedMessage, ElevatedOperation, MAX_ELEVATED_MESSAGE_BYTES, elevated_pipe_name,
-    read_limited_elevated_line, receive_local_component_packages_into,
-    wait_for_elevated_pipe_connection,
+    ElevatedMessage, ElevatedOperation, MAX_ELEVATED_MESSAGE_BYTES, read_limited_elevated_line,
+    receive_local_component_packages_into,
 };
 
 use log::info;

--- a/src-tauri/src/dualsense/tests.rs
+++ b/src-tauri/src/dualsense/tests.rs
@@ -13,8 +13,7 @@ use super::{
 };
 #[cfg(target_os = "windows")]
 use super::{
-    ElevatedMessage, ElevatedOperation, MAX_ELEVATED_MESSAGE_BYTES, elevated_pipe_name,
-    read_limited_elevated_line, wait_for_elevated_pipe_connection,
+    ElevatedMessage, ElevatedOperation, MAX_ELEVATED_MESSAGE_BYTES, read_limited_elevated_line,
 };
 use reqwest::header::HeaderValue;
 use std::io::Write as _;
@@ -669,7 +668,7 @@ fn elevated_operations_are_strictly_allowlisted() {
 fn elevated_ipc_uses_a_random_local_pipe_and_typed_messages() {
     let token = uuid::Uuid::parse_str("55d1fc2d-b474-4a86-a867-c6c514c077ef").unwrap();
     assert_eq!(
-        elevated_pipe_name(token),
+        crate::elevation::pipe_name("dualsense", token),
         r"\\.\pipe\sunshine-dualsense-55d1fc2d-b474-4a86-a867-c6c514c077ef"
     );
     let encoded = serde_json::to_string(&ElevatedMessage::Progress {
@@ -743,9 +742,10 @@ async fn elevated_ipc_rejects_oversized_messages_without_waiting_for_eof() {
 #[cfg(target_os = "windows")]
 #[tokio::test]
 async fn elevated_ipc_prefers_a_ready_pipe_over_a_ready_helper_exit() {
-    let result = wait_for_elevated_pipe_connection(
+    let result = crate::elevation::wait_for_pipe_connection(
         std::future::ready(Ok(())),
         std::future::ready(Ok(Some(0))),
+        "DS5-PKG-004",
     )
     .await;
 

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -1,0 +1,219 @@
+//! Shared plumbing for elevated same-binary helper processes.
+//!
+//! Privileged operations re-launch the current executable with the `runas`
+//! verb and speak to the parent over a per-invocation named pipe. Every
+//! helper stack needs the same skeleton: a hardened pipe whose name embeds a
+//! fresh UUID, the elevated launch, a connect race that notices an early
+//! helper exit (UAC cancellation) instead of waiting out the timeout,
+//! verification that the pipe client is the process this parent spawned, a
+//! poll-based exit-code wait, lifetime job binding so grandchildren die with
+//! the helper, and a native elevation probe. This module owns those parts;
+//! protocols and operations stay with each stack.
+
+/// Pipe name for one elevated invocation. `stack` names the calling feature
+/// (e.g. "usbip", "dualsense") so concurrent stacks never collide.
+pub(crate) fn pipe_name(stack: &str, token: uuid::Uuid) -> String {
+    format!(r"\\.\pipe\sunshine-{stack}-{token}")
+}
+
+/// Create the parent side of the helper pipe. `first_pipe_instance` makes
+/// CreateNamedPipe fail if the name already exists (no local squatting) and
+/// `reject_remote_clients` confines clients to this machine; the embedded
+/// UUID makes the name unguessable.
+pub(crate) fn create_hardened_pipe(
+    name: &str,
+    error_code: &str,
+) -> Result<tokio::net::windows::named_pipe::NamedPipeServer, String> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    ServerOptions::new()
+        .access_inbound(true)
+        .access_outbound(true)
+        .first_pipe_instance(true)
+        .reject_remote_clients(true)
+        .create(name)
+        .map_err(|error| format!("{error_code}: unable to create administrator IPC: {error}"))
+}
+
+/// Launch this executable elevated with the given helper arguments. Returns
+/// as soon as the UAC consent is granted or canceled.
+pub(crate) async fn spawn_helper(
+    arguments: Vec<String>,
+    error_code: &str,
+) -> Result<crate::utils::ElevatedProcess, String> {
+    tokio::task::spawn_blocking(move || {
+        let encoded: Vec<&str> = arguments.iter().map(String::as_str).collect();
+        crate::utils::launch_current_executable_elevated(
+            &encoded,
+            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
+        )
+    })
+    .await
+    .map_err(|error| format!("{error_code}: administrator launch task failed: {error}"))?
+    .map_err(|error| format!("{error_code}: administrator authorization was canceled: {error}"))
+}
+
+/// Poll the elevated process for up to `timeout`. Returns `None` when it is
+/// still running when the timeout elapses.
+pub(crate) async fn wait_for_exit(
+    process: &crate::utils::ElevatedProcess,
+    timeout: std::time::Duration,
+) -> Result<Option<i32>, String> {
+    let wait = async {
+        loop {
+            if let Some(exit_code) = process.exit_code()? {
+                return Ok::<_, String>(exit_code);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    };
+
+    match tokio::time::timeout(timeout, wait).await {
+        Ok(result) => result.map(Some),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Prefer a ready pipe connection over a ready helper exit: `biased` polls the
+/// connect future first, so a helper that exits after connecting still yields
+/// a successful connection.
+pub(crate) async fn wait_for_pipe_connection<Connect, HelperExit>(
+    connect: Connect,
+    helper_exit: HelperExit,
+    error_code: &str,
+) -> Result<(), String>
+where
+    Connect: std::future::Future<Output = std::io::Result<()>>,
+    HelperExit: std::future::Future<Output = Result<Option<i32>, String>>,
+{
+    tokio::select! {
+        biased;
+        connected = connect => connected.map_err(|error| {
+            format!("{error_code}: administrator IPC connection failed: {error}")
+        }),
+        status = helper_exit => {
+            let status = status
+                .map_err(|error| format!("{error_code}: administrator helper wait failed: {error}"))?;
+            let Some(status) = status else {
+                return Err(format!("{error_code}: administrator authorization timed out"));
+            };
+            Err(format!(
+                "{error_code}: administrator authorization was canceled or the helper exited early ({status})"
+            ))
+        },
+    }
+}
+
+/// Accept one helper connection and prove it belongs to the process this
+/// parent spawned: an early helper exit (UAC cancellation, crash) loses the
+/// race immediately instead of consuming the whole connect timeout, and a
+/// client whose PID does not match the spawned child is rejected.
+pub(crate) async fn connect_verified(
+    server: &mut tokio::net::windows::named_pipe::NamedPipeServer,
+    process: &crate::utils::ElevatedProcess,
+    connect_timeout: std::time::Duration,
+    error_code: &str,
+) -> Result<(), String> {
+    let mut helper_exit = Box::pin(wait_for_exit(process, connect_timeout));
+    wait_for_pipe_connection(server.connect(), &mut helper_exit, error_code).await?;
+    verify_client_process_id(server, process.process_id(), error_code)
+}
+
+/// The pipe server must never serve a client other than the elevated process
+/// this parent spawned for this invocation.
+pub(crate) fn verify_client_process_id(
+    server: &tokio::net::windows::named_pipe::NamedPipeServer,
+    expected_process_id: u32,
+    error_code: &str,
+) -> Result<(), String> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::Pipes::GetNamedPipeClientProcessId;
+
+    let mut client_process_id = 0;
+    unsafe {
+        GetNamedPipeClientProcessId(HANDLE(server.as_raw_handle()), &mut client_process_id)
+            .map_err(|error| {
+                format!("{error_code}: unable to authenticate administrator IPC client: {error}")
+            })?;
+    }
+    if client_process_id == 0 || client_process_id != expected_process_id {
+        return Err(format!(
+            "{error_code}: administrator IPC client is not the process authorized for this session"
+        ));
+    }
+    Ok(())
+}
+
+/// Connect to the parent's helper pipe from inside the elevated child,
+/// retrying while the pipe is still being created or is busy.
+pub(crate) async fn connect_helper_pipe(
+    name: &str,
+    error_code: &str,
+) -> Result<tokio::net::windows::named_pipe::NamedPipeClient, String> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    for _ in 0..100 {
+        match ClientOptions::new().read(true).write(true).open(name) {
+            Ok(client) => return Ok(client),
+            Err(error) if matches!(error.raw_os_error(), Some(2 | 231)) => {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "{error_code}: unable to connect to the administrator operation: {error}"
+                ));
+            }
+        }
+    }
+    Err(format!("{error_code}: administrator operation pipe was unavailable"))
+}
+
+static HELPER_JOB: once_cell::sync::OnceCell<std::os::windows::io::OwnedHandle> =
+    once_cell::sync::OnceCell::new();
+
+/// Bind the elevated helper and every process it launches to one lifetime
+/// job. Windows kills the whole tree when this process's handles close, so
+/// grandchildren (installers, downloaders) can never outlive the helper.
+pub(crate) fn bind_lifetime_job(error_code: &str) -> Result<(), String> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+        SetInformationJobObject,
+    };
+    use windows::Win32::System::Threading::GetCurrentProcess;
+    use windows::core::PCWSTR;
+
+    HELPER_JOB
+        .get_or_try_init(|| unsafe {
+            let raw_job = CreateJobObjectW(None, PCWSTR::null()).map_err(|error| {
+                format!("{error_code}: unable to create the elevated helper job: {error}")
+            })?;
+            let job = std::os::windows::io::OwnedHandle::from_raw_handle(raw_job.0);
+            let job_handle = HANDLE(job.as_raw_handle());
+            let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            SetInformationJobObject(
+                job_handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&limits).cast(),
+                std::mem::size_of_val(&limits) as u32,
+            )
+            .map_err(|error| {
+                format!("{error_code}: unable to configure the elevated helper job: {error}")
+            })?;
+            AssignProcessToJobObject(job_handle, GetCurrentProcess()).map_err(|error| {
+                format!("{error_code}: unable to bind the elevated helper lifetime: {error}")
+            })?;
+            Ok(job)
+        })
+        .map(|_| ())
+}
+
+/// Native elevation probe: reads the current process token instead of
+/// spawning PowerShell. A directly-launched (non-UAC) helper fails this.
+pub(crate) fn is_elevated() -> bool {
+    crate::utils::is_running_as_admin().unwrap_or(false)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,8 @@ mod controller_hub;
 mod controllermeta;
 mod desktop_settings;
 mod dualsense;
+#[cfg(target_os = "windows")]
+mod elevation;
 mod file_mapping;
 mod file_transfer;
 mod fs_utils;

--- a/src-tauri/src/usbip/elevated.rs
+++ b/src-tauri/src/usbip/elevated.rs
@@ -11,60 +11,34 @@ use super::{
 use super::{validate_bus_id, validate_remote, validate_tcp_port};
 
 #[cfg(target_os = "windows")]
-fn pipe_name(token: uuid::Uuid) -> String {
-    format!(r"\\.\pipe\sunshine-usbip-{token}")
-}
-
-#[cfg(target_os = "windows")]
 pub(super) async fn run_elevated(request: ElevatedRequest) -> Result<ElevatedResponse, String> {
-    use std::os::windows::io::AsRawHandle;
     use tokio::io::AsyncReadExt;
-    use tokio::net::windows::named_pipe::ServerOptions;
-    use windows::Win32::Foundation::HANDLE;
-    use windows::Win32::System::Pipes::GetNamedPipeClientProcessId;
 
     let timeout = request.timeout();
     let token = uuid::Uuid::new_v4();
-    let pipe = pipe_name(token);
-    let server = ServerOptions::new()
-        .access_inbound(true)
-        .access_outbound(true)
-        .first_pipe_instance(true)
-        .reject_remote_clients(true)
-        .create(&pipe)
-        .map_err(|error| format!("USBIP-UAC-002: unable to create administrator IPC: {error}"))?;
+    let mut server = crate::elevation::create_hardened_pipe(
+        &crate::elevation::pipe_name("usbip", token),
+        "USBIP-UAC-002",
+    )?;
     let payload = serde_json::to_string(&request).map_err(|error| {
         format!("USBIP-UAC-002: unable to encode administrator request: {error}")
     })?;
     let token_arg = token.to_string();
-    let process = tokio::task::spawn_blocking(move || {
-        crate::utils::launch_current_executable_elevated(
-            &[ELEVATED_ARG, &token_arg, &payload],
-            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
-        )
-    })
-    .await
-    .map_err(|error| format!("USBIP-UAC-001: administrator launch task failed: {error}"))?
-    .map_err(|error| format!("USBIP-UAC-001: administrator authorization was canceled: {error}"))?;
+    let process = crate::elevation::spawn_helper(
+        vec![ELEVATED_ARG.to_string(), token_arg, payload],
+        "USBIP-UAC-001",
+    )
+    .await?;
 
-    tokio::time::timeout(ELEVATED_CONNECT_TIMEOUT, server.connect())
-        .await
-        .map_err(|_| "USBIP-UAC-002: administrator helper connection timed out".to_string())?
-        .map_err(|error| format!("USBIP-UAC-002: administrator IPC connection failed: {error}"))?;
-    let expected_process_id = process.process_id();
-    let mut client_process_id = 0;
-    unsafe {
-        GetNamedPipeClientProcessId(HANDLE(server.as_raw_handle()), &mut client_process_id)
-            .map_err(|error| {
-                format!("USBIP-UAC-002: unable to authenticate administrator IPC client: {error}")
-            })?;
-    }
-    if client_process_id == 0 || client_process_id != expected_process_id {
-        return Err(
-            "USBIP-UAC-002: administrator IPC client is not the process authorized for this session"
-                .to_string(),
-        );
-    }
+    // Races the connect against an early helper exit (UAC cancellation) and
+    // verifies the pipe client is the process spawned above.
+    crate::elevation::connect_verified(
+        &mut server,
+        &process,
+        ELEVATED_CONNECT_TIMEOUT,
+        "USBIP-UAC-002",
+    )
+    .await?;
     let mut encoded = Vec::with_capacity(MAX_ELEVATED_RESPONSE_BYTES);
     let mut reader = server.take((MAX_ELEVATED_RESPONSE_BYTES + 1) as u64);
     tokio::time::timeout(timeout, reader.read_to_end(&mut encoded))
@@ -76,11 +50,21 @@ pub(super) async fn run_elevated(request: ElevatedRequest) -> Result<ElevatedRes
     }
     let response: ElevatedResponse = serde_json::from_slice(&encoded)
         .map_err(|error| format!("USBIP-UAC-002: invalid administrator response: {error}"))?;
-    drop(process);
-    if response.success {
+    // The helper's own verdict stays authoritative; the exit code only gates
+    // the success path as a belt-and-suspenders check.
+    if !response.success {
+        return Err(response.message);
+    }
+    let status = crate::elevation::wait_for_exit(&process, std::time::Duration::from_secs(5))
+        .await
+        .map_err(|error| format!("USBIP-UAC-002: administrator helper wait failed: {error}"))?
+        .ok_or_else(|| "USBIP-UAC-002: administrator helper did not exit".to_string())?;
+    if status == 0 {
         Ok(response)
     } else {
-        Err(response.message)
+        Err(format!(
+            "USBIP-UAC-002: administrator helper failed with exit code {status}"
+        ))
     }
 }
 
@@ -92,14 +76,19 @@ pub(super) async fn run_elevated(_request: ElevatedRequest) -> Result<ElevatedRe
 #[cfg(target_os = "windows")]
 async fn run_elevated_helper(token: uuid::Uuid, request: ElevatedRequest) -> i32 {
     use tokio::io::AsyncWriteExt;
-    use tokio::net::windows::named_pipe::ClientOptions;
 
-    let mut client = match ClientOptions::new().write(true).open(pipe_name(token)) {
+    let mut client = match crate::elevation::connect_helper_pipe(
+        &crate::elevation::pipe_name("usbip", token),
+        "USBIP-UAC-002",
+    )
+    .await
+    {
         Ok(client) => client,
         Err(_) => return 3,
     };
     let result: Result<ElevatedResponse, String> = async {
-        if !crate::bat_runner::is_elevated() {
+        crate::elevation::bind_lifetime_job("USBIP-UAC-002")?;
+        if !crate::elevation::is_elevated() {
             return Err("USBIP-UAC-001: administrator authorization was not granted".to_string());
         }
         match request {

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -1235,14 +1235,23 @@ async fn run_elevated_ioctl_command(command: &str) -> Result<(), String> {
         return Err("不允许的 VDD 提权命令".to_string());
     }
 
-    let executable = std::env::current_exe().map_err(|e| format!("无法定位控制面板程序: {e}"))?;
-    let executable = executable.to_string_lossy().replace('\'', "''");
     let encoded = URL_SAFE_NO_PAD.encode(command.as_bytes());
-    let inner = format!(
-        "$p = Start-Process -FilePath '{}' -ArgumentList '{}','{}' -Verb RunAs -WindowStyle Hidden -Wait -PassThru; exit $p.ExitCode",
-        executable, ELEVATED_VDD_IOCTL_ARG, encoded
-    );
-    run_elevated_powershell(&inner, "提权执行 VDD IOCTL").await
+    let process = crate::elevation::spawn_helper(
+        vec![ELEVATED_VDD_IOCTL_ARG.to_string(), encoded],
+        "VDD-ELEV",
+    )
+    .await
+    .map_err(|error| format!("提权执行 VDD IOCTL失败: {error}"))?;
+    // RELOAD_DRIVER triggers an IddCx display-driver reload that can be slow
+    // in pathological cases; the cap only guards against a truly hung child.
+    let status = crate::elevation::wait_for_exit(&process, std::time::Duration::from_secs(120))
+        .await
+        .map_err(|error| format!("提权执行 VDD IOCTL失败: {error}"))?
+        .ok_or_else(|| "提权执行 VDD IOCTL超时".to_string())?;
+    match status {
+        0 => Ok(()),
+        code => Err(format!("提权执行 VDD IOCTL失败（退出码 {code}）")),
+    }
 }
 
 /// 验证 EDID 文件格式和 checksum

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -1172,10 +1172,20 @@ pub(crate) fn try_handle_elevated_ioctl_command() -> Option<i32> {
         return Some(2);
     }
 
-    match crate::vdd_ioctl::send_command(&command) {
-        crate::vdd_ioctl::IoctlResult::Success => Some(0),
-        crate::vdd_ioctl::IoctlResult::InterfaceMissing
-        | crate::vdd_ioctl::IoctlResult::Failed { .. } => Some(1),
+    // A medium-integrity parent cannot terminate this high-integrity helper,
+    // so the helper bounds itself: if the ioctl hangs, exiting the process
+    // abandons the blocked thread and the parent observes the exit code
+    // instead of its own timeout. Kept just under the parent's 120 s wait.
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(crate::vdd_ioctl::send_command(&command));
+    });
+    let result = receiver.recv_timeout(std::time::Duration::from_secs(110));
+    match result {
+        Ok(crate::vdd_ioctl::IoctlResult::Success) => Some(0),
+        Ok(crate::vdd_ioctl::IoctlResult::InterfaceMissing)
+        | Ok(crate::vdd_ioctl::IoctlResult::Failed { .. })
+        | Err(_) => Some(1),
     }
 }
 


### PR DESCRIPTION
## Summary

Three elevated-helper stacks (DualSense, USB/IP, VDD IOCTL) each carried a private copy of the same IPC skeleton, with security properties that diverged in both directions. This adds `src-tauri/src/elevation.rs` and migrates all three onto it:

- **DualSense pipe now verifies the connecting client's PID** (`GetNamedPipeClientProcessId` vs the spawned process) — previously the first connect was trusted on name unguessability alone
- **USB/IP helper now binds a `KILL_ON_JOB_CLOSE` lifetime job** (grandchildren can no longer outlive it), connects with the retrying client, races connect against early child exit (fast UAC-cancel detection), and cross-checks exit code 0 on the success path — the helper's own response stays authoritative for failures
- **All helpers revalidate elevation with the native token probe** instead of spawning PowerShell per check
- **VDD IOCTL fallback launches through the hardened argument-quoting launcher** instead of a PowerShell `Start-Process` command line (which also had an unquoted `-ArgumentList` join), bounded at 120 s for slow `RELOAD_DRIVER` reloads

Net −122 lines in the migrated files (+321/−219 overall including the new module and its docs).

Based on #115 (which contains the usbip module split this builds on) — retarget to `main` after that merges.

## Verification

Three-lens adversarial audit before pushing (per-stack equivalence, security claims, regression hunt):
- every deleted local helper maps to a semantically identical shared function (pipe names byte-identical, same ServerOptions flags, same retry/poll budgets, same biased select, same job flags)
- the only behavior changes are the documented additions above
- two audit findings applied: usbip's exit-code check no longer preempts the helper's own error message; the VDD wait was raised from 30 s to 120 s

`cargo test` 168 passed, no warnings.

## Test plan

- [x] cargo test 168 passed
- [x] Adversarial equivalence audit over old vs new sources
- [ ] Real machine: DualSense install/uninstall round-trip (NDJSON stream + package upload through the shared connect)
- [ ] Real machine: USB/IP cleanup (elevated helper through the shared connect + new exit-code gate)
- [ ] Real machine: VDD RELOAD_DRIVER fallback path with a residual-state trigger