### PR TITLE
feat(clipboard): compound text+image clipboard via token-grouped bursts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4888,6 +4888,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clipboard-rs",
+ "clipboard-win",
  "dirs",
  "encoding_rs",
  "env_logger",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,6 +61,7 @@ beta = []
 
 [target.'cfg(windows)'.dependencies]
 tauri-winrt-notification = "0.7.3"
+clipboard-win = "5.4"
 windows = { version = "0.62.2", features = [
     "Win32",
     "Win32_Foundation",

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -21,22 +21,34 @@
 //! transferred out-of-band over HTTPS (`/api/v1/clipboard/blob[/<id>]`) so we
 //! can move payloads larger than the single-packet 65 KB wire ceiling.
 //!
+//! Compound clipboard (no wire-format change): a clipboard change carrying
+//! BOTH text and an image is emitted as two consecutive frames sharing a
+//! non-zero token, text frame first, image frame second. Peers without
+//! aggregation apply the frames in order and end with the image — the exact
+//! v1 outcome — so no version negotiation is needed. This agent applies each
+//! frame as it arrives (zero added latency) and retains the text payload;
+//! when the image lands — inline or after its REF blob fetch — the clipboard
+//! is upgraded with one compound write carrying both flavors. Single-flavor
+//! changes keep the legacy token=0 single frame. Burst text is always inline
+//! (a REF text frame would race the image frame onto the wire and flip
+//! legacy peers' final state to text); the image frame may still use REF.
+//!
 //! Echo suppression: every locally-applied inbound payload's hash is recorded
 //! before we touch the clipboard; the watcher's resulting on_clipboard_change
 //! sees the matching hash and drops the candidate, breaking the otherwise
 //! infinite write→watch→post→write loop.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{
-    Arc, Mutex,
     atomic::{AtomicBool, AtomicI64, AtomicU8, Ordering},
+    Arc, Mutex,
 };
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::Engine as _;
 use clipboard_rs::{
-    Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher, ClipboardWatcherContext,
-    RustImageData, WatcherShutdown, common::RustImage as _,
+    common::RustImage as _, Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher,
+    ClipboardWatcherContext, RustImageData, WatcherShutdown,
 };
 use log::{debug, info, warn};
 use serde::Serialize;
@@ -59,6 +71,16 @@ const MAX_IMAGE_PIXELS: u64 = 32 * 1024 * 1024;
 /// to out-of-band blob transfer (KIND_REF). Single-packet wire ceiling is
 /// ~65525 bytes of payload, so 60000 leaves comfortable headroom.
 const INLINE_THRESHOLD: usize = 60_000;
+
+/// The service rejects /item bodies above 65500 bytes; a burst text frame
+/// (10-byte header + payload) must stay inline, so larger text degrades the
+/// change to image-only rather than racing a REF text frame.
+const BURST_TEXT_MAX_INLINE: usize = 65_490;
+
+/// How long burst text stays retained after its frame applied — purely a
+/// memory bound; application is immediate on arrival (see module docs).
+const BURST_RETENTION: Duration = Duration::from_secs(5);
+const MAX_PENDING_BURSTS: usize = 32;
 
 const MIME_TEXT: &str = "text/plain; charset=utf-8";
 const MIME_PNG: &str = "image/png";
@@ -308,12 +330,11 @@ fn snapshot_and_post(echo: &Arc<Mutex<EchoState>>) {
         }
     };
 
-    // Image takes precedence: browsers and IM clients attach a fallback text
-    // label (source URL, file path, alt text) alongside a copied bitmap, and
-    // the old text-first order sent that label instead of the picture — or
-    // aborted the snapshot entirely on an empty text flavor. Extract the
-    // bitmap first, mirroring the Qt client's extraction order so both ends
-    // agree on what a mixed clipboard means.
+    // A mixed clipboard (image + fallback text label from browsers/IM, or a
+    // genuinely compound copy) is emitted as a compound burst: text frame
+    // first, image second, one shared non-zero token. Peers without
+    // aggregation apply the frames in order and keep the image — the exact
+    // v1 outcome. Single-flavor changes keep the legacy token=0 single frame.
     if let Ok(files) = ctx.get_files() {
         // Explorer file copies may include a thumbnail/icon bitmap; the
         // protocol cannot carry file references, so skip the snapshot rather
@@ -325,58 +346,154 @@ fn snapshot_and_post(echo: &Arc<Mutex<EchoState>>) {
         }
     }
 
