### PR TITLE
fix(gui): 刷新 WebView 合成器，修复系统缩放/分辨率变化后面板冻结

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4918,6 +4918,7 @@ dependencies = [
  "url",
  "uuid",
  "webview2-com",
+ "windows 0.61.3",
  "windows 0.62.2",
  "windows-core 0.61.2",
  "winreg",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -102,5 +102,7 @@ windows = { version = "0.62.2", features = [
 webview2-com = "0.38"
 # webview2-com 使用 windows-core 0.61，需要此版本的 Interface trait 来调用 .cast()
 wv2-windows-core = { package = "windows-core", version = "0.61" }
+# webview2-com 的 RECT 等 Win32 类型来自 windows 0.61，与 GUI 直依赖的 0.62 不互通
+wv2-windows = { package = "windows", version = "0.61", features = ["Win32_Foundation"] }
 winreg = "0.55"
 image = "0.25.9"

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -470,7 +470,9 @@ fn check_display_change<R: Runtime>(ww: &WebviewWindow<R>) {
             signatures.insert(label, signature);
         }
         Some(prev) => {
-            debug!(
+            // info 级：显示变化是罕见事件，这两条标记是用户导出日志里
+            // 判定 workaround 是否生效的依据（默认收集级别为 Info）。
+            info!(
                 "🖥️ 显示配置变化 [{}]: {:?} -> {:?}，刷新 WebView 合成器",
                 label, prev, signature
             );
@@ -1269,7 +1271,8 @@ fn kick_webview_compositor<R: Runtime>(ww: &WebviewWindow<R>) -> bool {
     });
     match dispatched {
         Ok(()) => {
-            debug!("☀️ 已刷新 WebView 合成器 [{}]", label);
+            // info 级：与 check_display_change 的标记配套，见其注释
+            info!("☀️ 已刷新 WebView 合成器 [{}]", label);
             true
         }
         Err(e) => {
@@ -1318,7 +1321,8 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
                 if let Some(ww) = app_handle.get_webview_window(&label)
                     && ww.is_visible().unwrap_or(false)
                 {
-                    debug!(
+                    // info 级：见 check_display_change 中关于日志级别的注释
+                    info!(
                         "🖥️ 缩放变化为 {:.3} [{}]，刷新 WebView 合成器",
                         new_scale, label
                     );

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -33,6 +33,19 @@ static HEARTBEAT_MAP: Lazy<Mutex<HashMap<String, HeartbeatState>>> =
 /// treat it as crashed while it sits in this set.
 static SUSPENDED_WEBVIEWS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
+/// 窗口所在显示器的分辨率/缩放快照。纯分辨率变化只广播 WM_DISPLAYCHANGE，
+/// Tauri 不会产生任何窗口事件，只能在心跳巡检里轮询对比，
+/// 作为 ScaleFactorChanged 事件路径的兜底。
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct DisplaySignature {
+    scale_permille: u32,
+    width: u32,
+    height: u32,
+}
+
+static DISPLAY_SIGNATURES: Lazy<Mutex<HashMap<String, DisplaySignature>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
 #[derive(Default)]
 struct ToolWindowMoveSave {
     version: u64,
@@ -435,6 +448,39 @@ fn check_and_recover_webview<R: Runtime>(window: &WebviewWindow<R>) {
     }
 }
 
+/// 心跳巡检兜底：对比窗口所在显示器当前分辨率/缩放与上次快照，发现变化则
+/// 触发与 ScaleFactorChanged 事件相同的合成器刷新。首个快照只记基线不打扰。
+#[cfg(target_os = "windows")]
+fn check_display_change<R: Runtime>(ww: &WebviewWindow<R>) {
+    let Ok(Some(monitor)) = ww.current_monitor() else {
+        return;
+    };
+    let signature = DisplaySignature {
+        scale_permille: (ww.scale_factor().unwrap_or(1.0) * 1000.0).round() as u32,
+        width: monitor.size().width,
+        height: monitor.size().height,
+    };
+
+    let label = ww.label().to_string();
+    let mut signatures = DISPLAY_SIGNATURES.lock().unwrap();
+    match signatures.get(&label) {
+        Some(prev) if *prev == signature => {}
+        None => {
+            signatures.insert(label, signature);
+        }
+        Some(prev) => {
+            debug!(
+                "🖥️ 显示配置变化 [{}]: {:?} -> {:?}，刷新 WebView 合成器",
+                label, prev, signature
+            );
+            signatures.insert(label, signature);
+            // 先释放锁，再向主线程派发 COM 刷新
+            drop(signatures);
+            kick_webview_compositor(ww);
+        }
+    }
+}
+
 /// 启动 WebView 心跳监控后台任务
 /// 定期检查可见窗口的心跳状态，若检测到崩溃则自动恢复
 pub fn start_heartbeat_monitor(app: AppHandle) {
@@ -460,6 +506,10 @@ pub fn start_heartbeat_monitor(app: AppHandle) {
                     if is_visible && !is_minimized {
                         #[cfg(target_os = "windows")]
                         check_and_recover_webview(&win);
+                        // 纯分辨率变化（WM_DISPLAYCHANGE）没有对应的 Tauri 事件，
+                        // 在这里轮询兜底
+                        #[cfg(target_os = "windows")]
+                        check_display_change(&win);
                     }
                 }
             }
@@ -1169,6 +1219,47 @@ fn resume_webview<R: Runtime>(ww: &WebviewWindow<R>) {
 #[cfg(not(target_os = "windows"))]
 fn resume_webview<R: Runtime>(_ww: &WebviewWindow<R>) {}
 
+/// 强制 WebView2 按当前设备参数重新合成一帧。
+///
+/// 显示器缩放/分辨率变化后 WebView2 合成器可能停滞：窗口与渲染进程都活着、
+/// 心跳正常，但画面冻结（AlkaidLab/foundation-sunshine#1049，WebView2 生态
+/// 的已知问题类别）。对 controller bounds 做一次 +1 物理像素往返，并通知父
+/// 窗口位置变化，可强制合成器用新 DPI/分辨率重新布局与提交帧。
+#[cfg(target_os = "windows")]
+fn kick_webview_compositor<R: Runtime>(ww: &WebviewWindow<R>) {
+    // RECT 必须取自 webview2-com 同版本的 windows crate（0.61），
+    // GUI 直依赖的 0.62 类型与其不互通。
+    use wv2_windows::Win32::Foundation::RECT;
+
+    let label = ww.label().to_string();
+    let closure_label = label.clone();
+    let _ = ww.with_webview(move |webview| {
+        let controller = webview.controller();
+        unsafe {
+            let mut bounds = RECT::default();
+            if controller.Bounds(&mut bounds).is_ok() {
+                let nudged = RECT {
+                    right: bounds.right + 1,
+                    ..bounds
+                };
+                if let Err(e) = controller.SetBounds(nudged) {
+                    debug!("⚠️ bounds 微调失败 [{}]: {}", closure_label, e);
+                }
+                if let Err(e) = controller.SetBounds(bounds) {
+                    log::warn!("⚠️ bounds 还原失败 [{}]: {}", closure_label, e);
+                }
+            }
+            if let Err(e) = controller.NotifyParentWindowPositionChanged() {
+                debug!("⚠️ NotifyParentWindowPositionChanged 失败 [{}]: {}", closure_label, e);
+            }
+        }
+    });
+    debug!("☀️ 已刷新 WebView 合成器 [{}]", label);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn kick_webview_compositor<R: Runtime>(_ww: &WebviewWindow<R>) {}
+
 /// Notify the page so it can pause animations and suspend expensive content.
 /// The native window already controls WebView2 composition. Toggling the
 /// controller's IsVisible property separately can leave transparent WebViews
@@ -1191,6 +1282,25 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
             if window.label() == TOOL_WINDOW_ID {
                 schedule_tool_window_position_save(window.app_handle().clone(), *position);
             }
+        }
+        tauri::WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+            // 显示器缩放变化时 WebView2 合成器可能停滞（画面冻结但进程存活）。
+            // tao 在本事件之后才应用新窗口尺寸，延迟到窗口尺寸稳定后再刷新合成器。
+            let app_handle = window.app_handle().clone();
+            let label = window.label().to_string();
+            let new_scale = *scale_factor;
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                if let Some(ww) = app_handle.get_webview_window(&label)
+                    && ww.is_visible().unwrap_or(false)
+                {
+                    debug!(
+                        "🖥️ 缩放变化为 {:.3} [{}]，刷新 WebView 合成器",
+                        new_scale, label
+                    );
+                    kick_webview_compositor(&ww);
+                }
+            });
         }
         tauri::WindowEvent::CloseRequested { .. } => {
             end_webview_heartbeat(window.label());

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -66,6 +66,7 @@ const ABOUT_WINDOW_ID: &str = "about";
 const LOG_CONSOLE_WINDOW_ID: &str = "log_console";
 const PIN_WINDOW_ID: &str = "pin_pairing";
 const DESKTOP_WINDOW_ID: &str = "desktop";
+const TOOLBAR_WINDOW_ID: &str = "toolbar";
 const TOOL_WINDOW_ID: &str = "tool_window";
 #[cfg(debug_assertions)]
 const DEBUG_PAGE_WINDOW_ID: &str = "debug_page";
@@ -473,10 +474,10 @@ fn check_display_change<R: Runtime>(ww: &WebviewWindow<R>) {
                 "🖥️ 显示配置变化 [{}]: {:?} -> {:?}，刷新 WebView 合成器",
                 label, prev, signature
             );
-            signatures.insert(label, signature);
-            // 先释放锁，再向主线程派发 COM 刷新
-            drop(signatures);
-            kick_webview_compositor(ww);
+            // 仅在刷新已成功派发时提交新快照；失败保留旧值，下个心跳周期重试
+            if kick_webview_compositor(ww) {
+                signatures.insert(label, signature);
+            }
         }
     }
 }
@@ -491,8 +492,9 @@ pub fn start_heartbeat_monitor(app: AppHandle) {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
 
-            // 只检查可见的主要窗口（main / desktop）
-            for label in &[MAIN_WINDOW_ID, DESKTOP_WINDOW_ID] {
+            // 心跳检查只覆盖注册过的 main / desktop；桌宠工具栏是常驻窗口，
+            // 只参与显示变化兜底检查（begin_webview_heartbeat 未对其注册）。
+            for label in &[MAIN_WINDOW_ID, DESKTOP_WINDOW_ID, TOOLBAR_WINDOW_ID] {
                 // 挂起中的 WebView JS 定时器被冻结，心跳缺失是预期行为，
                 // 不能按崩溃恢复（否则会在挂起期间强制重载页面）。
                 if SUSPENDED_WEBVIEWS.lock().unwrap().contains(*label) {
@@ -502,10 +504,12 @@ pub fn start_heartbeat_monitor(app: AppHandle) {
                     let is_visible = win.is_visible().unwrap_or(false);
                     let is_minimized = win.is_minimized().unwrap_or(true);
 
-                    // 仅当窗口可见且未最小化时检查心跳
+                    // 仅当窗口可见且未最小化时检查
                     if is_visible && !is_minimized {
-                        #[cfg(target_os = "windows")]
-                        check_and_recover_webview(&win);
+                        if *label != TOOLBAR_WINDOW_ID {
+                            #[cfg(target_os = "windows")]
+                            check_and_recover_webview(&win);
+                        }
                         // 纯分辨率变化（WM_DISPLAYCHANGE）没有对应的 Tauri 事件，
                         // 在这里轮询兜底
                         #[cfg(target_os = "windows")]
@@ -1225,28 +1229,37 @@ fn resume_webview<R: Runtime>(_ww: &WebviewWindow<R>) {}
 /// 心跳正常，但画面冻结（AlkaidLab/foundation-sunshine#1049，WebView2 生态
 /// 的已知问题类别）。对 controller bounds 做一次 +1 物理像素往返，并通知父
 /// 窗口位置变化，可强制合成器用新 DPI/分辨率重新布局与提交帧。
+///
+/// 返回刷新闭包是否成功派发到主线程。COM 调用在闭包内异步执行，其失败只能
+/// 记录日志、无法同步回传；派发失败（窗口/WebView 正在销毁）返回 false，
+/// 调用方可据此保留旧状态择机重试。
 #[cfg(target_os = "windows")]
-fn kick_webview_compositor<R: Runtime>(ww: &WebviewWindow<R>) {
+fn kick_webview_compositor<R: Runtime>(ww: &WebviewWindow<R>) -> bool {
     // RECT 必须取自 webview2-com 同版本的 windows crate（0.61），
     // GUI 直依赖的 0.62 类型与其不互通。
     use wv2_windows::Win32::Foundation::RECT;
 
     let label = ww.label().to_string();
     let closure_label = label.clone();
-    let _ = ww.with_webview(move |webview| {
+    let dispatched = ww.with_webview(move |webview| {
         let controller = webview.controller();
         unsafe {
             let mut bounds = RECT::default();
-            if controller.Bounds(&mut bounds).is_ok() {
-                let nudged = RECT {
-                    right: bounds.right + 1,
-                    ..bounds
-                };
-                if let Err(e) = controller.SetBounds(nudged) {
-                    debug!("⚠️ bounds 微调失败 [{}]: {}", closure_label, e);
+            match controller.Bounds(&mut bounds) {
+                Ok(()) => {
+                    let nudged = RECT {
+                        right: bounds.right + 1,
+                        ..bounds
+                    };
+                    if let Err(e) = controller.SetBounds(nudged) {
+                        log::warn!("⚠️ bounds 微调失败 [{}]: {}", closure_label, e);
+                    }
+                    if let Err(e) = controller.SetBounds(bounds) {
+                        log::warn!("⚠️ bounds 还原失败 [{}]: {}", closure_label, e);
+                    }
                 }
-                if let Err(e) = controller.SetBounds(bounds) {
-                    log::warn!("⚠️ bounds 还原失败 [{}]: {}", closure_label, e);
+                Err(e) => {
+                    log::warn!("⚠️ 读取 bounds 失败 [{}]: {}", closure_label, e);
                 }
             }
             if let Err(e) = controller.NotifyParentWindowPositionChanged() {
@@ -1254,11 +1267,22 @@ fn kick_webview_compositor<R: Runtime>(ww: &WebviewWindow<R>) {
             }
         }
     });
-    debug!("☀️ 已刷新 WebView 合成器 [{}]", label);
+    match dispatched {
+        Ok(()) => {
+            debug!("☀️ 已刷新 WebView 合成器 [{}]", label);
+            true
+        }
+        Err(e) => {
+            log::warn!("⚠️ WebView 合成器刷新派发失败 [{}]: {}", label, e);
+            false
+        }
+    }
 }
 
 #[cfg(not(target_os = "windows"))]
-fn kick_webview_compositor<R: Runtime>(_ww: &WebviewWindow<R>) {}
+fn kick_webview_compositor<R: Runtime>(_ww: &WebviewWindow<R>) -> bool {
+    true
+}
 
 /// Notify the page so it can pause animations and suspend expensive content.
 /// The native window already controls WebView2 composition. Toggling the


### PR DESCRIPTION
## 问题

系统界面分辨率或缩放改变后，面板 UI 冻结/无响应（上游 [AlkaidLab/foundation-sunshine#1049](https://github.com/AlkaidLab/foundation-sunshine/issues/1049)）。

排查结论：GUI 自身代码在显示变化时对窗口无任何处理（`handle_window_event` 原本没有 `ScaleFactorChanged`/`Resized` 分支，无应用层反馈回路），冻结发生在 WebView2 合成器层——窗口与渲染进程存活、心跳正常，但画面停止提交。WebView2Feedback 也有同类开放问题（[#5247](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5247)、[#4485](https://github.com/MicrosoftEdge/WebView2Feedback/issues/4485)）；当前依赖链（tao 0.35.x / wry 0.55.x）没有可用修复，升级无效。

## 修复

对冻结的合成器做一次强制刷新（bounds ±1 物理像素往返 + `NotifyParentWindowPositionChanged`），两条触发路径：

1. **`ScaleFactorChanged` 事件臂**（主路径）：tao 在事件之后才应用新窗口尺寸，延迟 250ms 再刷新；对所有 GUI 窗口生效。
2. **心跳巡检轮询兜底**：纯分辨率变化只广播 `WM_DISPLAYCHANGE`，Tauri 不产生窗口事件，在既有 30s 心跳循环里对比显示器「缩放+分辨率」快照，变化即触发同样的刷新；首个快照只记基线不动作。

## 实现备注

- COM 调用沿用本文件 suspend/resume 的既有写法（`with_webview` + controller）。
- `webview2-com` 的 `RECT` 来自 windows crate 0.61，与 GUI 直依赖的 0.62 不互通，按 `wv2-windows-core` 先例在 Cargo.toml 增加 `wv2-windows` 别名桥接。

## 验证

- `cargo check` / `cargo build` 通过；`cargo test` 179 项全过。
- debug 构建冒烟：面板正常打开、进程响应正常。
- 真机 DPI 切换验证待做：预期缩放变化 ~250ms 内恢复、纯分辨率变化 ≤30s 恢复；日志关键词「已刷新 WebView 合成器」（`RUST_LOG=sunshine_gui=debug`）。