### PR TITLE
refactor(elevation): converge every roll-own elevated spawn onto the shared launcher

### DIFF
--- a/src-tauri/src/bat_runner.rs
+++ b/src-tauri/src/bat_runner.rs
@@ -96,26 +96,16 @@ pub fn run_elevated(bat_path: &Path, log_prefix: &str, extra_args: &[&str]) -> R
                 .map_err(|e| format!("写入 wrapper 失败: {e}，日志: {log_str}"))?;
         }
 
-        // 直接以 runas 启动 System32 的 cmd.exe 执行 wrapper：参数经过
-        // C-runtime 引号处理，%TEMP% 含空格时依然正确（此前经 PowerShell
-        // Start-Process -ArgumentList 中转，未加引号的路径会被拆断）。
-        let process = crate::elevation::launch_elevated(
-            crate::elevation::system_binary("cmd.exe").as_os_str(),
-            &[
-                "/d",
-                "/s",
-                "/c",
-                &wrapper_path.to_string_lossy(),
-            ],
-            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
+        // 经共享 run_cmd_elevated（裸 switch + 外层引号对）执行 wrapper：
+        // cmd 的 /S 精确剥掉外层引号后 `call "<wrapper>"` 原样执行，
+        // %TEMP% 含空格时依然正确（此前经 PowerShell Start-Process
+        // -ArgumentList 中转，未加引号的路径会被拆断）。
+        let command_line = format!(r#"call "{}""#, wrapper_path.to_string_lossy());
+        let status = crate::elevation::run_cmd_elevated(
+            &command_line,
+            std::time::Duration::from_secs(600),
         )
         .map_err(|e| format!("无法启动提权脚本: {e}，日志: {log_str}"))?;
-
-        // 驱动脚本可能跑数分钟；上限只兜底真正挂死的场景。
-        let status = process
-            .wait_for_exit_blocking(std::time::Duration::from_secs(600))
-            .map_err(|e| format!("等待提权脚本失败: {e}，日志: {log_str}"))?
-            .ok_or_else(|| format!("脚本执行超时，日志: {log_str}"))?;
 
         if status != 0 {
             return Err(format!("脚本执行失败 (exit {status})，日志: {log_str}"));

--- a/src-tauri/src/bat_runner.rs
+++ b/src-tauri/src/bat_runner.rs
@@ -12,19 +12,10 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
-const ELEVATION_LAUNCH_FAILED: i32 = 1223;
 
-/// 检查当前进程是否具有管理员权限
+/// 检查当前进程是否具有管理员权限（读取进程令牌，不再 spawn PowerShell）
 pub fn is_elevated() -> bool {
-    let output = Command::new("powershell")
-        .args([
-            "-NoProfile",
-            "-Command",
-            "([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)",
-        ])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output();
-    matches!(output, Ok(out) if String::from_utf8_lossy(&out.stdout).trim() == "True")
+    crate::elevation::is_elevated()
 }
 
 fn append_process_output(log_path: &Path, stdout: &[u8], stderr: &[u8]) {
@@ -105,25 +96,29 @@ pub fn run_elevated(bat_path: &Path, log_prefix: &str, extra_args: &[&str]) -> R
                 .map_err(|e| format!("写入 wrapper 失败: {e}，日志: {log_str}"))?;
         }
 
-        let escaped_wrapper = wrapper_path.to_string_lossy().replace('\'', "''");
-        let ps_cmd = format!(
-            r#"$ErrorActionPreference = 'Stop'; try {{ $p = Start-Process cmd -ArgumentList '/c','{escaped_wrapper}' -Verb RunAs -WindowStyle Hidden -PassThru -Wait; exit $p.ExitCode }} catch {{ [Console]::Error.WriteLine($_.Exception.Message); exit {ELEVATION_LAUNCH_FAILED} }}"#
-        );
-        let output = Command::new("powershell")
-            .args(["-NoProfile", "-Command", &ps_cmd])
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("无法启动提权脚本: {e}，日志: {log_str}"))?;
+        // 直接以 runas 启动 System32 的 cmd.exe 执行 wrapper：参数经过
+        // C-runtime 引号处理，%TEMP% 含空格时依然正确（此前经 PowerShell
+        // Start-Process -ArgumentList 中转，未加引号的路径会被拆断）。
+        let process = crate::elevation::launch_elevated(
+            crate::elevation::system_binary("cmd.exe").as_os_str(),
+            &[
+                "/d",
+                "/s",
+                "/c",
+                &wrapper_path.to_string_lossy(),
+            ],
+            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
+        )
+        .map_err(|e| format!("无法启动提权脚本: {e}，日志: {log_str}"))?;
 
-        append_process_output(&log_path, &output.stdout, &output.stderr);
-        if !output.status.success() {
-            let code = output.status.code().unwrap_or(-1);
-            if code == ELEVATION_LAUNCH_FAILED && !output.stderr.is_empty() {
-                return Err(format!(
-                    "无法启动提权脚本（管理员授权被取消或启动失败），请重试。日志: {log_str}"
-                ));
-            }
-            return Err(format!("脚本执行失败 (exit {code})，日志: {log_str}"));
+        // 驱动脚本可能跑数分钟；上限只兜底真正挂死的场景。
+        let status = process
+            .wait_for_exit_blocking(std::time::Duration::from_secs(600))
+            .map_err(|e| format!("等待提权脚本失败: {e}，日志: {log_str}"))?
+            .ok_or_else(|| format!("脚本执行超时，日志: {log_str}"))?;
+
+        if status != 0 {
+            return Err(format!("脚本执行失败 (exit {status})，日志: {log_str}"));
         }
         let _ = std::fs::remove_file(&wrapper_path);
     }

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -347,6 +347,19 @@ pub(crate) fn run_cmd_elevated(
         .ok_or_else(|| "elevated command timed out".to_string())
 }
 
+/// Async form of [`run_cmd_elevated`] for callers on the async runtime: the
+/// UAC consent wait and the command wait run on the blocking pool instead of
+/// pinning a Tokio worker thread.
+pub(crate) async fn run_cmd_elevated_async(
+    command_line: &str,
+    timeout: std::time::Duration,
+) -> Result<i32, String> {
+    let command_line = command_line.to_string();
+    tokio::task::spawn_blocking(move || run_cmd_elevated(&command_line, timeout))
+        .await
+        .map_err(|error| format!("elevated command task failed: {error}"))?
+}
+
 /// Run one PowerShell `-Command <inner>` elevated (hidden window) and wait
 /// for its exit code. `inner` is passed verbatim: callers already quote their
 /// own values with PowerShell single quotes, and the C-runtime quoting at the

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -217,3 +217,171 @@ pub(crate) fn bind_lifetime_job(error_code: &str) -> Result<(), String> {
 pub(crate) fn is_elevated() -> bool {
     crate::utils::is_running_as_admin().unwrap_or(false)
 }
+
+/// Quote one argument the way the C runtime parses command lines, so a
+/// re-launched process receives it verbatim. Rejects NUL bytes.
+pub(crate) fn quote_windows_argument(value: &str) -> Result<String, String> {
+    if value.contains('\0') {
+        return Err("elevated process argument contains a NUL byte".to_string());
+    }
+
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    let mut backslashes = 0;
+    for character in value.chars() {
+        match character {
+            '\\' => backslashes += 1,
+            '"' => {
+                quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+                quoted.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                quoted.extend(std::iter::repeat_n('\\', backslashes));
+                quoted.push(character);
+                backslashes = 0;
+            }
+        }
+    }
+    quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
+    quoted.push('"');
+    Ok(quoted)
+}
+
+/// Launch an arbitrary program with the Windows `runas` verb.
+///
+/// Blocks until the UAC consent is granted or canceled, then returns the
+/// process handle for exit waiting. `program` should be an absolute path —
+/// callers resolve system binaries from `%SystemRoot%` rather than trusting
+/// PATH. Arguments are C-runtime quoted.
+pub(crate) fn launch_elevated(
+    program: &std::ffi::OsStr,
+    arguments: &[&str],
+    show_window: i32,
+) -> Result<crate::utils::ElevatedProcess, String> {
+    let parameters = arguments
+        .iter()
+        .map(|argument| quote_windows_argument(argument))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(" ");
+    launch_elevated_raw(program, &parameters, show_window)
+}
+
+/// Launch an arbitrary program with the Windows `runas` verb, passing
+/// `raw_parameters` to `lpParameters` verbatim — for consumers (cmd.exe)
+/// whose command-line dialect is not the C-runtime quoting rules.
+///
+/// Blocks until the UAC consent is granted or canceled.
+pub(crate) fn launch_elevated_raw(
+    program: &std::ffi::OsStr,
+    raw_parameters: &str,
+    show_window: i32,
+) -> Result<crate::utils::ElevatedProcess, String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::Shell::{SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW};
+    use windows::core::PCWSTR;
+
+    fn os_to_wide(value: &std::ffi::OsStr) -> Vec<u16> {
+        value.encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    let verb = os_to_wide("runas".as_ref());
+    let executable = os_to_wide(program);
+    let parameters = os_to_wide(raw_parameters.as_ref());
+    let mut execute_info = SHELLEXECUTEINFOW::default();
+    execute_info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
+    execute_info.fMask = SEE_MASK_NOCLOSEPROCESS;
+    execute_info.hwnd = HWND(std::ptr::null_mut());
+    execute_info.lpVerb = PCWSTR(verb.as_ptr());
+    execute_info.lpFile = PCWSTR(executable.as_ptr());
+    execute_info.lpParameters = PCWSTR(parameters.as_ptr());
+    execute_info.nShow = show_window;
+
+    unsafe {
+        ShellExecuteExW(&mut execute_info)
+            .map_err(|error| format!("Windows could not start the elevated process: {error}"))?;
+    }
+    if execute_info.hProcess.0.is_null() {
+        return Err("Windows did not return an elevated process handle".to_string());
+    }
+    use std::os::windows::io::FromRawHandle;
+    Ok(crate::utils::ElevatedProcess::from_owned_handle(unsafe {
+        std::os::windows::io::OwnedHandle::from_raw_handle(execute_info.hProcess.0)
+    }))
+}
+
+/// Resolve a system binary as an absolute path, independent of PATH.
+pub(crate) fn system_binary(name: &str) -> std::path::PathBuf {
+    let system_root =
+        std::env::var_os("SystemRoot").unwrap_or_else(|| "C:\\Windows".into());
+    std::path::Path::new(&system_root).join("System32").join(name)
+}
+
+/// Run one cmd.exe command line elevated (hidden window) and wait for its exit
+/// code.
+///
+/// The command is passed as `/d /s /c "<command_line>"`: with `/s`, cmd strips
+/// exactly the outer quote pair and executes the rest verbatim, so the
+/// command's own quoting travels unmodified. `command_line` must therefore
+/// contain no NUL bytes and must quote its own paths; it is NOT re-escaped —
+/// cmd does not understand the C-runtime `\"` convention.
+pub(crate) fn run_cmd_elevated(
+    command_line: &str,
+    timeout: std::time::Duration,
+) -> Result<i32, String> {
+    if command_line.contains('\0') {
+        return Err("elevated command contains a NUL byte".to_string());
+    }
+    // Switches must stay unquoted: cmd applies its /c quote-stripping rule
+    // only when the switches are bare. With /s, exactly the outer quote pair
+    // around the command is stripped and the rest executes verbatim.
+    let parameters = format!("/d /s /c \"{command_line}\"");
+    let process = launch_elevated_raw(
+        system_binary("cmd.exe").as_os_str(),
+        &parameters,
+        windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
+    )?;
+    process
+        .wait_for_exit_blocking(timeout)?
+        .ok_or_else(|| "elevated command timed out".to_string())
+}
+
+/// Run one PowerShell `-Command <inner>` elevated (hidden window) and wait
+/// for its exit code. `inner` is passed verbatim: callers already quote their
+/// own values with PowerShell single quotes, and the C-runtime quoting at the
+/// launch layer protects the argument boundary — no further escaping here.
+pub(crate) async fn run_powershell_elevated(
+    inner_command: &str,
+    timeout: std::time::Duration,
+) -> Result<i32, String> {
+    let inner = inner_command.to_string();
+    tokio::task::spawn_blocking(move || {
+        let process = launch_elevated(
+            system_binary(r"WindowsPowerShell\v1.0\powershell.exe").as_os_str(),
+            &["-NoProfile", "-Command", &inner],
+            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
+        )?;
+        process
+            .wait_for_exit_blocking(timeout)?
+            .ok_or_else(|| "elevated PowerShell command timed out".to_string())
+    })
+    .await
+    .map_err(|error| format!("elevated PowerShell task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quote_windows_argument;
+
+    #[test]
+    fn quotes_arguments_like_the_c_runtime() {
+        assert_eq!(quote_windows_argument("abc").unwrap(), "\"abc\"");
+        assert_eq!(quote_windows_argument("a b").unwrap(), "\"a b\"");
+        assert_eq!(quote_windows_argument("a\"b").unwrap(), "\"a\\\"b\"");
+        assert_eq!(quote_windows_argument("a\\b").unwrap(), "\"a\\b\"");
+        assert_eq!(quote_windows_argument("a\\").unwrap(), "\"a\\\\\"");
+        assert_eq!(quote_windows_argument("a\\\\\"b").unwrap(), "\"a\\\\\\\\\\\"b\"");
+        assert!(quote_windows_argument("a\0b").is_err());
+    }
+}

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -279,7 +279,9 @@ pub(crate) fn launch_elevated_raw(
 ) -> Result<crate::utils::ElevatedProcess, String> {
     use std::os::windows::ffi::OsStrExt;
     use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::Shell::{SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW};
+    use windows::Win32::UI::Shell::{
+        SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW,
+    };
     use windows::core::PCWSTR;
 
     fn os_to_wide(value: &std::ffi::OsStr) -> Vec<u16> {
@@ -291,7 +293,9 @@ pub(crate) fn launch_elevated_raw(
     let parameters = os_to_wide(raw_parameters.as_ref());
     let mut execute_info = SHELLEXECUTEINFOW::default();
     execute_info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
-    execute_info.fMask = SEE_MASK_NOCLOSEPROCESS;
+    // NOASYNC: worker threads (spawn_blocking) have no message loop, and this
+    // call must complete synchronously before returning the handle.
+    execute_info.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC;
     execute_info.hwnd = HWND(std::ptr::null_mut());
     execute_info.lpVerb = PCWSTR(verb.as_ptr());
     execute_info.lpFile = PCWSTR(executable.as_ptr());

--- a/src-tauri/src/rtss.rs
+++ b/src-tauri/src/rtss.rs
@@ -387,10 +387,11 @@ fn set_ini_value(
                     .map_err(|e| format!("读回校验失败: {}", e))
             });
 
-            let _ = std::fs::remove_file(&tmp);
-
+            // 超时/失败路径保留临时文件：中等完整性父进程无法终止高完整性的
+            // 提权子进程，复制仍可能在后台进行并需要该源文件。
             match elevated_ok {
                 Ok(true) => {
+                    let _ = std::fs::remove_file(&tmp);
                     info!("🎯 RTSS profile 管理员权限更新成功");
                     Ok(())
                 }
@@ -399,6 +400,28 @@ fn set_ini_value(
             }
         }
     }
+}
+
+/// 把 rtss-cli 参数编码为嵌入提权 cmd 命令行的片段。
+///
+/// 参数最终由 rtss-cli.exe 以 C-runtime 规则解析自己的 argv，因此每个
+/// 参数按 CRT 约定加引号（空参数、含空格或尾反斜杠的参数都能正确
+/// 往返）；同时拒绝引号、cmd 元字符、控制字符与延迟展开字符，防止
+/// 在 cmd 的解析层拼接逃逸。
+#[cfg(target_os = "windows")]
+fn format_rtss_cli_args(args: &[&str]) -> Result<String, String> {
+    args.iter()
+        .map(|a| {
+            if a.chars().any(|c| {
+                c.is_ascii_control()
+                    || matches!(c, '"' | '&' | '|' | '<' | '>' | '%' | '^' | '!')
+            }) {
+                return Err(format!("rtss-cli 参数包含非法字符: {a}"));
+            }
+            crate::elevation::quote_windows_argument(a)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|quoted| quoted.join(" "))
 }
 
 /// 以管理员权限执行 rtss-cli 并捕获 stdout
@@ -413,24 +436,7 @@ fn run_rtss_cli_elevated(args: &[&str]) -> Result<String, String> {
     let tmp_out = std::env::temp_dir().join("rtss_cli_elevated_out.txt");
     let _ = std::fs::remove_file(&tmp_out);
 
-    let args_str = args
-        .iter()
-        .map(|a| {
-            // 参数嵌入提权 cmd 命令行：拒绝引号、cmd 元字符、控制字符
-            //（CR/LF 是命令分隔符）与延迟展开字符，防止拼接逃逸
-            if a.chars().any(|c| {
-                c.is_ascii_control() || matches!(c, '"' | '&' | '|' | '<' | '>' | '%' | '^' | '!')
-            }) {
-                return Err(format!("rtss-cli 参数包含非法字符: {a}"));
-            }
-            Ok(if a.contains(' ') {
-                format!("\"{}\"", a)
-            } else {
-                a.to_string()
-            })
-        })
-        .collect::<Result<Vec<_>, String>>()?
-        .join(" ");
+    let args_str = format_rtss_cli_args(args)?;
     let command_line = format!(
         r#""{}" {} > "{}" 2>&1"#,
         cli_path.display(),
@@ -1051,7 +1057,16 @@ pub async fn rtss_download_cli() -> Result<String, String> {
 
         // 4. 直接写入失败（权限不足），用提权方式复制
         let temp_dir = std::env::temp_dir();
-        let temp_path = temp_dir.join("rtss-cli.exe");
+        // 唯一源文件名：超时后本文件会保留给可能仍在进行的提权复制，
+        // 固定名会让后续调用覆盖一个正被复制的文件。
+        let temp_path = temp_dir.join(format!(
+            "rtss-cli-{}-{}.exe",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
         std::fs::write(&temp_path, &bytes).map_err(|e| format!("写入临时文件失败: {}", e))?;
 
         // 用 cmd copy 以管理员权限复制（等待退出码）
@@ -2293,5 +2308,41 @@ pub async fn rtss_set_osd_property(
     #[cfg(not(target_os = "windows"))]
     {
         Err("RTSS 仅在 Windows 上可用".to_string())
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::format_rtss_cli_args;
+
+    #[test]
+    fn quotable_arguments_survive_the_cmd_layer_round_trip() {
+        // 嵌入提权 cmd 命令行的参数由 rtss-cli.exe 以 CRT 规则解析，
+        // 因此按 CRT 加引号：空参数与尾反斜杠都能正确往返。
+        assert_eq!(
+            format_rtss_cli_args(&["limiter:toggle", "60"]).unwrap(),
+            "\"limiter:toggle\" \"60\"".to_string()
+        );
+        // 空参数保留为一对引号，而不是消失。
+        assert_eq!(
+            format_rtss_cli_args(&["", "60"]).unwrap(),
+            "\"\" \"60\"".to_string()
+        );
+        // 含空格且以反斜杠结尾：手工引号会把它变成 \"（CRT 里是字面引号），
+        // CRT 规则正确地把尾反斜杠翻倍。
+        assert_eq!(
+            format_rtss_cli_args(&["profile dir\\", "1"]).unwrap(),
+            "\"profile dir\\\\\" \"1\"".to_string()
+        );
+    }
+
+    #[test]
+    fn cmd_metacharacters_are_rejected() {
+        for bad in ["a&b", "a|b", "a<b", "a>b", "a%b%", "a^b", "a!b", "a\"b", "a\r\nb"] {
+            assert!(
+                format_rtss_cli_args(&["limiter:toggle", bad]).is_err(),
+                "should reject {bad:?}"
+            );
+        }
     }
 }

--- a/src-tauri/src/rtss.rs
+++ b/src-tauri/src/rtss.rs
@@ -363,114 +363,96 @@ fn set_ini_value(
             Ok(())
         }
         Err(_) => {
-            // 使用 PowerShell 提权写入
+            // 使用提权 cmd 复制（等待退出码），再读回校验
             info!("🎯 普通权限写入失败, 尝试管理员权限...");
             let tmp = std::env::temp_dir().join("rtss_profile_tmp");
             std::fs::write(&tmp, &new_content).map_err(|e| format!("写入临时文件失败: {}", e))?;
 
-            let ps_cmd = format!(
-                "Copy-Item -Path '{}' -Destination '{}' -Force",
+            let command_line = format!(
+                r#"copy "{}" "{}" /Y"#,
                 tmp.display(),
                 path.display()
             );
-            use std::os::windows::process::CommandExt;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            let output = std::process::Command::new("powershell")
-                .args(["-Command", &format!(
-                    "Start-Process powershell -Verb RunAs -WindowStyle Hidden -ArgumentList '-Command {}' -Wait",
-                    ps_cmd.replace('\'', "''")
-                )])
-                .creation_flags(CREATE_NO_WINDOW)
-                .output()
-                .map_err(|e| format!("提权写入失败: {}", e))?;
+            let elevated_ok = crate::elevation::run_cmd_elevated(
+                &command_line,
+                std::time::Duration::from_secs(30),
+            )
+            .map(|code| code == 0)
+            .and_then(|copied| {
+                if !copied {
+                    return Ok(false);
+                }
+                std::fs::read_to_string(path)
+                    .map(|written| written == new_content)
+                    .map_err(|e| format!("读回校验失败: {}", e))
+            });
 
             let _ = std::fs::remove_file(&tmp);
 
-            if output.status.success() {
-                info!("🎯 RTSS profile 管理员权限更新成功");
-                Ok(())
-            } else {
-                Err("写入 RTSS profile 失败: 需要管理员权限".to_string())
+            match elevated_ok {
+                Ok(true) => {
+                    info!("🎯 RTSS profile 管理员权限更新成功");
+                    Ok(())
+                }
+                Ok(false) => Err("写入 RTSS profile 失败: 需要管理员权限".to_string()),
+                Err(e) => Err(format!("提权写入失败: {}", e)),
             }
         }
     }
 }
 
 /// 以管理员权限执行 rtss-cli 并捕获 stdout
+///
+/// 通过 `cmd /c "cli ... > tmp 2>&1"` 中转捕获输出；以真实退出码判定成败，
+/// 空 stdout 只在退出码为 0 时视为合法输出（此前输出文件被清空也会被当成
+/// 成功，命令的真实失败会被吞掉）。
 #[cfg(target_os = "windows")]
 fn run_rtss_cli_elevated(args: &[&str]) -> Result<String, String> {
-    use windows::Win32::UI::Shell::ShellExecuteW;
-    use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
-    use windows::core::PCWSTR;
-
     let cli_path = get_rtss_cli_path()?;
 
-    // 通过临时文件捕获 stdout；先清理上次可能残留的旧文件
     let tmp_out = std::env::temp_dir().join("rtss_cli_elevated_out.txt");
     let _ = std::fs::remove_file(&tmp_out);
-    // cmd /c "rtss-cli.exe arg1 arg2 > tmpfile 2>&1"
+
     let args_str = args
         .iter()
         .map(|a| {
-            if a.contains(' ') {
+            // 参数嵌入提权 cmd 命令行：拒绝引号与 cmd 元字符，防止拼接逃逸
+            if a.chars().any(|c| matches!(c, '"' | '&' | '|' | '<' | '>' | '%')) {
+                return Err(format!("rtss-cli 参数包含非法字符: {a}"));
+            }
+            Ok(if a.contains(' ') {
                 format!("\"{}\"", a)
             } else {
                 a.to_string()
-            }
+            })
         })
-        .collect::<Vec<_>>()
+        .collect::<Result<Vec<_>, String>>()?
         .join(" ");
-    let cmd_line = format!(
-        "/c \"\"{}\" {} > \"{}\" 2>&1\"",
+    let command_line = format!(
+        r#""{}" {} > "{}" 2>&1"#,
         cli_path.display(),
         args_str,
         tmp_out.display()
     );
 
-    debug!("🎯 rtss-cli elevated: cmd {}", cmd_line);
+    debug!("🎯 rtss-cli elevated: cmd {}", command_line);
 
-    let verb: Vec<u16> = "runas\0".encode_utf16().collect();
-    let file: Vec<u16> = "cmd.exe\0".encode_utf16().collect();
-    let params: Vec<u16> = format!("{}\0", cmd_line).encode_utf16().collect();
+    let exit_code = crate::elevation::run_cmd_elevated(
+        &command_line,
+        std::time::Duration::from_secs(30),
+    )?;
 
-    unsafe {
-        let result = ShellExecuteW(
-            None,
-            PCWSTR(verb.as_ptr()),
-            PCWSTR(file.as_ptr()),
-            PCWSTR(params.as_ptr()),
-            PCWSTR::null(),
-            SW_HIDE,
-        );
-        let code = result.0 as usize;
-        if code <= 32 {
-            return Err(format!("管理员权限执行失败 (code={})", code));
+    let content = std::fs::read_to_string(&tmp_out).unwrap_or_default();
+    let _ = std::fs::remove_file(&tmp_out);
+
+    if exit_code != 0 {
+        let detail = content.trim();
+        if detail.is_empty() {
+            return Err(format!("管理员权限执行失败 (exit {exit_code})"));
         }
+        return Err(format!("管理员权限执行失败 (exit {exit_code}): {detail}"));
     }
-
-    // 等待执行完成（检测输出文件）
-    for _ in 0..30 {
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        if tmp_out.exists() {
-            if let Ok(content) = std::fs::read_to_string(&tmp_out) {
-                if !content.is_empty() {
-                    let _ = std::fs::remove_file(&tmp_out);
-                    return Ok(content.trim().to_string());
-                }
-            }
-        }
-    }
-
-    // 超时后尝试最后一次读取
-    if tmp_out.exists() {
-        let content = std::fs::read_to_string(&tmp_out).unwrap_or_default();
-        let _ = std::fs::remove_file(&tmp_out);
-        if !content.is_empty() {
-            return Ok(content.trim().to_string());
-        }
-    }
-
-    Err("管理员权限执行超时".to_string())
+    Ok(content.trim().to_string())
 }
 
 // ─── RTSS 状态查询 ─────────────────────────────────────────
@@ -1001,9 +983,6 @@ const RTSS_CLI_GITHUB_API: &str =
 pub async fn rtss_download_cli() -> Result<String, String> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::UI::Shell::ShellExecuteW;
-        use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
-        use windows::core::HSTRING;
 
         let install_dir =
             detect_rtss_install_dir().ok_or("未检测到 RTSS 安装路径，请先安装 RTSS")?;
@@ -1072,46 +1051,32 @@ pub async fn rtss_download_cli() -> Result<String, String> {
         let temp_path = temp_dir.join("rtss-cli.exe");
         std::fs::write(&temp_path, &bytes).map_err(|e| format!("写入临时文件失败: {}", e))?;
 
-        // 用 cmd /c copy 以管理员权限复制
-        let params = format!(
-            "/c copy /Y \"{}\" \"{}\"",
+        // 用 cmd copy 以管理员权限复制（等待退出码）
+        let command_line = format!(
+            r#"copy /Y "{}" "{}""#,
             temp_path.display(),
             dest.display()
         );
 
         info!("🎯 需要管理员权限，提权复制 rtss-cli.exe ...");
 
-        let result = unsafe {
-            ShellExecuteW(
-                None,
-                &HSTRING::from("runas"),
-                &HSTRING::from("cmd.exe"),
-                &HSTRING::from(&params),
-                None,
-                SW_HIDE,
-            )
-        };
-
-        // ShellExecuteW 返回值 > 32 表示成功
-        let hinstance_val = result.0 as isize;
-        if hinstance_val <= 32 {
-            // 清理临时文件
-            let _ = std::fs::remove_file(&temp_path);
-            return Err("用户取消了管理员权限请求，或提权失败".into());
-        }
-
-        // 等待文件出现（提权命令是异步的）
-        for _ in 0..30 {
-            if dest.exists() {
-                let _ = std::fs::remove_file(&temp_path);
-                info!("🎯 rtss-cli.exe 提权复制完成: {}", dest.display());
-                return Ok(dest.to_string_lossy().to_string());
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        }
+        let copy_result = crate::elevation::run_cmd_elevated(
+            &command_line,
+            std::time::Duration::from_secs(60),
+        );
 
         let _ = std::fs::remove_file(&temp_path);
-        Err("提权复制超时，请手动复制 rtss-cli.exe 到 RTSS 目录".into())
+
+        match copy_result {
+            Ok(0) if dest.exists() => {
+                info!("🎯 rtss-cli.exe 提权复制完成: {}", dest.display());
+                Ok(dest.to_string_lossy().to_string())
+            }
+            Ok(code) => Err(format!(
+                "提权复制失败 (exit {code})，请手动复制 rtss-cli.exe 到 RTSS 目录"
+            )),
+            Err(e) => Err(format!("提权复制失败: {e}")),
+        }
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/rtss.rs
+++ b/src-tauri/src/rtss.rs
@@ -416,8 +416,11 @@ fn run_rtss_cli_elevated(args: &[&str]) -> Result<String, String> {
     let args_str = args
         .iter()
         .map(|a| {
-            // 参数嵌入提权 cmd 命令行：拒绝引号与 cmd 元字符，防止拼接逃逸
-            if a.chars().any(|c| matches!(c, '"' | '&' | '|' | '<' | '>' | '%')) {
+            // 参数嵌入提权 cmd 命令行：拒绝引号、cmd 元字符、控制字符
+            //（CR/LF 是命令分隔符）与延迟展开字符，防止拼接逃逸
+            if a.chars().any(|c| {
+                c.is_ascii_control() || matches!(c, '"' | '&' | '|' | '<' | '>' | '%' | '^' | '!')
+            }) {
                 return Err(format!("rtss-cli 参数包含非法字符: {a}"));
             }
             Ok(if a.contains(' ') {
@@ -1060,15 +1063,17 @@ pub async fn rtss_download_cli() -> Result<String, String> {
 
         info!("🎯 需要管理员权限，提权复制 rtss-cli.exe ...");
 
-        let copy_result = crate::elevation::run_cmd_elevated(
+        let copy_result = crate::elevation::run_cmd_elevated_async(
             &command_line,
             std::time::Duration::from_secs(60),
-        );
+        )
+        .await;
 
-        let _ = std::fs::remove_file(&temp_path);
-
+        // 超时路径保留临时文件：中等完整性父进程无法终止高完整性的提权
+        // 子进程，复制仍可能在后台完成并需要该源文件。
         match copy_result {
             Ok(0) if dest.exists() => {
+                let _ = std::fs::remove_file(&temp_path);
                 info!("🎯 rtss-cli.exe 提权复制完成: {}", dest.display());
                 Ok(dest.to_string_lossy().to_string())
             }

--- a/src-tauri/src/rtss.rs
+++ b/src-tauri/src/rtss.rs
@@ -365,7 +365,16 @@ fn set_ini_value(
         Err(_) => {
             // 使用提权 cmd 复制（等待退出码），再读回校验
             info!("🎯 普通权限写入失败, 尝试管理员权限...");
-            let tmp = std::env::temp_dir().join("rtss_profile_tmp");
+            // 唯一临时文件名：超时/失败路径会保留本文件给可能仍在进行的
+            // 提权复制，固定名会让后续调用覆盖一个正被复制的文件。
+            let tmp = std::env::temp_dir().join(format!(
+                "rtss_profile_{}_{}.tmp",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            ));
             std::fs::write(&tmp, &new_content).map_err(|e| format!("写入临时文件失败: {}", e))?;
 
             let command_line = format!(

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -13,6 +13,12 @@ pub(crate) struct ElevatedProcess {
 
 #[cfg(target_os = "windows")]
 impl ElevatedProcess {
+    pub(crate) fn from_owned_handle(
+        handle: std::os::windows::io::OwnedHandle,
+    ) -> Self {
+        Self { handle }
+    }
+
     pub(crate) fn process_id(&self) -> u32 {
         use std::os::windows::io::AsRawHandle;
         use windows::Win32::Foundation::HANDLE;
@@ -44,92 +50,54 @@ impl ElevatedProcess {
             Ok(Some(exit_code as i32))
         }
     }
-}
 
-#[cfg(target_os = "windows")]
-fn quote_windows_argument(value: &str) -> Result<String, String> {
-    if value.contains('\0') {
-        return Err("elevated process argument contains a NUL byte".to_string());
-    }
+    /// Blocking wait for the process to exit, bounded by `timeout`. Returns
+    /// `None` when it is still running when the timeout elapses.
+    pub(crate) fn wait_for_exit_blocking(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<Option<i32>, String> {
+        use std::os::windows::io::AsRawHandle;
+        use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+        use windows::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject};
 
-    let mut quoted = String::with_capacity(value.len() + 2);
-    quoted.push('"');
-    let mut backslashes = 0;
-    for character in value.chars() {
-        match character {
-            '\\' => backslashes += 1,
-            '"' => {
-                quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
-                quoted.push('"');
-                backslashes = 0;
+        unsafe {
+            let handle = HANDLE(self.handle.as_raw_handle());
+            // u32::MAX is INFINITE for WaitForSingleObject; saturate one below
+            // so the wait stays bounded as documented.
+            let millis = timeout.as_millis().min(u32::MAX as u128 - 1) as u32;
+            match WaitForSingleObject(handle, millis) {
+                WAIT_TIMEOUT => return Ok(None),
+                WAIT_OBJECT_0 => {}
+                status => {
+                    return Err(format!(
+                        "could not wait for elevated process exit: {:?}",
+                        status
+                    ));
+                }
             }
-            _ => {
-                quoted.extend(std::iter::repeat_n('\\', backslashes));
-                quoted.push(character);
-                backslashes = 0;
-            }
+            let mut exit_code = 0;
+            GetExitCodeProcess(handle, &mut exit_code)
+                .map_err(|error| format!("could not read elevated process exit code: {error}"))?;
+            Ok(Some(exit_code as i32))
         }
     }
-    quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
-    quoted.push('"');
-    Ok(quoted)
 }
 
 /// Start the current executable with the Windows `runas` verb.
 ///
 /// Callers pass fixed, internally validated arguments only. `ShellExecuteExW`
 /// waits for UAC approval before it returns, so a caller can retain its current
-/// process when elevation is canceled.
+/// process when elevation is canceled. The launcher itself lives in
+/// `crate::elevation` so external-program elevation shares one implementation.
 #[cfg(target_os = "windows")]
 pub(crate) fn launch_current_executable_elevated(
     arguments: &[&str],
     show_window: i32,
 ) -> Result<ElevatedProcess, String> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::Shell::{SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW};
-    use windows::core::PCWSTR;
-
-    fn to_wide(value: &str) -> Vec<u16> {
-        value.encode_utf16().chain(std::iter::once(0)).collect()
-    }
-
-    fn os_to_wide(value: &std::ffi::OsStr) -> Vec<u16> {
-        value.encode_wide().chain(std::iter::once(0)).collect()
-    }
-
     let executable = env::current_exe()
         .map_err(|error| format!("could not resolve current executable: {error}"))?;
-    let parameters = arguments
-        .iter()
-        .map(|argument| quote_windows_argument(argument))
-        .collect::<Result<Vec<_>, _>>()?
-        .join(" ");
-    let verb = to_wide("runas");
-    let executable = os_to_wide(executable.as_os_str());
-    let parameters = to_wide(&parameters);
-    let mut execute_info = SHELLEXECUTEINFOW::default();
-    execute_info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
-    execute_info.fMask = SEE_MASK_NOCLOSEPROCESS;
-    execute_info.hwnd = HWND(std::ptr::null_mut());
-    execute_info.lpVerb = PCWSTR(verb.as_ptr());
-    execute_info.lpFile = PCWSTR(executable.as_ptr());
-    execute_info.lpParameters = PCWSTR(parameters.as_ptr());
-    execute_info.nShow = show_window;
-
-    unsafe {
-        ShellExecuteExW(&mut execute_info)
-            .map_err(|error| format!("Windows could not start the elevated process: {error}"))?;
-    }
-    if execute_info.hProcess.0.is_null() {
-        return Err("Windows did not return an elevated process handle".to_string());
-    }
-    use std::os::windows::io::FromRawHandle;
-    Ok(ElevatedProcess {
-        handle: unsafe {
-            std::os::windows::io::OwnedHandle::from_raw_handle(execute_info.hProcess.0)
-        },
-    })
+    crate::elevation::launch_elevated(executable.as_os_str(), arguments, show_window)
 }
 
 /// Wait for the unelevated GUI to exit before creating the elevated GUI's
@@ -439,55 +407,22 @@ pub fn open_local_path(path: String, app_name: String) -> Result<bool, String> {
 /// Execute an elevated PowerShell command.
 #[cfg(target_os = "windows")]
 pub fn execute_powershell_command(command: &str, error_context: &str) -> Result<(), String> {
-    use std::os::windows::process::CommandExt;
-    use std::process::Command;
-
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
-
-    let ps_command = format!(
-        "Start-Process powershell -ArgumentList '-NoProfile', '-Command', '{}' -Verb RunAs -WindowStyle Hidden",
-        command.replace("'", "''")
-    );
-
-    Command::new("powershell")
-        .args(&["-NoProfile", "-Command", &ps_command])
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn()
-        .map_err(|e| {
-            error!("{}: {}", error_context, e);
-            format!("{}: {}", error_context, e)
-        })?;
+    // 直接以 runas 启动 PowerShell（fire-and-forget：在后台线程等待 UAC，
+    // 不阻塞 async 调用方）。命令原样传递——调用方已自行用 PowerShell
+    // 单引号包好值。
+    let command = command.to_string();
+    let context = error_context.to_string();
+    std::thread::spawn(move || {
+        let program = crate::elevation::system_binary(r"WindowsPowerShell\v1.0\powershell.exe");
+        if let Err(error) = crate::elevation::launch_elevated(
+            program.as_os_str(),
+            &["-NoProfile", "-Command", &command],
+            windows::Win32::UI::WindowsAndMessaging::SW_HIDE.0,
+        ) {
+            error!("{}: {}", context, error);
+        }
+    });
 
     Ok(())
 }
 
-#[cfg(all(test, target_os = "windows"))]
-mod tests {
-    use super::quote_windows_argument;
-
-    #[test]
-    fn elevated_process_arguments_are_windows_quoted() {
-        assert_eq!(
-            quote_windows_argument("--elevated-dualsense").unwrap(),
-            "\"--elevated-dualsense\""
-        );
-        assert_eq!(
-            quote_windows_argument("contains spaces").unwrap(),
-            "\"contains spaces\""
-        );
-    }
-
-    #[test]
-    fn elevated_process_arguments_reject_nul_bytes() {
-        assert!(quote_windows_argument("invalid\0argument").is_err());
-    }
-
-    #[test]
-    fn elevated_process_arguments_escape_backslashes_and_quotes() {
-        assert_eq!(quote_windows_argument(r#"a\"b"#).unwrap(), r#""a\\\"b""#);
-        assert_eq!(
-            quote_windows_argument(r#"C:\path\"#).unwrap(),
-            r#""C:\path\\""#
-        );
-    }
-}

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -463,82 +463,28 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 
     debug!("  📝 目标文件: {:?}", vdd_xml_path);
 
-    // 先尝试使用 ShellExecuteW 触发 UAC 并复制
-    let shell_execute_success = match elevated_copy_with_shell_execute(&temp_path, vdd_xml_path) {
-        Ok(()) => {
-            debug!("  🔧 已请求使用 ShellExecuteW 提权复制");
-            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-            match tokio::fs::read_to_string(vdd_xml_path).await {
-                Ok(written) if written == content => {
-                    info!("  ✅ ShellExecuteW 提权复制成功");
-                    true
-                }
-                Ok(_) => {
-                    warn!("  ⚠️ ShellExecuteW 复制后内容不匹配，准备回退到 PowerShell");
-                    false
-                }
-                Err(err) => {
-                    warn!(
-                        "  ⚠️ ShellExecuteW 复制后读取失败 ({}), 准备回退到 PowerShell",
-                        err
-                    );
-                    false
-                }
+    // 提权复制（run_cmd_elevated 内部等待完成并核对退出码），再读回校验内容
+    let mut elevated_success = false;
+    match elevated_copy_with_shell_execute(&temp_path, vdd_xml_path) {
+        Ok(()) => match tokio::fs::read_to_string(vdd_xml_path).await {
+            Ok(written) if written == content => {
+                info!("  ✅ 提权复制成功");
+                elevated_success = true;
             }
+            Ok(_) => warn!("  ⚠️ 提权复制后内容不匹配，准备回退到直接写入"),
+            Err(err) => warn!("  ⚠️ 提权复制后读取失败 ({err})，准备回退到直接写入"),
+        },
+        Err(err) => warn!("  ⚠️ 提权复制失败 ({err})，准备回退到直接写入"),
+    }
+
+    if !elevated_success {
+        // 尝试直接写入（可能会因权限不足而失败）
+        warn!("  ⚠️ 尝试直接写入...");
+        if let Err(error) = tokio::fs::write(vdd_xml_path, content).await {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(format!("写入失败，需要管理员权限: {}", error));
         }
-        Err(err) => {
-            warn!(
-                "  ⚠️ ShellExecuteW 提权复制调用失败 ({}), 准备回退到 PowerShell",
-                err
-            );
-            false
-        }
-    };
-
-    if !shell_execute_success {
-        // 使用 Start-Process 以管理员权限运行 PowerShell 复制命令
-        let inner_command = format!(
-            "Copy-Item -Path '{}' -Destination '{}' -Force",
-            temp_path.display(),
-            vdd_xml_path.display()
-        );
-
-        debug!("  🔧 执行 PowerShell 提权命令...");
-
-        let powershell_success = match run_elevated_powershell(&inner_command, "写入 VDD XML").await
-        {
-            Ok(()) => match tokio::fs::read_to_string(vdd_xml_path).await {
-                Ok(written) if written == content => {
-                    info!("  ✅ PowerShell 提权复制成功");
-                    true
-                }
-                Ok(_) => {
-                    warn!("  ⚠️ PowerShell 复制后内容不匹配，准备回退到直接写入");
-                    false
-                }
-                Err(err) => {
-                    warn!("  ⚠️ PowerShell 复制后读取失败 ({err})，准备回退到直接写入");
-                    false
-                }
-            },
-            Err(err) => {
-                warn!("  ⚠️ PowerShell 提权复制失败 ({err})，准备回退到直接写入");
-                false
-            }
-        };
-
-        if !powershell_success {
-            error!("  ❌ PowerShell 提权复制失败");
-
-            // 尝试直接写入（可能会因权限不足而失败）
-            warn!("  ⚠️ 尝试直接写入...");
-            if let Err(error) = tokio::fs::write(vdd_xml_path, content).await {
-                let _ = tokio::fs::remove_file(&temp_path).await;
-                return Err(format!("写入失败，需要管理员权限: {}", error));
-            }
-            info!("  ✓ 直接写入成功");
-        }
+        info!("  ✓ 直接写入成功");
     }
 
     // 清理临时文件
@@ -549,70 +495,35 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 
 #[cfg(target_os = "windows")]
 fn elevated_copy_with_shell_execute(source: &Path, destination: &Path) -> Result<(), String> {
-    use std::path::PathBuf;
-    use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::Shell::ShellExecuteW;
-    use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
-    use windows::core::PCWSTR;
-
-    fn to_wide(s: &str) -> Vec<u16> {
-        s.encode_utf16().chain(std::iter::once(0u16)).collect()
-    }
-
-    let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
-    let cmd_path: PathBuf = Path::new(&system_root).join("System32").join("cmd.exe");
-
-    let parameters = format!(
-        r#"/C copy "{}" "{}" /Y"#,
+    let command_line = format!(
+        r#"copy "{}" "{}" /Y"#,
         source.to_string_lossy(),
         destination.to_string_lossy()
     );
-
-    let operation_w = to_wide("runas");
-    let file_w = to_wide(&cmd_path.to_string_lossy());
-    let parameters_w = to_wide(&parameters);
-
-    unsafe {
-        let result = ShellExecuteW(
-            Some(HWND(std::ptr::null_mut())),
-            PCWSTR(operation_w.as_ptr()),
-            PCWSTR(file_w.as_ptr()),
-            PCWSTR(parameters_w.as_ptr()),
-            PCWSTR::null(),
-            SW_HIDE,
-        );
-
-        if result.0 as isize <= 32 {
-            return Err(format!("ShellExecuteW 返回错误码 {}", result.0 as isize));
-        }
+    let exit_code = crate::elevation::run_cmd_elevated(
+        &command_line,
+        std::time::Duration::from_secs(60),
+    )?;
+    if exit_code != 0 {
+        return Err(format!("提权复制退出码 {exit_code}"));
     }
-
     Ok(())
 }
 
 #[cfg(target_os = "windows")]
 async fn run_elevated_powershell(inner_command: &str, action_label: &str) -> Result<(), String> {
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    // 直接以 runas 启动 PowerShell 并等待退出码；此前经 Start-Process
+    // 中转且以固定 500ms sleep 代替确定等待。
+    let exit_code = crate::elevation::run_powershell_elevated(
+        inner_command,
+        std::time::Duration::from_secs(120),
+    )
+    .await
+    .map_err(|e| format!("{action_label}失败: {e}"))?;
 
-    let escaped_command = inner_command.replace("'", "''");
-    let ps_script = format!(
-        "$proc = Start-Process powershell -ArgumentList '-NoProfile', '-Command', '{}' -Verb RunAs -WindowStyle Hidden -Wait -PassThru; exit $proc.ExitCode",
-        escaped_command
-    );
-
-    let status = tokio::process::Command::new("powershell")
-        .args(&["-NoProfile", "-Command", &ps_script])
-        .creation_flags(CREATE_NO_WINDOW)
-        .status()
-        .await
-        .map_err(|e| format!("{}失败: {}", action_label, e))?;
-
-    if !status.success() {
-        let code = status.code().unwrap_or(-1);
-        return Err(format!("{}失败，PowerShell 退出码: {}", action_label, code));
+    if exit_code != 0 {
+        return Err(format!("{action_label}失败，PowerShell 退出码: {exit_code}"));
     }
-
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     Ok(())
 }
 

--- a/src-tauri/src/vdd.rs
+++ b/src-tauri/src/vdd.rs
@@ -465,7 +465,7 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 
     // 提权复制（run_cmd_elevated 内部等待完成并核对退出码），再读回校验内容
     let mut elevated_success = false;
-    match elevated_copy_with_shell_execute(&temp_path, vdd_xml_path) {
+    match elevated_copy_with_shell_execute(&temp_path, vdd_xml_path).await {
         Ok(()) => match tokio::fs::read_to_string(vdd_xml_path).await {
             Ok(written) if written == content => {
                 info!("  ✅ 提权复制成功");
@@ -494,16 +494,17 @@ async fn write_vdd_xml(vdd_xml_path: &PathBuf, content: &str) -> Result<(), Stri
 }
 
 #[cfg(target_os = "windows")]
-fn elevated_copy_with_shell_execute(source: &Path, destination: &Path) -> Result<(), String> {
+async fn elevated_copy_with_shell_execute(source: &Path, destination: &Path) -> Result<(), String> {
     let command_line = format!(
         r#"copy "{}" "{}" /Y"#,
         source.to_string_lossy(),
         destination.to_string_lossy()
     );
-    let exit_code = crate::elevation::run_cmd_elevated(
+    let exit_code = crate::elevation::run_cmd_elevated_async(
         &command_line,
         std::time::Duration::from_secs(60),
-    )?;
+    )
+    .await?;
     if exit_code != 0 {
         return Err(format!("提权复制退出码 {exit_code}"));
     }


### PR DESCRIPTION
## Summary

Step 2 of the elevation unification ([survey](../_dev_notes)) — every module that hand-rolled its own elevated spawn now goes through `elevation.rs`:

- **`launch_elevated` / `launch_elevated_raw`** — generic `ShellExecuteExW` runas launcher (CRT-quoted args, or raw `lpParameters` for cmd.exe whose `/d /s /c` dialect is not CRT quoting). `utils::launch_current_executable_elevated` delegates to it.
- **`run_cmd_elevated`** — bare switches + one outer quote pair: `/S` strips exactly that pair and the command executes verbatim with its own quoting.
- **`run_powershell_elevated`** — direct SystemRoot-resolved PowerShell launch, exit-code wait, no `Start-Process` relay, no PATH trust, commands pass verbatim.
- **bat_runner** — unelevated branch uses the hardened launcher (fixes `%TEMP%` with spaces breaking the old unquoted `-ArgumentList` join); `is_elevated` reads the process token instead of spawning PowerShell per check.
- **vdd** — privileged XML copy waits for the exit code instead of a 500 ms guess; the PowerShell `Copy-Item` twin tier is deleted.
- **rtss** — profile write, elevated CLI runner, and CLI download all go through `run_cmd_elevated`; the CLI runner trusts the real exit code (an emptied output file no longer reads as success) and rejects cmd metacharacters in arguments.
- **utils** — `execute_powershell_command` launches PowerShell directly, stays fire-and-forget via a detached thread (no async-caller blocking on the UAC dialog); `wait_for_exit_blocking` clamps below the Win32 `INFINITE` sentinel.

Net −26 lines across 5 files.

## The two bugs adversarial verification caught before pushing

The first version of this change had two critical defects, both found by a 3-lens verification workflow that replicated the exact `CreateProcess` byte shapes on-machine:

1. **cmd.exe does not honor CRT `\"` escaping** — MSVCRT-quoting the `/c` payload mangled every quoted path, so all four migrated cmd paths failed 100% of the time. Fixed with the raw-parameters form.
2. **Orphaned `''` doubling** — the single-quote doubling kept from the old `Start-Process` relays had no consumer once the relay was removed, so PowerShell bound `''value''` as an empty string + bareword, silently breaking all EDID/ETW/mode-toggle commands. Fixed by passing commands verbatim (callers already quote).

Both fixes empirically re-verified (14/14 on-machine shape tests pass); residual findings are pre-existing minors (raw `'{}'` quoting at three vdd EDID sites, fixed temp filename collisions) — noted, not regressions.

Out of scope, deliberately: `game_session.rs` (external-app launches, verb switching) and `update.rs` (updater outlives the parent).

## Test plan

- [x] `cargo test` 166 passed, no warnings
- [x] Adversarial verification ×2 (initial + fix re-review), 14/14 empirical shape tests
- [ ] Real machine: VDD settings save as non-admin (XML elevated copy), RTSS limiter toggle as non-admin, driver install/uninstall round-trip (bat_runner path)