-    if let Ok(img) = ctx.get_image() {
-        let pixel_hash = hash_image_pixels(&img);
-        let png = match img.to_png() {
-            Ok(p) => p,
-            Err(e) => {
-                debug!("clipboard image to_png failed: {e}");
-                return;
+    let text = match ctx.get_text() {
+        Ok(t) if !t.is_empty() => Some(t),
+        _ => None,
+    };
+    let img = ctx.get_image().ok().filter(|i| !i.is_empty());
+    let png_bytes = img.as_ref().and_then(|i| match i.to_png() {
+        Ok(p) => {
+            let bytes = p.get_bytes().to_vec();
+            if bytes.is_empty() {
+                None
+            } else {
+                Some(bytes)
             }
-        };
-        let bytes = png.get_bytes().to_vec();
-        if bytes.len() > MAX_IMAGE_BYTES {
+        }
+        Err(e) => {
+            debug!("clipboard image to_png failed: {e}");
+            None
+        }
+    });
+    let pixel_hash = img.as_ref().and_then(hash_image_pixels);
+
+    if let Some(pb) = &png_bytes {
+        if pb.len() > MAX_IMAGE_BYTES {
             warn!(
                 "local clipboard png {}B exceeds {}B cap; dropped",
-                bytes.len(),
+                pb.len(),
                 MAX_IMAGE_BYTES
             );
             return;
         }
-        {
-            let mut st = echo.lock().unwrap();
-            if st.is_echo(Kind::Png, &bytes) {
-                return;
-            }
-            if let Some(h) = pixel_hash {
-                if st.is_image_echo(h) {
-                    return;
-                }
-                st.record_image(h);
-            }
-        }
-        post_outbound(Kind::Png, bytes, MIME_PNG);
-        return;
     }
 
-    if let Ok(text) = ctx.get_text() {
-        if text.is_empty() {
-            return;
+    let text_bytes = match text {
+        Some(t) => {
+            let bytes = t.into_bytes();
+            if bytes.len() > MAX_TEXT_BYTES {
+                warn!(
+                    "local clipboard text {}B exceeds {}B cap; dropped",
+                    bytes.len(),
+                    MAX_TEXT_BYTES
+                );
+                return;
+            }
+            Some(bytes)
         }
-        let bytes = text.into_bytes();
-        if bytes.len() > MAX_TEXT_BYTES {
-            warn!(
-                "local clipboard text {}B exceeds {}B cap; dropped",
-                bytes.len(),
-                MAX_TEXT_BYTES
-            );
-            return;
+        None => None,
+    };
+
+    match (text_bytes, png_bytes) {
+        (Some(tb), Some(pb)) => {
+            if tb.len() > BURST_TEXT_MAX_INLINE {
+                // Burst text must stay inline (a REF text frame would race
+                // the image frame onto the wire and flip legacy peers'
+                // final state to text); degrade to image-only.
+                info!(
+                    "clipboard burst text {}B exceeds inline cap; sending image only",
+                    tb.len()
+                );
+                if !png_payload_is_echo(echo, &pb, pixel_hash) {
+                    post_outbound(Kind::Png, pb, MIME_PNG);
+                }
+                return;
+            }
+
+            let (text_echo, png_echo) = {
+                let mut st = echo.lock().unwrap();
+                let te = st.is_echo(Kind::Text, &tb);
+                let pe =
+                    st.is_echo(Kind::Png, &pb) || pixel_hash.map_or(false, |h| st.is_image_echo(h));
+                if !te {
+                    st.record(Kind::Text, &tb);
+                }
+                if !pe {
+                    if let Some(h) = pixel_hash {
+                        st.record_image(h);
+                    }
+                }
+                (te, pe)
+            };
+
+            match (text_echo, png_echo) {
+                (true, true) => {}
+                (true, false) => post_outbound(Kind::Png, pb, MIME_PNG),
+                (false, true) => post_outbound(Kind::Text, tb, MIME_TEXT),
+                (false, false) => post_burst(tb, pb),
+            }
         }
-        if echo.lock().unwrap().is_echo(Kind::Text, &bytes) {
-            return;
+        (None, Some(pb)) => {
+            if !png_payload_is_echo(echo, &pb, pixel_hash) {
+                post_outbound(Kind::Png, pb, MIME_PNG);
+            }
         }
-        post_outbound(Kind::Text, bytes, MIME_TEXT);
+        (Some(tb), None) => {
+            if !echo.lock().unwrap().is_echo(Kind::Text, &tb) {
+                post_outbound(Kind::Text, tb, MIME_TEXT);
+            }
+        }
+        (None, None) => {}
     }
+}
+
+/// Echo check for an outbound image payload (byte hash + pixel hash). The
+/// pixel hash is recorded when the payload passes so a delayed platform
+/// re-encode of the same image is still recognized as an echo.
+fn png_payload_is_echo(echo: &Arc<Mutex<EchoState>>, png: &[u8], pixel_hash: Option<u64>) -> bool {
+    let mut st = echo.lock().unwrap();
+    if st.is_echo(Kind::Png, png) {
+        return true;
+    }
+    if let Some(h) = pixel_hash {
+        if st.is_image_echo(h) {
+            return true;
+        }
+        st.record_image(h);
+    }
+    false
+}
+
+/// Emit a compound burst: one spawned task posting the text frame and then
+/// the image frame with sequential awaits — two independent HTTP POSTs have
+/// no ordering guarantee, and legacy peers rely on text-first ordering to
+/// end with the image.
+fn post_burst(text: Vec<u8>, png: Vec<u8>) {
+    let token = next_token();
+    tauri::async_runtime::spawn(async move {
+        let text_frame = encode_frame(&Frame {
+            kind: Kind::Text,
+            token,
+            payload: text,
+        });
+        if let Err(e) = post_item(text_frame).await {
+            warn!("clipboard burst text POST failed: {e}");
+            return;
+        }
+
+        if png.len() <= INLINE_THRESHOLD {
+            let frame = encode_frame(&Frame {
+                kind: Kind::Png,
+                token,
+                payload: png,
+            });
+            if let Err(e) = post_item(frame).await {
+                warn!("clipboard burst image POST failed: {e}");
+            }
+        } else if let Err(e) = upload_and_post_ref(png, MIME_PNG, token).await {
+            warn!("clipboard burst blob transfer failed: {e}");
+        }
+    });
 }
 
 /// Decide inline vs out-of-band based on payload size, then dispatch.
@@ -389,10 +506,11 @@ fn post_outbound(kind: Kind, payload: Vec<u8>, mime: &'static str) {
 }
 
 fn post_inline(kind: Kind, payload: Vec<u8>) {
-    let token = next_token();
+    // Single-flavor changes stay token=0: standalone frames apply
+    // immediately on aggregating peers and are never coalesced.
     let body = encode_frame(&Frame {
         kind,
-        token,
+        token: 0,
         payload,
     });
     tauri::async_runtime::spawn(async move {
@@ -403,40 +521,31 @@ fn post_inline(kind: Kind, payload: Vec<u8>) {
 }
 
 fn post_via_blob(kind: Kind, payload: Vec<u8>, mime: &'static str) {
-    let size = payload.len() as u64;
     tauri::async_runtime::spawn(async move {
-        let id = match upload_blob(payload, mime).await {
-            Ok(id) => id,
-            Err(e) => {
-                warn!(
-                    "clipboard blob upload failed (kind={:?}, size={}): {e}",
-                    kind, size
-                );
-                return;
-            }
-        };
-        let meta = RefMeta {
-            id,
-            mime: mime.to_string(),
-            size,
-        };
-        let json = match serde_json::to_vec(&meta) {
-            Ok(v) => v,
-            Err(e) => {
-                warn!("clipboard ref json encode failed: {e}");
-                return;
-            }
-        };
-        let token = next_token();
-        let body = encode_frame(&Frame {
-            kind: Kind::Ref,
-            token,
-            payload: json,
-        });
-        if let Err(e) = post_item(body).await {
-            warn!("clipboard /item POST (ref) failed: {e}");
+        if let Err(e) = upload_and_post_ref(payload, mime, 0).await {
+            warn!("clipboard blob upload failed (kind={:?}): {e}", kind);
         }
     });
+}
+
+/// Upload a payload as an out-of-band blob and post the KIND_REF descriptor
+/// frame. Used by single-flavor changes (token 0) and the image frame of a
+/// compound burst (the burst token, so aggregating peers can group it).
+async fn upload_and_post_ref(payload: Vec<u8>, mime: &str, token: u32) -> Result<(), String> {
+    let size = payload.len() as u64;
+    let id = upload_blob(payload, mime).await?;
+    let meta = RefMeta {
+        id,
+        mime: mime.to_string(),
+        size,
+    };
+    let json = serde_json::to_vec(&meta).map_err(|e| format!("ref json encode failed: {e}"))?;
+    let body = encode_frame(&Frame {
+        kind: Kind::Ref,
+        token,
+        payload: json,
+    });
+    post_item(body).await
 }
 
 fn next_token() -> u32 {
@@ -546,10 +655,75 @@ async fn fetch_blob(id: &str) -> Result<(Vec<u8>, String), String> {
 
 // ---------- Inbound apply ----------
 
-fn apply_inbound(frame: Frame, echo: &Arc<Mutex<EchoState>>) {
-    // Non-REF path is fully synchronous; REF path is dispatched by the caller
-    // onto the async runtime instead (see sse_pump).
-    apply_inbound_inline(frame, echo);
+/// Retained text payloads of in-flight compound bursts (frames sharing a
+/// non-zero token). Text applies on arrival; the image later upgrades the
+/// clipboard to one compound write using the retained bytes.
+static BURSTS: once_cell::sync::Lazy<Mutex<HashMap<u32, (Vec<u8>, Instant)>>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn prune_bursts(map: &mut HashMap<u32, (Vec<u8>, Instant)>) {
+    map.retain(|_, (_, ts)| ts.elapsed() < BURST_RETENTION);
+}
+
+fn retain_burst_text(token: u32, text: Vec<u8>) {
+    let mut map = BURSTS.lock().unwrap();
+    prune_bursts(&mut map);
+    if map.len() >= MAX_PENDING_BURSTS {
+        // Defensive bound against a pathological sender.
+        if let Some(oldest) = map.iter().min_by_key(|(_, (_, ts))| *ts).map(|(k, _)| *k) {
+            map.remove(&oldest);
+        }
+    }
+    map.insert(token, (text, Instant::now()));
+}
+
+fn take_burst_text(token: u32) -> Option<Vec<u8>> {
+    let mut map = BURSTS.lock().unwrap();
+    prune_bursts(&mut map);
+    map.remove(&token).map(|(text, _)| text)
+}
+
+/// Frames are applied synchronously here, in SSE stream order: the
+/// compound-upgrade logic relies on text-before-image processing, which
+/// per-frame spawns onto a thread pool cannot guarantee (and which, prior
+/// to this, could reorder plain v1 multi-frame applies too).
+fn handle_inbound_frame(frame: Frame, echo: &Arc<Mutex<EchoState>>) {
+    match frame.kind {
+        Kind::Ref => {
+            let echo = echo.clone();
+            tauri::async_runtime::spawn(async move {
+                apply_inbound_ref(frame, echo).await;
+            });
+        }
+        _ if frame.token == 0 => apply_inbound_inline(frame, echo),
+        Kind::Text => {
+            retain_burst_text(frame.token, frame.payload.clone());
+            apply_inbound_inline(frame, echo);
+        }
+        Kind::Png => {
+            let token = frame.token;
+            deliver_burst_png(token, &frame.payload, echo);
+        }
+        Kind::FileOffer => {
+            // Keep the legacy warn-and-drop path (apply_inbound_inline
+            // rejects file offers on the host agent).
+            apply_inbound_inline(frame, echo);
+        }
+    }
+}
+
+fn deliver_burst_png(token: u32, png: &[u8], echo: &Arc<Mutex<EchoState>>) {
+    match take_burst_text(token) {
+        Some(text) => apply_compound(&text, png, echo),
+        None => apply_inbound_inline(
+            Frame {
+                kind: Kind::Png,
+                token,
+                payload: png.to_vec(),
+            },
+            echo,
+        ),
+    }
 }
 
 async fn apply_inbound_ref(frame: Frame, echo: Arc<Mutex<EchoState>>) {
@@ -581,13 +755,147 @@ async fn apply_inbound_ref(frame: Frame, echo: Arc<Mutex<EchoState>>) {
             return;
         }
     };
+    let token = frame.token;
+
+    if token != 0 && matches!(kind, Kind::Text | Kind::Png) {
+        // Blob payload of a compound burst: route through the aggregator so
+        // the image can upgrade the already-applied text flavor.
+        match kind {
+            Kind::Text => {
+                retain_burst_text(token, bytes.clone());
+                let _ = tauri::async_runtime::spawn_blocking(move || {
+                    apply_inbound_inline(
+                        Frame {
+                            kind: Kind::Text,
+                            token,
+                            payload: bytes,
+                        },
+                        &echo,
+                    )
+                })
+                .await;
+            }
+            Kind::Png => {
+                let _ = tauri::async_runtime::spawn_blocking(move || {
+                    deliver_burst_png(token, &bytes, &echo)
+                })
+                .await;
+            }
+            _ => unreachable!(),
+        }
+        return;
+    }
+
     let frame = Frame {
         kind,
-        token: frame.token,
+        token,
         payload: bytes,
     };
     let echo = echo.clone();
     let _ = tauri::async_runtime::spawn_blocking(move || apply_inbound_inline(frame, &echo)).await;
+}
+
+/// Write text + image flavors in one clipboard transaction. Records every
+/// echo identity first so the watcher's snapshot of the compound write is
+/// suppressed (byte hashes + pixel hash).
+fn apply_compound(text: &[u8], png: &[u8], echo: &Arc<Mutex<EchoState>>) {
+    // Preserve a pending local file paste (mirrors the inline-path guard).
+    if let Ok(ctx) = ClipboardContext::new() {
+        if let Ok(files) = ctx.get_files() {
+            if !files.is_empty() {
+                debug!("local file clipboard detected; inbound compound dropped");
+                return;
+            }
+        }
+    }
+
+    let text_str = match std::str::from_utf8(text) {
+        Ok(s) if !s.is_empty() && !s.contains('\0') => s,
+        _ => {
+            warn!("inbound compound text unusable; applying image only");
+            apply_inbound_inline(
+                Frame {
+                    kind: Kind::Png,
+                    token: 0,
+                    payload: png.to_vec(),
+                },
+                echo,
+            );
+            return;
+        }
+    };
+
+    // Bound decoded pixel count (mirrors the inline PNG path).
+    let cursor = std::io::Cursor::new(png);
+    if let Ok(reader) = image::ImageReader::new(cursor).with_guessed_format() {
+        if let Ok((w, h)) = reader.into_dimensions() {
+            if (w as u64) * (h as u64) > MAX_IMAGE_PIXELS {
+                warn!(
+                    "inbound image {}x{} exceeds {} pixel cap; dropped",
+                    w, h, MAX_IMAGE_PIXELS
+                );
+                return;
+            }
+        }
+    }
+    let img = match RustImageData::from_bytes(png) {
+        Ok(i) => i,
+        Err(e) => {
+            warn!("RustImageData::from_bytes failed: {e}");
+            return;
+        }
+    };
+    let pixel_hash = hash_image_pixels(&img);
+
+    {
+        let mut st = echo.lock().unwrap();
+        st.record(Kind::Text, text);
+        st.record(Kind::Png, png);
+        if let Some(h) = pixel_hash {
+            st.record_image(h);
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        match img.to_rgba8() {
+            Ok(rgba) => match crate::win_clipboard::write_compound(text_str, &rgba, png) {
+                Ok(()) => {
+                    debug!(
+                        "applied compound clipboard (text {}B + PNG {}B)",
+                        text.len(),
+                        png.len()
+                    );
+                    return;
+                }
+                Err(e) => {
+                    warn!("compound clipboard write failed: {e}; falling back to image only");
+                }
+            },
+            Err(e) => {
+                warn!("compound rgba conversion failed: {e}; falling back to image only");
+            }
+        }
+        if let Ok(ctx) = ClipboardContext::new() {
+            let _ = ctx.set_image(img);
+        }
+        return;
+    }
+
+    #[cfg(not(windows))]
+    {
+        // clipboard-rs has no compound write off-Windows; degrade to
+        // sequential writes, image last (v1 outcome).
+        if let Ok(ctx) = ClipboardContext::new() {
+            let _ = ctx.set_text(text_str.to_string());
+            let _ = ctx.set_image(img);
+        }
+        debug!(
+            "applied compound clipboard via sequential fallback (text {}B + PNG {}B)",
+            text.len(),
+            png.len()
+        );
+    }
 }
 
 fn apply_inbound_inline(frame: Frame, echo: &Arc<Mutex<EchoState>>) {
@@ -749,14 +1057,7 @@ async fn sse_pump(stop: Arc<Notify>, echo: Arc<Mutex<EchoState>>) {
                         while let Some(end) = find_event_end(&buf) {
                             let raw = buf.drain(..end + 2).collect::<Vec<u8>>();
                             if let Some(frame) = parse_sse_event(&raw) {
-                                let echo = echo.clone();
-                                if frame.kind == Kind::Ref {
-                                    tauri::async_runtime::spawn(async move {
-                                        apply_inbound_ref(frame, echo).await;
-                                    });
-                                } else {
-                                    tauri::async_runtime::spawn_blocking(move || apply_inbound(frame, &echo));
-                                }
+                                handle_inbound_frame(frame, &echo);
                             }
                         }
                     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,6 +39,8 @@ mod utils;
 mod vdd;
 mod vdd_calibration;
 #[cfg(target_os = "windows")]
+mod win_clipboard;
+#[cfg(target_os = "windows")]
 mod vdd_ioctl;
 mod vigem;
 mod vmouse;

--- a/src-tauri/src/win_clipboard.rs
+++ b/src-tauri/src/win_clipboard.rs
@@ -1,0 +1,82 @@
+//! One-transaction Windows clipboard write carrying text AND image flavors.
+//!
+//! clipboard-rs's `set_text`/`set_image` each open + EmptyClipboard before
+//! writing (and its batched `set(Vec<ClipboardContent>)` delegates the image
+//! branch back to `set_image`, clearing the batch), so a compound clipboard
+//! cannot be written through it. This module opens the clipboard once,
+//! empties it once, and sets all flavors with clipboard-win's no-clear raw
+//! setter.
+
+use clipboard_win::{formats, raw, Clipboard};
+use std::sync::OnceLock;
+
+const CF_DIB: u32 = 8;
+
+/// Registered "PNG" format id (0 = registration failed and PNG bytes are
+/// skipped; CF_DIB still carries the image).
+fn png_format_id() -> u32 {
+    static PNG: OnceLock<u32> = OnceLock::new();
+    *PNG.get_or_init(|| unsafe {
+        let name: Vec<u16> = "PNG\0".encode_utf16().collect();
+        raw::register_raw_format(&name)
+            .map(|f| f.get())
+            .unwrap_or(0)
+    })
+}
+
+/// Build a 32bpp bottom-up BGRA CF_DIB (BITMAPINFOHEADER + pixels).
+fn build_dib(rgba: &image::RgbaImage) -> Vec<u8> {
+    let (w, h) = rgba.dimensions();
+    let row_bytes = w as usize * 4;
+    let mut out = Vec::with_capacity(40 + row_bytes * h as usize);
+
+    out.extend_from_slice(&40u32.to_le_bytes()); // biSize
+    out.extend_from_slice(&(w as i32).to_le_bytes()); // biWidth
+    out.extend_from_slice(&(h as i32).to_le_bytes()); // biHeight (positive = bottom-up)
+    out.extend_from_slice(&1u16.to_le_bytes()); // biPlanes
+    out.extend_from_slice(&32u16.to_le_bytes()); // biBitCount
+    out.extend_from_slice(&0u32.to_le_bytes()); // biCompression = BI_RGB
+    out.extend_from_slice(&(row_bytes as u32 * h).to_le_bytes()); // biSizeImage
+    out.extend_from_slice(&[0u8; 16]); // biXPelPerMeter..biClrImportant
+
+    for y in (0..h).rev() {
+        for x in 0..w {
+            let p = rgba.get_pixel(x, y).0;
+            out.extend_from_slice(&[p[2], p[1], p[0], p[3]]); // RGBA -> BGRA
+        }
+    }
+    out
+}
+
+/// Write CF_UNICODETEXT + CF_DIB + registered "PNG" in one clipboard
+/// transaction. On partial failure the flavors already written stay on the
+/// clipboard and the error is returned for the caller's fallback.
+pub fn write_compound(text: &str, rgba: &image::RgbaImage, png: &[u8]) -> Result<(), String> {
+    if text.is_empty() || png.is_empty() {
+        return Err("empty compound payload".to_string());
+    }
+
+    let _clip = Clipboard::new_attempts(10).map_err(|e| format!("open clipboard: {e}"))?;
+    raw::empty().map_err(|e| format!("empty clipboard: {e}"))?;
+
+    let mut utf16: Vec<u16> = text.encode_utf16().collect();
+    utf16.push(0);
+    let mut text_bytes = Vec::with_capacity(utf16.len() * 2);
+    for unit in &utf16 {
+        text_bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    raw::set_without_clear(formats::CF_UNICODETEXT, &text_bytes)
+        .map_err(|e| format!("set CF_UNICODETEXT: {e}"))?;
+
+    let dib = build_dib(rgba);
+    raw::set_without_clear(CF_DIB, &dib).map_err(|e| format!("set CF_DIB: {e}"))?;
+
+    let png_id = png_format_id();
+    if png_id != 0 {
+        // Browsers and modern editors prefer the verbatim PNG bytes over
+        // the DIB; mirrors clipboard-rs's set_image flavor pair.
+        raw::set_without_clear(png_id, png).map_err(|e| format!("set PNG format: {e}"))?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
> 堆叠于 #124（先合并 #124，再把本 PR base 改为 main 或直接合并）。

## 背景

v1 是"快照单 payload"模型：混合剪贴板（图 + 来源 URL/文字）只同步图。本 PR 用最小协议扩展实现 RDP 级别的 text+image 复合剪贴板。

## 协议设计（无 wire 格式变化、无版本协商、服务端零改动）

- **发射**：混合变更 = 两帧共享同一**非零** token，文字帧在前、图片帧后；单帧内容改用 token=0
- **顺序保证**：burst 在单个 spawn 任务内**顺序 await** 两次 POST（两个独立 HTTP POST 无顺序保证，旧端依赖文字先行才能最终态=图片）
- **接收（apply-as-arrive）**：SSE 帧**同步按流序**应用（顺带修掉 v1 每帧独立 spawn 的乱序隐患）；文字帧到达即应用并保留 payload，图片（内联或 blob 拉取完成）到达时一次复合写入升级
- burst 文字恒内联（≤65490B，超限降级为只发图）：REF 文字帧会因 blob 上传延迟乱序上 wire
- 服务端已验证为不透明 FIFO 逐帧转发，零改动

## Windows 复合写入（win_clipboard.rs 新模块）

clipboard-rs 的 set_text/set_image 各自 EmptyClipboard（其批量 set 的 Image 分支同样清板），复合写绕过它：clipboard-win 原语一次 open + empty 后写 CF_UNICODETEXT（UTF-16LE）+ CF_DIB（32bpp bottom-up BGRA，手工构造 BITMAPINFOHEADER）+ 注册格式 "PNG"（原始字节，对齐 clipboard-rs set_image 的双格式行为）。失败降级为 set_image 单写。

## 互操作矩阵

| 发送 ↓ 接收 → | 旧 v1 端 | 新 v2 端 |
|---|---|---|
| 旧单帧 | 现状 | token=0 立即应用 |
| 新 burst | 逐帧应用 → 最终=图片（=v1 现状） | 聚合复合写（text+CF_DIB+PNG） |

回声：复合应用前记录 text 哈希 + 图片字节哈希 + 像素哈希（#124 双缓存）。

## 验证

- `cargo check`：clipboard.rs 零错误（macOS 上 Windows-only 模块不参与编译，win_clipboard.rs API 已对照 clipboard-win 5.4.1 源码逐一核验；CI build-windows 为权威验证）
- 客户端侧配套实现已在 macOS 完成全路径实测（混合出站 burst、复合入站四 flavor 共存、回声零重发、旧端兼容），见 qiin2333/moonlight-qt#214

🤖 Generated with [Claude Code](https://claude.com/claude-code)